### PR TITLE
USB_SA124B: pass kwargs through in FrequencySweep constructor

### DIFF
--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -105,16 +105,27 @@ class FrequencySweep(ArrayParameter):
           get(): executes a sweep and returns magnitude and phase arrays
 
     """
-    def __init__(self, name: str, instrument: 'SignalHound_USB_SA124B',
-                 sweep_len: int, start_freq: float, stepsize: float, **kwargs: Any) -> None:
-        super().__init__(name, shape=(sweep_len,),
-                         instrument=instrument,
-                         unit='dBm',
-                         label='Magnitude',
-                         setpoint_units=('Hz',),
-                         setpoint_labels=(f'Frequency',),
-                         setpoint_names=(f'frequency',),
-                         **kwargs)
+
+    def __init__(
+        self,
+        name: str,
+        instrument: "SignalHound_USB_SA124B",
+        sweep_len: int,
+        start_freq: float,
+        stepsize: float,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            name,
+            shape=(sweep_len,),
+            instrument=instrument,
+            unit="dBm",
+            label="Magnitude",
+            setpoint_units=("Hz",),
+            setpoint_labels=(f"Frequency",),
+            setpoint_names=(f"frequency",),
+            **kwargs,
+        )
         self.set_sweep(sweep_len, start_freq, stepsize)
 
     def set_sweep(self, sweep_len: int, start_freq: float,


### PR DESCRIPTION
Adding *args, **kwargs option to `FrequencySweep` class. Mostly to prevent the annoying warning.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
