### PR TITLE
Better typing of select_one/many_where

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -464,7 +464,7 @@ class DataSet(Sized):
         return get_experiment_name_from_experiment_id(self.conn, self.exp_id)
 
     @property
-    def sample_name(self) -> Optional[str]:
+    def sample_name(self) -> str:
         return get_sample_name_from_experiment_id(self.conn, self.exp_id)
 
     @property

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -95,7 +95,7 @@ class DataSetProtocol(Protocol, Sized):
         pass
 
     @property
-    def sample_name(self) -> Optional[str]:
+    def sample_name(self) -> str:
         pass
 
     def run_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -96,7 +96,7 @@ class Experiment(Sized):
         return get_experiment_name_from_experiment_id(self.conn, self.exp_id)
 
     @property
-    def sample_name(self) -> Optional[str]:
+    def sample_name(self) -> str:
         return get_sample_name_from_experiment_id(self.conn, self.exp_id)
 
     @property

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1837,12 +1837,13 @@ def get_experiment_name_from_experiment_id(conn: ConnectionPlus, exp_id: int) ->
     return exp_name
 
 
-def get_sample_name_from_experiment_id(
-    conn: ConnectionPlus, exp_id: int
-) -> Optional[str]:
+def get_sample_name_from_experiment_id(conn: ConnectionPlus, exp_id: int) -> str:
     sample_name = select_one_where(conn, "experiments", "sample_name", "exp_id", exp_id)
     assert isinstance(sample_name, (str, type(None)))
-    return sample_name
+    # there may be a few cases for very old db where None is returned as a sample name
+    # however, these probably do not exist in relaity outside that test so here we
+    # cast to str. See test_experiments_with_NULL_sample_name
+    return cast(str, sample_name)
 
 
 def get_run_timestamp_from_run_id(conn: ConnectionPlus,

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -951,7 +951,7 @@ def plot(
     axes, cbs = plot_dataset(data)
     mainfolder = config.user.mainfolder
     experiment_name = data.exp_name
-    sample_name = data.sample_name or "unknown_sample"
+    sample_name = data.sample_name
     storage_dir = os.path.join(mainfolder, experiment_name, sample_name)
     os.makedirs(storage_dir, exist_ok=True)
     png_dir = os.path.join(storage_dir, "png")


### PR DESCRIPTION
Rather than returning Any they are now types to return the Set of all the possible return types. 

Since there is no mapping from the sqlite column types this requires a fair bit of asserting to type check. Nevertheless this did uncover a few inconsistencies and I think it is worthwhile to do
