### PR TITLE
Modifications to ATS9870-dev-branch

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -94,7 +94,7 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                                parameter_class=AlazarParameter,
                                label='Trigger Engine ' + i,
                                unit=None,
-                               value='TRIG_ENGINE_' + ('J' if i == 0 else 'K'),
+                               value='TRIG_ENGINE_'+('J' if i == '1' else 'K'),
                                byte_to_value_dict={0: 'TRIG_ENGINE_J',
                                                    1: 'TRIG_ENGINE_K'})
             self.add_parameter(name='trigger_source' + i,

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -1,13 +1,146 @@
 from .ATS import AcquisitionController
 import math
 import numpy as np
+from qcodes.instrument.parameter import ManualParameter
+from qcodes.utils import validators as vals
+
+
+class Basic_AcquisitionController(AcquisitionController):
+    """Basic AcquisitionController tested on ATS9360
+    returns unprocessed data averaged by record with 2 channels
+    """
+    def __init__(self, name, alazar_name, **kwargs):
+        self.samples_per_record = None
+        self.records_per_buffer = None
+        self.buffers_per_acquisition = None
+        self.buffer = None
+        super().__init__(name, alazar_name, **kwargs)
+        self.alazar = self._get_alazar()
+
+        self.add_parameter(name='average_mode',
+                           parameter_class=ManualParameter,
+                           initial_value='trace',
+                           vals=vals.Enum('none', 'trace', 'point'))
+
+
+        self.buffer_idx = 0
+        # Names and shapes must have initial value, even though they will be
+        # overwritten in set_acquisitionkwargs. If we don't do this, the
+        # RemoteInstrument will not recognize that it returns multiple values.
+        self.add_parameter(name="acquisition",
+                           names=['channel_signal'],
+                           get_cmd=self.do_acquisition,
+                           shapes=((),),
+                           snapshot_value=False)
+
+    def setup(self, **kwargs):
+        """
+        This function sets up the ATS for an acquisition.
+        In particular, it updates the acquisition kwargs, and the attributes
+        for the parameter acquisition.
+        These attributes depend on the controller's average_mode.
+        This function must be performed after setting the acquisitionkwargs,
+        and before starting an actual Loop
+        """
+
+        self.update_acquisitionkwargs(**kwargs)
+
+        channel_selection = self.get_acquisitionkwarg('channel_selection')
+        samples_per_record = self.get_acquisitionkwarg('samples_per_record')
+        records_per_buffer = self.get_acquisitionkwarg('records_per_buffer')
+        buffers_per_acquisition = self.get_acquisitionkwarg(
+            'buffers_per_acquisition')
+
+        self.acquisition.names = tuple(
+            ['Channel_{}_signal'.format(ch) for ch in channel_selection])
+
+        self.acquisition.labels = self.acquisition.names
+        self.acquisition.units = ['V'*len(channel_selection)]
+
+        if self.average_mode() == 'point':
+            self.acquisition.shapes = tuple([()]*len(channel_selection))
+        elif self.average_mode() == 'trace':
+            shape = (samples_per_record,)
+            self.acquisition.shapes = tuple([shape] * len(channel_selection))
+        else:
+            shape = (records_per_buffer * buffers_per_acquisition,
+                     samples_per_record)
+            self.acquisition.shapes = tuple([shape] * len(channel_selection))
+
+    def do_acquisition(self):
+        value = self._get_alazar().acquire(acquisition_controller=self,
+                                           **self.acquisitionkwargs())
+        return value
+
+    def pre_start_capture(self):
+        alazar = self._get_alazar()
+        number_of_channels = len(alazar.channel_selection.get())
+        self.buffer_idx = 0
+        if self.average_mode() in ['point', 'trace']:
+            self.buffer = np.zeros(alazar.samples_per_record.get() *
+                                   alazar.records_per_buffer.get() *
+                                   number_of_channels)
+        else:
+            self.buffer = np.zeros((alazar.buffers_per_acquisition.get(),
+                                    alazar.samples_per_record.get() *
+                                    alazar.records_per_buffer.get() *
+                                    number_of_channels))
+
+    def pre_acquire(self):
+        # gets called after 'AlazarStartCapture'
+        pass
+
+    def handle_buffer(self, data):
+        if self.buffer_idx < self.buffers_per_acquisition:
+            if self.average_mode() in ['point', 'trace']:
+                self.buffer += data
+            else:
+                    self.buffer[self.buffer_idx] = data
+        else:
+            print('*'*20+'\nIgnoring extra ATS buffer')
+        self.buffer_idx += 1
+
+    def post_acquire(self):
+        # Perform averaging over records.
+        # The averaging mode depends on parameter average_mode
+        records_per_acquisition = self.buffers_per_acquisition * \
+                                  self.records_per_buffer
+
+        def channel_offset(ch):
+            return ch * self.samples_per_record * self.records_per_buffer
+
+        if self.average_mode() == 'none':
+            records = [self.buffer[:,
+                       channel_offset(ch):channel_offset(ch+1)].reshape(
+                (records_per_acquisition, self.samples_per_record))
+                       for ch in range(self.number_of_channels)]
+        elif self.average_mode() == 'trace':
+            records = [np.zeros(self.samples_per_record) for _ in
+                       range(self.number_of_channels)]
+
+            for channel in range(self.number_of_channels):
+                for i in range(self.records_per_buffer):
+                    i0 = channel_offset(channel) + i * self.samples_per_record
+                    i1 = i0 + self.samples_per_record
+                    records[channel] += \
+                        self.buffer[i0:i1] / records_per_acquisition
+        elif self.average_mode() == 'point':
+            trace_length = self.samples_per_record * self.records_per_buffer
+            records = [np.mean(self.buffer[i*trace_length:(i+1)*trace_length]) /
+                       records_per_acquisition
+                       for i in range(self.number_of_channels)]
+
+        # Scale datapoints
+        for i, record in enumerate(records):
+            channel_range = eval('self.alazar.channel_range{}()'.format(i + 1))
+            records[i] = 2 * (record / 2 ** 16 - 0.5) * channel_range
+        return records
 
 
 # DFT AcquisitionController
 class DFT_AcquisitionController(AcquisitionController):
     def __init__(self, name, alazar_name, demodulation_frequency, **kwargs):
         self.demodulation_frequency = demodulation_frequency
-        self.acquisitionkwargs = {'acquisition_controller': self}
         self.samples_per_record = None
         self.records_per_buffer = None
         self.buffers_per_acquisition = None
@@ -20,13 +153,6 @@ class DFT_AcquisitionController(AcquisitionController):
         # structure of this class
         super().__init__(name, alazar_name, **kwargs)
         self.add_parameter("acquisition", get_cmd=self.do_acquisition)
-
-    def set_acquisitionkwargs(self, **kwargs):
-        self.acquisitionkwargs.update(**kwargs)
-
-    def do_acquisition(self):
-        value = self._get_alazar().acquire(**self.acquisitionkwargs)
-        return value
 
     def pre_start_capture(self):
         alazar = self._get_alazar()


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow the ATS to work with more than two channels. this was already sort of implemented, but the channels were not provided in binary format, so it did not work.
- Add a __bwlimit_support_ property to the ATS. Some ATS drivers (such as ATS9440) do not support a bwlimit, and so by setting this property to false, it does not try to set this and recieve an error.
- Move acquisitionkwargs to AcquisitionController. It seems to me that these are funcitonalities that are not only relevant for DFT_AcquisitionController, but to all. I have furthermore added acquisitionkwargs as a parameter, because it will then be saved in a snapshot. For this to work, I had to remove acquisition_controller from the acquisitionkwargs, and hardcode it. I also added some checks to ensure that all kwargs added and retrieved from acquisitionkwargs are actual kwargs used in ATS.acquire()
- Small bug in ATS9870, upon creation of different trigger engines
- Basic_AcquisitionController, which can do simple forms of acquisitions. It has three modes for average_mode. These are:
  - **point**: Returns a point, which is the average over time and over all traces
  - **trace (default)**: Returns a trace, which is the average over all traces
  - **none**: Returns all traces, not averaged.

I have not yet been able to fully test the code yet, because I tried to merge the code with the latest version of the ATS9870-dev-branch, and was not able to acquire anymore because the ATS I'm using (ATS9440) retrieves 14 bits, and the latest version of the code only supports 8 bits. I will test it soon, and implement the code for 14 bits as well. 

Note that the Basic_AcquisitionController still checks if the buffer recieved does not exceed the total number of buffers. This is still a remnant from the old code, and I believe this has been fixed by Damaz, but I haven't had a chance to test it out yet.
