### PR TITLE
only report qcodes coverage

### DIFF
--- a/qcodes/test.py
+++ b/qcodes/test.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    cov = coverage.Coverage()
+    cov = coverage.Coverage(source=['qcodes'])
     cov.start()
 
     success = _test_core(verbosity=args.verbosity,


### PR DESCRIPTION
According to [coverage docs](http://coverage.readthedocs.io/en/coverage-4.1/api_coverage.html#coverage.Coverage.__init__) this is the way to only report coverage of qcodes.

Ping @giulioungaretti 
