### PR TITLE
fix plot.update() for plain data_array

### DIFF
--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -70,7 +70,8 @@ class BasePlot:
             for key in self.data_keys:
                 data_array = plot_config.get(key, '')
                 if hasattr(data_array, 'data_set'):
-                    self.data_updaters.add(data_array.data_set.sync)
+                    if data_array.data_set is not None:
+                        self.data_updaters.add(data_array.data_set.sync)
 
         if self.data_updaters:
             self.update_widget.interval = self.interval
@@ -88,9 +89,10 @@ class BasePlot:
             for part in self.data_keys:
                 data_array = config.get(part, '')
                 if hasattr(data_array, 'data_set'):
-                    location = data_array.data_set.location
-                    if location and location not in title_parts:
-                        title_parts.append(location)
+                    if data_array.data_set is not None:
+                        location = data_array.data_set.location
+                        if location and location not in title_parts:
+                            title_parts.append(location)
         return ', '.join(title_parts)
 
     def get_label(self, data_array):


### PR DESCRIPTION
This fixes the following code: (the `DataArray` created here does not have a data_set field).

``` python
import qcodes
import qcodes as qc
from qcodes.plots.pyqtgraph import QtPlot
import numpy as np

def getData(offset=0):
    data=qcodes.new_data(location='dummy')

    pa=qcodes.DataArray(array_id='param', name='param', preset_data=np.arange(0,100))
    da=qcodes.DataArray(array_id='amplitude', name='amplitude', set_arrays=(pa, ), preset_data=offset+np.random.rand(100, ))

    data.add_array(da)
    return data

data=getData()    
plotQ = qc.QtPlot(data.amplitude, remote=False)
plotQ.win.setGeometry(1920+360, 100, 800, 600)
plotQ.update()
```
