### PR TITLE
Add setting of read and write termination characters as empty strings to IVVI driver

### DIFF
--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -58,6 +58,8 @@ class IVVI(VisaInstrument):
         # values based on descriptor
         self.visa_handle.baud_rate = 115200
         self.visa_handle.parity = visa.constants.Parity(1)  # odd parity
+        self.visa_handle.write_termination = ''
+        self.visa_handle.read_termination = ''
 
         self.add_parameter('version',
                            get_cmd=self._get_version)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add setting of read and write termination characters in IVVI instrument driver. This fixes an error that occurs when setting different values fast after each other.

@giulioungaretti 
