### PR TITLE
enable local version of pyqtgraph

### DIFF
--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -41,17 +41,15 @@ class QtPlot(BasePlot):
                  windowTitle='', theme=((60, 60, 60), 'w'), remote=True, **kwargs):
         super().__init__(interval)
 
-        if not self.__class__.proc:
-            self._init_qt()
-
         self.theme = theme
 
         if remote:
-            self.win = self.rpg.GraphicsWindow(title=windowTitle)
+            if not self.__class__.proc:
+                self._init_qt()
         else:            
-            self.win = pg.GraphicsWindow(title=windowTitle)
             # overrule the remote pyqtgraph class
             self.rpg = pg 
+        self.win = pg.GraphicsWindow(title=windowTitle)
         self.win.setBackground(theme[1])
         self.win.resize(*figsize)
         self.subplots = [self.add_subplot()]


### PR DESCRIPTION
This enables creating a non-remote processing QtPlot. This is a work around for #103. At the same time it allows for embedding q QtPlot object into a QWidget, which is not possible with the current setup.

Personally I would like to set `remote=False` in the QtPlot constructor, but right now it is `remote=True` which gives the old behaviour.
