### PR TITLE
Cleanup sqlite base tests

### DIFF
--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -4,7 +4,6 @@
 import time
 import unicodedata
 from contextlib import contextmanager
-from sqlite3 import OperationalError
 from unittest.mock import patch
 
 import hypothesis.strategies as hst


### PR DESCRIPTION
Silence warnings related to dict construction and remove a work around for python 3.6.0 doing incorrect error chaining