### PR TITLE
AWG Driver adjustments

### DIFF
--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1189,7 +1189,7 @@ class Tektronix_AWG5014(VisaInstrument):
         dim = len(w)
 
         if (not((len(w) == len(m1)) and ((len(m1) == len(m2))))):
-            raise 'error: sizes of the waveforms do not match'
+            raise Exception('error: sizes of the waveforms do not match')
             
         self._values['files'][wfmname] = self._file_dict(w, m1, m2, None)
 


### PR DESCRIPTION
Added function `send_waveform_to_list` to AWG driver to write waveforms directly to User Defined Waveform List. Also used autopep8. Made changes in function `send_waveform`, settings the waveform works but we haven't fully tested it. In `send_waveform_to_list` we adjusted the code to use bytes instead of unicode.
