### PR TITLE
Changed Tek5014 ch_amp to reflect hardware limits

### DIFF
--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -263,11 +263,11 @@ class Tektronix_AWG5014(VisaInstrument):
                                set_cmd=state_cmd + ' {}',
                                vals=vals.Ints(0, 1))
             self.add_parameter('ch{}_amp'.format(i),
-                               label='Amplitude channel {} (V)'.format(i),
-                               units='V',
+                               label='Amplitude channel {} (Vpp)'.format(i),
+                               units='Vpp',
                                get_cmd=amp_cmd + '?',
                                set_cmd=amp_cmd + ' {:.6f}',
-                               vals=vals.Numbers(0.02, 1.5),
+                               vals=vals.Numbers(0.02, 4.5),
                                get_parser=float)
             self.add_parameter('ch{}_offset'.format(i),
                                label='Offset channel {} (V)'.format(i),


### PR DESCRIPTION
Fixes no existing issue 

Changes proposed in this pull request:
- Fix units in AWG 5014 channel amp from V to Vpp (peak-peak) 
- Changed validator to correspond to hardware limits of 5014 (safety should be set by #230 )

@giulioungaretti 

This change is made so that the validator corresponds to the hardware
limit of the 5014. Any device safety limits should be set using a soft
validator as proposed in #230. Units also updated to reflect that
setting is peak-tpeak voltage

Very minor change, I suggest merging asap unless someone disagrees 
