### PR TITLE
add configuration system to qcodes

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -9,12 +9,12 @@ from multiprocessing import active_children
 from qcodes.version import __version__
 
 # load config system
-import qcodes.qconfig 
-from qcodes.qconfig import (is_int, is_bool, is_text, is_float,
-                                is_instance_factory, is_one_of_factory,
-                                get_default_val)
-from qcodes.qconfig import (get_option, set_option, reset_option,
-                                describe_option, option_context, options)    
+import qcodes.config
+from qcodes.config import (is_int, is_bool, is_text, is_float,
+                           is_instance_factory, is_one_of_factory,
+                           get_default_val)
+from qcodes.config import (get_option, set_option, reset_option,
+                           describe_option, option_context, options)
 
 # create various options
 usezmq_doc = """
@@ -22,18 +22,18 @@ usezmq_doc = """
     If set to True the framework will install a hook to send logging data
     to a ZMQ socket.
 """
-                                
-with qconfig.config_prefix('display'):
-    qconfig.register_option('frontend', 1, 'frontend that is used (1: notebook, 0: unknown, 2: spyder', validator=is_int)
-with qconfig.config_prefix('logging'):
-    qconfig.register_option('usezmq', 1, usezmq_doc, validator=is_int)
+
+with config.config_prefix('display'):
+    config.register_option(
+        'frontend', 1, 'frontend that is used (1: notebook, 0: unknown, 2: spyder', validator=is_int)
+with config.config_prefix('logging'):
+    config.register_option('usezmq', 1, usezmq_doc, validator=is_int)
 
 
 # load config file
-path=qcodes.qconfig.qcodes_fname()
+path = qcodes.config.qcodes_fname()
 if path is not None:
-    print('loading options from path %s' % path)
-    x=qcodes.qconfig.from_file(path)
+    qcodes.config.from_file(path)
 
 
 from qcodes.process.helpers import set_mp_method

--- a/qcodes/config.py
+++ b/qcodes/config.py
@@ -53,13 +53,14 @@ Implementation
 
 """
 
+import os
+import six
 import re
 
 from collections import namedtuple
 from contextlib import contextmanager
 import warnings
-from pandas.compat import map, lmap, u
-import pandas.compat as compat
+from pandas.compat import lmap, u
 
 DeprecatedOption = namedtuple('DeprecatedOption', 'key msg rkey removal_ver')
 RegisteredOption = namedtuple(
@@ -810,17 +811,13 @@ is_int = is_type_factory(int)
 is_bool = is_type_factory(bool)
 is_float = is_type_factory(float)
 is_str = is_type_factory(str)
-is_unicode = is_type_factory(compat.text_type)
 is_text = is_instance_factory((str, bytes))
 
 #%% Qcodes custom
-import os
-import re
-import six
 
 
-def from_file(path, verbose=1):
-    # from pandas.core.common import _get_handle
+def from_file(path: str, verbose=1):
+    ''' Load options from specified configuration file '''
     option_splitter = re.compile('\s*[:=]\s*').split
     f = open(path, 'r')
     errors = []


### PR DESCRIPTION
This allows to configure various options in qcodes. This is needed for example to decide whether qcodes should use ipython notebook widgets or not.

The PR creates an object `qcodes.options` which can be used as:

``` python
if qcodes.options.display.frontend == 1:
    # do something with the frontend
```

Options are set to defaults that can be modified using a configuration file. For example a `qcodesrc` in the working directory with

```
logging.usezmq  = 1
display.frontend = 2
```

The config system was copied from `pandas`.

@giulioungaretti @alexcjohnson @MerlinSmiles 
