### PR TITLE
fix toymodel typo

### DIFF
--- a/docs/examples/toymodel.py
+++ b/docs/examples/toymodel.py
@@ -40,7 +40,7 @@ class AModel(MockModel):
 
     def gates_get(self, parameter):
         if parameter[0] == 'c':
-            return self.fmt(self.gates[int(parameter[1:])])
+            return self.fmt(self._gates[int(parameter[1:])])
         else:
             raise ValueError
 


### PR DESCRIPTION
@peendebak fixes #84 - I guess my example notebook doesn't cover all the functionality in the toy model or I would have noticed the typo. And I guess I need to work on formatting subprocess errors better, the root of the problem _was_ in the traceback (`AModel object has no attribute 'gates'` - duh, it's supposed to be `'_gates'`) but it's awfully hard to read when you get a string repr rather than the printed string...
