### PR TITLE
show parameter name in __repr__ and __str__

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -458,6 +458,15 @@ class DataSet(DelegateAttributes):
             return
         self.formatter.read(self)
 
+    def write_to_disk(self, location):
+        """
+        Write the whole (or only changed parts) DataSet to storage, with specified location
+        """
+        if self.mode != DataMode.LOCAL:
+            # maybe emit a warning?
+            pass
+        self.formatter.write(self, custom_location=location)
+        
     def write(self):
         """
         Write the whole (or only changed parts) DataSet to storage,

--- a/qcodes/data/format.py
+++ b/qcodes/data/format.py
@@ -33,7 +33,7 @@ class Formatter:
     """
     ArrayGroup = namedtuple('ArrayGroup', 'size set_arrays data name')
 
-    def write(self, data_set):
+    def write(self, data_set, custom_location=None):
         """
         Write the DataSet to storage. It is up to the Formatter to decide
         when to overwrite completely, and when to just append or otherwise
@@ -66,6 +66,7 @@ class Formatter:
                     self.read_one_file(data_set, f, ids_read)
                 except ValueError:
                     logging.warning('error reading file ' + fn)
+                    logging.warning('io_manager: %s' % io_manager)
                     logging.warning(format_exc())
 
     def read_one_file(self, data_set, f, ids_read):

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -281,6 +281,10 @@ class Parameter(Metadatable):
         '''
         return SweepFixedValues(self, keys)
 
+    def __repr__(self):
+        s='<' + '.'.join([self.__module__ , self.__class__.__name__]) +': ' + self.name + ' at ' + str(id(self)) +'>'
+
+        return s
 
 class StandardParameter(Parameter):
     '''


### PR DESCRIPTION
This gives a more informative output of a `Parameter` (and derived classes):

``` python
In [4]: param
Out[4]: <qcodes.instrument.parameter.StandardParameter: D1 at 140211932295464>
```

instead of

``` python
In [4]: param
Out[4]: <qcodes.instrument.parameter.StandardParameter at 140211932295464>
```
