### PR TITLE
fix __repr__ of dataset

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -534,8 +534,8 @@ class DataSet(DelegateAttributes):
 
         for array_id, array in self.arrays.items():
             setp = 'Setpoint' if array.is_setpoint else 'Measured'
-            name=array.name or 'None'
-            array_id=array_id or 'None'
+            name = array.name or 'None'
+            array_id = array_id or 'None'
             arr_info.append([setp, array_id, name, repr(array.shape)])
 
         column_lengths = [max(len(row[i]) for row in arr_info)


### PR DESCRIPTION
The `.name` and `.array_id` fields of a `DataArray` can be `None`. This fixes an error generated when a `DataSet` contains such a `DataArray`. 

@alexcjohnson @giulioungaretti Is it an idea to gather multiple of these small fixed into a single branch like `onelinefixes`. This would decrease the number of PRs.
