### PR TITLE
fix warning that occur when plotting 2D data

### DIFF
--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 from .base import BasePlot
 from .colors import color_cycle, colorscales
 
-
 TransformState = namedtuple('TransformState', 'translate scale revisit')
 
 
@@ -203,7 +202,9 @@ class QtPlot(BasePlot):
             hist.setLevels(*z_range)
             hist_range = z_range
 
-        img.setImage(self._clean_array(z), levels=hist_range)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', 'using a non-integer number instead of an integer will result in an error in the future')
+            img.setImage(self._clean_array(z), levels=hist_range)
 
         scales_changed = False
         for axletter, axscale in scales.items():


### PR DESCRIPTION
This fixes a warning that occurs in 2D plots of `QtPlot`. The warning is not visible with remote plotting of `QtPlot` (the default).
Note: the warning is already fixed in upstream `pyqtgraph`, but there is no release so it might take some time before this is in the default packages (e.g. the python packaging index).
