### PR TITLE
Sphinx extension correctly unpack default. 

### DIFF
--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -196,9 +196,9 @@ def qcodes_parameter_attr_getter(
                     f"Falling back to default Sphinx attribute loader for {name}"
                     f" on {object_to_document_attr_on}"
                 )
-                attr = safe_getattr(object_to_document_attr_on, name, default)
+                attr = safe_getattr(object_to_document_attr_on, name, *default)
     else:
-        attr = safe_getattr(object_to_document_attr_on, name, default)
+        attr = safe_getattr(object_to_document_attr_on, name, *default)
     return attr
 
 


### PR DESCRIPTION
This should always have unpacked default before passing to safe_getattr. E.g. like https://github.com/sphinx-doc/sphinx/blob/5.x/sphinx/ext/autodoc/__init__.py#L2794