### PR TITLE
allow testsuite to run with pattern

### DIFF
--- a/qcodes/test.py
+++ b/qcodes/test.py
@@ -1,3 +1,5 @@
+import logging
+
 def test_core(verbosity=1, failfast=False):
     """
     Run the qcodes core tests.
@@ -10,15 +12,19 @@ def test_core(verbosity=1, failfast=False):
 
     _test_core(verbosity=verbosity, failfast=failfast)
 
+import re
 
-def _test_core(**kwargs):
+def _test_core(test_pattern='test*.py', **kwargs):
     import unittest
 
     import qcodes.tests as qctest
     import qcodes
 
     suite = unittest.defaultTestLoader.discover(
-        qctest.__path__[0], top_level_dir=qcodes.__path__[0])
+        qctest.__path__[0], top_level_dir=qcodes.__path__[0], pattern=test_pattern)   
+
+    print('testing %d cases'  % suite.countTestCases() )
+    
     result = unittest.TextTestRunner(**kwargs).run(suite)
     return result.wasSuccessful()
 
@@ -61,6 +67,10 @@ if __name__ == '__main__':
                         help=('show coverage. default is True '
                               '-c is the same as -c 1'))
 
+    parser.add_argument('-t', '--test_pattern', nargs='?', dest='test_pattern',
+                        const=1, default='test*.py', type=str,
+                        help=('regexp for test name to match'))
+
     parser.add_argument('-f', '--failfast', nargs='?', dest='failfast',
                         const=1, default=0, type=int,
                         help=('halt on first error/failure? default 0 '
@@ -72,7 +82,7 @@ if __name__ == '__main__':
     cov.start()
 
     success = _test_core(verbosity=args.verbosity,
-                         failfast=bool(args.failfast))
+                         failfast=bool(args.failfast), test_pattern=args.test_pattern)
 
     cov.stop()
 


### PR DESCRIPTION
To perform fast runs of the testsuite one can do

``` python
python qcodes/test.py -t "test_data*.py"
```
