### PR TITLE
[WIP] Reuse existing instrument when recreating a new instrument with same name and type

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -514,6 +514,25 @@ class AbstractInstrumentMeta(ABCMeta):
         Overloads `type.__call__` to add code that runs only if __init__ completes
         successfully.
         """
+        if len(args) >= 1:
+            name = args[0]
+        else:
+            name = kwargs.get("name", None)
+        existing_instr = None
+        if name is not None:
+
+            try:
+                existing_instr = cls.find_instrument(name, cls)  # type: ignore[attr-defined]
+            except (KeyError, TypeError):
+                pass
+
+        if existing_instr is not None:
+            log.info(f"Reusing existing instrument {name}")
+            # todo this is only really safe if this is the same instrument
+            # e.g. address should be the same but that is a trait only implemented
+            # in subclasses
+            return existing_instr
+
         new_inst = super().__call__(*args, **kwargs)
         is_abstract = new_inst._is_abstract()
         if is_abstract:


### PR DESCRIPTION
This should remove one of the most common errors for users working interactively with qcodes

Obviously still a few issues:

- [ ] See inline comment about checking that this is the same physical instrument. 
- [ ] Type checking could be cleaner
- [ ] New tests and adaptions of old tests
- [ ] Add bolean for recreate true - false

Now that this implements everything that find_or_create_instrument does
we can also remove the use of than + perhaps deprecate it.


