### PR TITLE
make number validator more generic

### DIFF
--- a/qcodes/tests/test_validators.py
+++ b/qcodes/tests/test_validators.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import math
+import numpy 
 
 from qcodes.utils.validators import (Validator, Anything, Bool, Strings,
                                      Numbers, Ints, Enum, MultiType)
@@ -174,7 +175,10 @@ class TestNumbers(TestCase):
                # warning: True==1 and False==0
                True, False,
                # warning: +/- inf are allowed if max & min are not specified!
-               -float("inf"), float("inf")]
+               -float("inf"), float("inf"),
+                # numpy scalars
+               numpy.int64(36), numpy.float32(-1.123)
+                ]
     not_numbers = ['', None, '1', [], {}, [1, 2], {1: 1},
                    b'good', AClass, AClass(), a_func]
 
@@ -264,7 +268,9 @@ class TestInts(TestCase):
     ints = [0, 1, 10, -1, 100, 1000000, int(-1e15), int(1e15),
             # warning: True==1 and False==0 - we *could* prohibit these, using
             # isinstance(v, bool)
-            True, False]
+            True, False,
+            # numpy scalars
+            numpy.int64(3)]
     not_ints = [0.1, -0.1, 1.0, 3.5, -2.3e6, 5.5e15, 1.34e-10, -2.5e-5,
                 math.pi, math.e, '', None, float("nan"), float("inf"),
                 -float("inf"), '1', [], {}, [1, 2], {1: 1}, b'good',

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -133,7 +133,7 @@ class Numbers(Validator):
     min_value <= value <= max_value
     '''
 
-    validtypes = (float, int, numpy.int64, numpy.float32)
+    validtypes = (float, int, numpy.integer, numpy.floating)
 
     def __init__(self, min_value=-float("inf"), max_value=float("inf")):
         if isinstance(min_value, self.validtypes):
@@ -172,22 +172,24 @@ class Ints(Validator):
     min_value <= value <= max_value
     '''
 
+    validtypes = (int, numpy.integer)
+
     def __init__(self, min_value=-BIGINT, max_value=BIGINT):
-        if isinstance(min_value, int):
-            self._min_value = min_value
+        if isinstance(min_value, self.validtypes):
+            self._min_value = int(min_value)
         else:
             raise TypeError('min_value must be an integer')
 
-        if not isinstance(max_value, int):
+        if not isinstance(max_value, self.validtypes):
             raise TypeError('max_value must be an integer')
         if max_value > min_value:
-            self._max_value = max_value
+            self._max_value = int(max_value)
         else:
             raise TypeError(
                 'max_value must be an integer bigger than min_value')
 
     def validate(self, value, context=''):
-        if not isinstance(value, int):
+        if not isinstance(value, self.validtypes):
             raise TypeError(
                 '{} is not an int; {}'.format(repr(value), context))
 


### PR DESCRIPTION
When working with Numpy often scalars end up as `numpy.int64` (or similar). We should allow these as `Numbers`.
