### PR TITLE
add test for dataset object to test pickling

### DIFF
--- a/qcodes/tests/test_data.py
+++ b/qcodes/tests/test_data.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 import numpy as np
+import pickle
 
 from qcodes.data.data_array import DataArray
 from qcodes.data.manager import get_data_manager, NoData
@@ -9,11 +10,12 @@ from qcodes.process.helpers import kill_processes
 from qcodes import active_children
 
 from .data_mocks import (MockDataManager, MockFormatter, MatchIO,
-                         MockLive, MockArray)
+                         MockLive, MockArray, DataSet2D)
 from .common import strip_qc
 
 
 class TestDataArray(TestCase):
+
     def test_attributes(self):
         pname = 'Betty Sue'
         plabel = 'The best apple pie this side of Wenatchee'
@@ -237,6 +239,7 @@ class TestDataArray(TestCase):
 
 
 class TestLoadData(TestCase):
+
     def setUp(self):
         kill_processes()
 
@@ -294,6 +297,7 @@ class TestLoadData(TestCase):
 
 
 class TestDataSetMetaData(TestCase):
+
     def test_snapshot(self):
         data = new_data(location=False)
         expected_snap = {
@@ -331,6 +335,7 @@ class TestDataSetMetaData(TestCase):
 
 
 class TestNewData(TestCase):
+
     def setUp(self):
         kill_processes()
         self.original_lp = DataSet.location_provider
@@ -374,6 +379,7 @@ class TestNewData(TestCase):
 
 
 class TestDataSet(TestCase):
+
     def tearDown(self):
         kill_processes()
 
@@ -465,3 +471,9 @@ class TestDataSet(TestCase):
         # we can only add a given array_id once
         with self.assertRaises(ValueError):
             data.add_array(MockArray())
+
+    def test_pickle_dataset(self):
+        # Test pickling of DataSet object
+        # If the data_manager is set to None, then the object should pickle.
+        m = DataSet2D()
+        _ = pickle.dumps(m)


### PR DESCRIPTION
Storing data contained in dicts is important. To be able to store a DataSet we make sure the object can be pickled. For objects recorded with a DataManager one has to set the data_manager field to None to be able to store a DataSet.

Changes proposed in this pull request:

Add test to make sure a DataSet object can be pickled.

@alexcjohnson 
