### PR TITLE
Allow raw parameter access

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -403,6 +403,12 @@ class StandardParameter(Parameter):
             exec_str=self._instrument.ask if self._instrument else None,
             output_parser=get_parser, no_cmd_function=no_getter)
 
+        # Set access functions that bypass the parser
+        self._get_raw, self._get_async_raw = syncable_command(
+            arg_count=0, cmd=get_cmd, acmd=async_get_cmd,
+            exec_str=self._instrument.ask if self._instrument else None,
+            output_parser=None, no_cmd_function=no_getter)
+
         if self._get is not no_getter:
             self.has_get = True
 
@@ -413,6 +419,12 @@ class StandardParameter(Parameter):
             arg_count=1, cmd=set_cmd, acmd=async_set_cmd,
             exec_str=self._instrument.write if self._instrument else None,
             input_parser=set_parser, no_cmd_function=no_setter)
+
+        # Set access functions that bypass the input parser
+        self._set_raw, self._set_async_raw = syncable_command(
+            arg_count=1, cmd=set_cmd, acmd=async_set_cmd,
+            exec_str=self._instrument.write if self._instrument else None,
+            input_parser=None, no_cmd_function=no_setter)
 
         if self._set is not no_setter:
             self.has_set = True

--- a/qcodes/instrument/remote.py
+++ b/qcodes/instrument/remote.py
@@ -122,12 +122,24 @@ class RemoteParameter(RemoteComponent):
     def get(self):
         return self._instrument.connection.ask('get', self.name)
 
+    def get_raw(self):
+        """
+        Retrieve the raw response from an instrument, without passing it through the parser function
+        """
+        return self._instrument.connection.ask('param_call', self.name, "_get_raw")
+
     def set(self, value):
         # TODO: sometimes we want set to block (as here) and sometimes
         # we want it async... which would just be changing the 'ask'
         # to 'write' below. how do we decide, and how do we let the user
         # do it?
         self._instrument.connection.ask('set', self.name, value)
+
+    def set_raw(self, value):
+        """
+        Set the raw parameter, without passing it through the parser function
+        """
+        return self._instrument.connection.ask('param_call', self.name, "_set_raw", value)
 
     # manually copy over validate and __getitem__ so they execute locally
     # no reason to send these to the server, unless the validators change...

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -147,6 +147,12 @@ class MockSource(MockInstTester):
                            set_cmd='ampl:{:.4f}', get_parser=float,
                            vals=Numbers(0, 1),
                            step=0.2, delay=0.005)
+        self.add_parameter('form_amp', get_cmd='ampl?', set_cmd='ampl:{:.4f}',
+                           get_parser=float, set_parser=self.ampl_form_set,
+                           vals=Numbers(0, 1), step=0.2, delay=0.005)
+
+    def ampl_form_set(self, val):
+        return 2*val
 
 
 class MockMeter(MockInstTester):
@@ -156,3 +162,7 @@ class MockMeter(MockInstTester):
         self.add_parameter('amplitude', get_cmd='ampl?', get_parser=float)
         self.add_function('echo', call_cmd='echo {:.2f}?',
                           args=[Numbers(0, 1000)], return_parser=float)
+        self.add_parameter('form_amp', get_cmd='ampl?', get_parser=self.ampl_form)
+
+    def ampl_form(self, val):
+        return "Amplitude is: {:s}".format(val)

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -276,6 +276,26 @@ class TestParameters(TestCase):
             [float(h[3]) for h in gatehist if h[1] == 'write'],
             [0.1, 0.2, 0.3, 0.4, 0.5])
 
+    def test_raw_access(self):
+        gates, meter, source = self.gates, self.meter, self.source
+        meter_val = meter.amplitude()
+        # Check that the formatted output looks correct
+        self.assertEqual(meter.form_amp(), "Amplitude is: {:.3f}".format(meter_val))
+        # Check that the raw value is a string from the instrument
+        self.assertEqual(meter.form_amp.get_raw(), "{:.3f}".format(meter_val))
+
+        source_val = source.amplitude()
+        # Check that we can bypass a formatter
+        source.form_amp(0.1)
+        self.assertEqual(source.amplitude(), 0.2)
+        source.form_amp.set_raw(0.1)
+        self.assertEqual(source.amplitude(), 0.1)
+
+        # Check that we can set the source without triggering the validator
+        source.amplitude.set_raw(2.0)
+        self.assertEqual(source.amplitude(), 2.0)
+        source.amplitude.set_raw(source_val)
+
     def test_mock_instrument_errors(self):
         gates, meter = self.gates, self.meter
         with self.assertRaises(ValueError):
@@ -457,7 +477,8 @@ class TestParameters(TestCase):
 
     def test_standard_snapshot(self):
         self.assertEqual(self.meter.snapshot(), {
-            'parameters': {'amplitude': {'value': None, 'ts': None}},
+            'parameters': {'amplitude': {'value': None, 'ts': None},
+            'form_amp': {'ts': None, 'value': None}},
             'functions': {'echo': {}}
         })
 


### PR DESCRIPTION
Create methods in the parameter class that allows us to bypass the get/set parsers, as well as the validators and the sweep.

In particular this change is motivated by the desire to access the raw response from an instrument, however it is also useful when one may want to bypass a safety check and manually set a parameter to a certain value, manually sweep a parameter within an instrument driver etc.

The syntax is (using a mock source as an example):

``` py
source.amplitude.set_raw(2.0) # Sets the source without checking the validator
print(source.amplitude.get_raw() # Get's the source without converting the result to a float
```

Caveats:
- This form of access is dangerous. Generally limits are there for a reason, but it is not unreasonable to allow people to bypass limits if they jump through the right hoops.
- Coming back from a raw set may cause an error if we try to sweep back. For example:

``` py
source.amplitude.set_raw(1.75)
source.amplitude(0.5) # Will cause a value error
```

``` pytb
ValueError: *** error on MockInsts-8f65858 ***

Traceback (most recent call last):
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\server.py", line 177, in __init__
    self.process_query(query)
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\server.py", line 184, in process_query
    getattr(self, 'handle_' + query[0])(*(query[1:]))
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\server.py", line 259, in handle_ask
    response = func(*args, **kwargs)
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\base.py", line 393, in set
    self.parameters[param_name].set(value)
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\parameter.py", line 514, in _validate_and_sweep
    'setting {}:{} to {}'.format(self._instrument.name,
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\parameter.py", line 497, in _validate_and_sweep
    step_clock = time.perf_counter()
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\parameter.py", line 463, in _sweep_steps
    start_value = state['value']
  File "c:\users\spauka\documents\qcodes\qcodes\instrument\parameter.py", line 275, in validate
    self._vals.validate(value, 'Parameter: ' + context)
  File "c:\users\spauka\documents\qcodes\qcodes\utils\validators.py", line 155, in validate
    repr(value), self._min_value, self._max_value, context))
ValueError: ('1.75 is invalid: must be between 0 and 1 inclusive; Parameter: source.amplitude', 'setting source:amplitude to 0.5', "error processing query ('ask', 1, 'set', ('amplitude', 0.5), {})")
```
