### PR TITLE
prevent sleep if complete is already done

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -458,8 +458,7 @@ class DataSet(DelegateAttributes):
         failing = {key: False for key in self.background_functions}
 
         nloops = 0
-        completed = False
-        while not completed:
+        while True:
             logging.info('DataSet: {:.0f}% complete'.format(
                 self.fraction_complete() * 100))
 
@@ -480,7 +479,6 @@ class DataSet(DelegateAttributes):
                     failing[key] = True
 
             if self.sync() is False:
-                completed = True
                 break
 
             time.sleep(delay)


### PR DESCRIPTION
This prevents an unnecessary sleep when running an experiment.

Changes proposed in this pull request:
- Change order of `time.sleep` and check on completion in `DataSet.complete` 

@giulioungaretti @alexcjohnson 
