### PR TITLE
complex NumpyJSONEncoder fix

### DIFF
--- a/qcodes/tests/test_json.py
+++ b/qcodes/tests/test_json.py
@@ -18,7 +18,8 @@ class TestNumpyJson(TestCase):
             'weight': 19,
             'length': 45.23,
             'points': [12, 24, 48],
-            'RapunzelNumber': np.float64(4.89) + np.float64(0.11) * 1j
+            'RapunzelNumber': np.float64(4.89) + np.float64(0.11) * 1j,
+            'verisimilitude': 1j
         }
 
     def test_numpy_fail(self):
@@ -40,7 +41,8 @@ class TestNumpyJson(TestCase):
             'weight': 19,
             'length': 45.23,
             'points': [12, 24, 48],
-            'RapunzelNumber': {'__dtype__': 'complex', 're': 4.89, 'im': 0.11}
+            'RapunzelNumber': {'__dtype__': 'complex', 're': 4.89, 'im': 0.11},
+            'verisimilitude': {'__dtype__': 'complex', 're': 0, 'im': 1}
         }
 
         self.assertEqual(metadata, data_dict)

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -23,8 +23,8 @@ class NumpyJSONEncoder(json.JSONEncoder):
             return float(obj)
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
-        elif isinstance(obj, numbers.Complex):
-            return {'__dtype__': 'complex', 're': self.default(obj.real), 'im': self.default(obj.imag)}
+        elif isinstance(obj, numbers.Complex) and not isinstance(obj, numbers.Real):
+            return {'__dtype__': 'complex', 're': float(obj.real), 'im': float(obj.imag)}
         else:
             return super(NumpyJSONEncoder, self).default(obj)
 


### PR DESCRIPTION
This pull request fixes an issue that I didn't bother to write, because the fix was shorter than writing the issue. But in Short, when you have a complex parameters that gets logged at the start of the measurement loop, it crashes because the complex value cannot be JSON Serialized

Changes proposed in this pull request:
Add a numpy encoder for complex numbers 

I did not run any tests yet, because I don't yet know how to do that. Any explanation on that would be appreciated
EDIT: I see something happening
EDIT2: I see that one test failed, but I cannot understand why, I don't think this it has anything to do with this pull request
EDIT3: I know it is bad practice to keep editing posts, but most of you are sleeping anyway

@alexcjohnson 
@giulioungaretti 
