### PR TITLE
fix data store errors

### DIFF
--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -613,9 +613,7 @@ class _Measure:
         self.store = data_set.store
 
         # for performance, pre-calculate which params return data for
-        # multiple arrays, pre-create the dict to pass these to store fn
-        # and pre-calculate the name mappings
-        self.dict = {}
+        # multiple arrays, and the name mappings
         self.getters = []
         self.param_ids = []
         self.composite = []
@@ -627,16 +625,15 @@ class _Measure:
                 for i in range(len(param.names)):
                     param_id = data_set.action_id_map[action_indices + (i,)]
                     part_ids.append(param_id)
-                    self.dict[param_id] = None
                 self.param_ids.append(None)
                 self.composite.append(part_ids)
             else:
                 param_id = data_set.action_id_map[action_indices]
-                self.dict[param_id] = None
                 self.param_ids.append(param_id)
                 self.composite.append(False)
 
     def __call__(self, loop_indices, **ignore_kwargs):
+        out_dict = {}
         if self.use_threads:
             out = thread_map(self.getters)
         else:
@@ -646,11 +643,11 @@ class _Measure:
                                                   self.composite):
             if composite:
                 for val, part_id in zip(param_out, composite):
-                    self.dict[part_id] = val
+                    out_dict[part_id] = val
             else:
-                self.dict[param_id] = param_out
+                out_dict[param_id] = param_out
 
-        self.store(loop_indices, self.dict)
+        self.store(loop_indices, out_dict)
 
 
 class _Nest:


### PR DESCRIPTION
@damazter fixes #101 - the wrong data getting stored - can you give it a try and verify?

[premature optimization is the root of all evil](https://en.wikiquote.org/wiki/Donald_Knuth)

I thought I'd save a few cycles by pre-creating a dictionary for each repeated measurement, then just put new values into the already existing keys and pass it off to `dataset.store`. Unfortunately somehow it seems that the dict isn't serialized when you put it _on_ the queue but when you take it _off_? Seems strange, but when the `DataServer` slows down (perhaps when it's writing to disk? This might explain why we didn't see much at the beginning of the file, but errors pile up toward the end) we store the value of that dict as it exists some time later, when the `DataServer` reads the queue again.

Lesson learned, don't put mutable items on a queue unless you're going to wait for them to be read! I don't know if this is really a mac/windows difference or if I just have a comparatively overpowered hard drive in comparison to my CPU :)

I can still generate errors if I live-plot a big enough data set. I think this comes from the fact that the live plot currently needs to pull the WHOLE data set down from the data server every time it updates. Obviously that should be changed so we only need to get the updates! But also we need to make sure data saving doesn't block this long enough to generate timeouts...

I would love to have a test for this, and maybe I'll figure out a way to mock a super-slow `DataServer` tomorrow, but for now no tests.
