### PR TITLE
Pytest Fixtures: Cleanup

### DIFF
--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -1,10 +1,19 @@
+import gc
+import os
 import sys
-import pytest
-import qcodes as qc
 
+import pytest
 from hypothesis import settings
 
+import qcodes as qc
+from qcodes import initialise_database, new_data_set
+from qcodes.dataset.descriptions.dependencies import InterDependencies_
+from qcodes.dataset.descriptions.param_spec import ParamSpecBase
+from qcodes.dataset.experiment_container import new_experiment
+
 settings.register_profile("ci", deadline=1000)
+
+n_experiments = 0
 
 
 def pytest_configure(config):
@@ -48,3 +57,77 @@ def disable_config_subscriber():
         yield
     finally:
         qc.config.subscription.default_subscribers = original_state
+
+
+@pytest.fixture(scope="function", name="empty_temp_db")
+def _make_empty_temp_db(tmp_path):
+    global n_experiments
+    n_experiments = 0
+    # create a temp database for testing
+    try:
+        qc.config["core"]["db_location"] = str(tmp_path / "temp.db")
+        if os.environ.get("QCODES_SQL_DEBUG"):
+            qc.config["core"]["db_debug"] = True
+        else:
+            qc.config["core"]["db_debug"] = False
+        initialise_database()
+        yield
+    finally:
+        # there is a very real chance that the tests will leave open
+        # connections to the database. These will have gone out of scope at
+        # this stage but a gc collection may not have run. The gc
+        # collection ensures that all connections belonging to now out of
+        # scope objects will be closed
+        gc.collect()
+
+
+@pytest.fixture(scope="function", name="experiment")
+def _make_experiment(empty_temp_db):
+    e = new_experiment("test-experiment", sample_name="test-sample")
+    try:
+        yield e
+    finally:
+        e.conn.close()
+
+
+@pytest.fixture(scope="function", name="dataset")
+def _make_dataset(experiment):
+    dataset = new_data_set("test-dataset")
+    try:
+        yield dataset
+    finally:
+        dataset.unsubscribe_all()
+        dataset.conn.close()
+
+
+@pytest.fixture(name="standalone_parameters_dataset")
+def _make_standalone_parameters_dataset(dataset):
+    n_params = 3
+    n_rows = 10 ** 3
+    params_indep = [
+        ParamSpecBase(f"param_{i}", "numeric", label=f"param_{i}", unit="V")
+        for i in range(n_params)
+    ]
+
+    param_dep = ParamSpecBase(
+        f"param_{n_params}", "numeric", label=f"param_{n_params}", unit="Ohm"
+    )
+
+    params_all = params_indep + [param_dep]
+
+    idps = InterDependencies_(
+        dependencies={param_dep: tuple(params_indep[0:1])},
+        standalones=tuple(params_indep[1:]),
+    )
+
+    dataset.set_interdependencies(idps)
+
+    dataset.mark_started()
+    dataset.add_results(
+        [
+            {p.name: int(n_rows * 10 * pn + i) for pn, p in enumerate(params_all)}
+            for i in range(n_rows)
+        ]
+    )
+    dataset.mark_completed()
+    yield dataset

--- a/qcodes/tests/delegate/test_device.py
+++ b/qcodes/tests/delegate/test_device.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from qcodes import Measurement
-from qcodes.tests.dataset.conftest import empty_temp_db, experiment
 from qcodes.tests.instrument_mocks import DummyChannel, MockCustomChannel
 
 

--- a/qcodes/tests/test_interactive_widget.py
+++ b/qcodes/tests/test_interactive_widget.py
@@ -9,17 +9,6 @@ from ipywidgets import HTML, Button, GridspecLayout, Tab, Textarea
 matplotlib.use("Agg")
 from qcodes import interactive_widget
 
-# we only need `experiment` here, but pytest does not discover the dependencies
-# by itself so we also need to import all the fixtures this one is dependent
-# on
-# pylint: disable=unused-import
-from qcodes.tests.dataset.conftest import (
-    dataset,
-    empty_temp_db,
-    experiment,
-    standalone_parameters_dataset,
-)
-
 
 @pytest.fixture(name="tab", scope="function")
 def _create_tab():

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -2,23 +2,18 @@
 Tests for `qcodes.utils.plotting`.
 """
 import matplotlib
+
 # set matplotlib backend before importing pyplot
 matplotlib.use("Agg")
 
-from pytest import fixture
 from matplotlib import pyplot as plt
+from pytest import fixture
 
-# we only need `dataset` here, but pytest does not discover the dependencies
-# by itself so we also need to import all the fixtures this one is dependent
-# on.
-# pylint: disable=unused-import
-from qcodes.tests.dataset.conftest import (empty_temp_db,
-                                           experiment, dataset)
-
-from qcodes.tests.common import default_config
-from qcodes.dataset.plotting import plot_by_id
-from .dataset_generators import dataset_with_outliers_generator
 import qcodes
+from qcodes.dataset.plotting import plot_by_id
+from qcodes.tests.common import default_config
+
+from .dataset_generators import dataset_with_outliers_generator
 
 
 @fixture(scope='function')


### PR DESCRIPTION
* Move fixtures that are reused outside the dataset level up one level so they can be reused without hacky imports
* Rename fixture functions to be private and use name so we avoid shadowing names warnings.

