### PR TITLE
Only upload docs from python3.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,6 @@ after_success:
     - codecov
     # upload the docs
     - |
-      if [[ $TRAVIS_REPO_SLUG == "QCoDeS/Qcodes" && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" ]]; then
+      if [[ $TRAVIS_REPO_SLUG == "QCoDeS/Qcodes" && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_PYTHON_VERSION  == "3.6" ]]; then
         make -f docs/Makefile gh-pages
       fi


### PR DESCRIPTION
To avoid a pointless race condition on the upload. Unfortunately this is hard to test without merging
