### PR TITLE
Add basic read only mode to connect

### DIFF
--- a/docs/changes/newsfragments/4783.readonly
+++ b/docs/changes/newsfragments/4783.readonly
@@ -1,0 +1,1 @@
+Add a read-only option to sqlite connection

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -256,7 +256,7 @@ class DataSet(BaseDataSet):
                 Only takes effect if `conn` is not given.
 
         """
-        if run_id is None and read_only:
+        if run_id is None and conn is None and read_only:
             # raise valueerror here because if no run id, a new dataset will be created
             # and it will be written to the database
             raise ValueError(

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -219,6 +219,7 @@ class DataSet(BaseDataSet):
         metadata: Mapping[str, Any] | None = None,
         shapes: Shapes | None = None,
         in_memory_cache: bool = True,
+        read_only: bool = False,
     ) -> None:
         """
         Create a new :class:`.DataSet` object. The object can either hold a new run or
@@ -251,9 +252,18 @@ class DataSet(BaseDataSet):
                 Ignored if ``run_id`` is provided.
             in_memory_cache: Should measured data be keep in memory
                 and available as part of the `dataset.cache` object.
+            read_only: whether to open the connection in read-only mode.
+                Only takes effect if `conn` is not given.
 
         """
-        self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
+        if run_id is None and read_only:
+            # raise valueerror here because if no run id, a new dataset will be created
+            # and it will be written to the database
+            raise ValueError(
+                "Cannot open database in read-only mode without a run_id provided"
+                " since a new dataset will be created."
+            )
+        self.conn = conn_from_dbpath_or_conn(conn, path_to_db, read_only=read_only)
 
         self._debug = False
         self.subscribers: dict[str, _Subscriber] = {}
@@ -1567,6 +1577,7 @@ def load_by_run_spec(
     location: int | None = None,
     work_station: int | None = None,
     conn: AtomicConnection | None = None,
+    read_only: bool = False,
 ) -> DataSetProtocol:
     """
     Load a run from one or more pieces of runs specification. All
@@ -1591,6 +1602,8 @@ def load_by_run_spec(
         work_station: The workstation assigned as part of the GUID.
         conn: An optional connection to the database. If no connection is
           supplied a connection to the default database will be opened.
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Raises:
         NameError: if no run or more than one run with the given specification
@@ -1602,7 +1615,7 @@ def load_by_run_spec(
         specification.
 
     """
-    internal_conn = conn or connect(get_DB_location())
+    internal_conn = conn or connect(get_DB_location(), read_only=read_only)
     d: DataSetProtocol | None = None
     try:
         guids = get_guids_by_run_spec(
@@ -1646,6 +1659,7 @@ def get_guids_by_run_spec(
     location: int | None = None,
     work_station: int | None = None,
     conn: AtomicConnection | None = None,
+    read_only: bool = False,
 ) -> list[str]:
     """
     Get a list of matching guids from one or more pieces of runs specification. All
@@ -1663,12 +1677,14 @@ def get_guids_by_run_spec(
         work_station: The workstation assigned as part of the GUID.
         conn: An optional connection to the database. If no connection is
           supplied a connection to the default database will be opened.
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns:
         List of guids matching the run spec.
 
     """
-    internal_conn = conn or connect(get_DB_location())
+    internal_conn = conn or connect(get_DB_location(), read_only=read_only)
     try:
         guids = _query_guids_from_run_spec(
             internal_conn,
@@ -1687,7 +1703,9 @@ def get_guids_by_run_spec(
     return matched_guids
 
 
-def load_by_id(run_id: int, conn: AtomicConnection | None = None) -> DataSetProtocol:
+def load_by_id(
+    run_id: int, conn: AtomicConnection | None = None, read_only: bool = False
+) -> DataSetProtocol:
     """
     Load a dataset by run id
 
@@ -1707,6 +1725,8 @@ def load_by_id(run_id: int, conn: AtomicConnection | None = None) -> DataSetProt
     Args:
         run_id: run id of the dataset
         conn: connection to the database to load from
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns:
         :class:`qcodes.dataset.data_set.DataSet` or
@@ -1715,7 +1735,7 @@ def load_by_id(run_id: int, conn: AtomicConnection | None = None) -> DataSetProt
     """
     if run_id is None:
         raise ValueError("run_id has to be a positive integer, not None.")
-    internal_conn = conn or connect(get_DB_location())
+    internal_conn = conn or connect(get_DB_location(), read_only=read_only)
     d: DataSetProtocol | None = None
 
     try:
@@ -1733,7 +1753,9 @@ def load_by_id(run_id: int, conn: AtomicConnection | None = None) -> DataSetProt
     return d
 
 
-def load_by_guid(guid: str, conn: AtomicConnection | None = None) -> DataSetProtocol:
+def load_by_guid(
+    guid: str, conn: AtomicConnection | None = None, read_only: bool = False
+) -> DataSetProtocol:
     """
     Load a dataset by its GUID
 
@@ -1748,6 +1770,8 @@ def load_by_guid(guid: str, conn: AtomicConnection | None = None) -> DataSetProt
     Args:
         guid: guid of the dataset
         conn: connection to the database to load from
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns:
         :class:`qcodes.dataset.data_set.DataSet` or
@@ -1758,7 +1782,7 @@ def load_by_guid(guid: str, conn: AtomicConnection | None = None) -> DataSetProt
         RuntimeError: if several runs with the given GUID are found
 
     """
-    internal_conn = conn or connect(get_DB_location())
+    internal_conn = conn or connect(get_DB_location(), read_only=read_only)
     d: DataSetProtocol | None = None
 
     # this function raises a RuntimeError if more than one run matches the GUID
@@ -1773,7 +1797,10 @@ def load_by_guid(guid: str, conn: AtomicConnection | None = None) -> DataSetProt
 
 
 def load_by_counter(
-    counter: int, exp_id: int, conn: AtomicConnection | None = None
+    counter: int,
+    exp_id: int,
+    conn: AtomicConnection | None = None,
+    read_only: bool = False,
 ) -> DataSetProtocol:
     """
     Load a dataset given its counter in a given experiment
@@ -1795,6 +1822,8 @@ def load_by_counter(
         exp_id: id of the experiment where to look for the dataset
         conn: connection to the database to load from. If not provided, a
           connection to the DB file specified in the config is made
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns:
         :class:`DataSet` or
@@ -1802,7 +1831,7 @@ def load_by_counter(
         the given experiment
 
     """
-    internal_conn = conn or connect(get_DB_location())
+    internal_conn = conn or connect(get_DB_location(), read_only=read_only)
     d: DataSetProtocol | None = None
 
     # this function raises a RuntimeError if more than one run matches the GUID
@@ -1906,7 +1935,7 @@ def new_data_set(
 
 
 def generate_dataset_table(
-    guids: Sequence[str], conn: AtomicConnection | None = None
+    guids: Sequence[str], conn: AtomicConnection | None = None, read_only: bool = False
 ) -> str:
     """
     Generate an ASCII art table of information about the runs attached to the
@@ -1915,6 +1944,8 @@ def generate_dataset_table(
     Args:
         guids: Sequence of one or more guids
         conn: An AtomicConnection object with a connection to the database.
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns: ASCII art table of information about the supplied guids.
 
@@ -1931,7 +1962,7 @@ def generate_dataset_table(
     )
     table = []
     for guid in guids:
-        ds = load_by_guid(guid, conn=conn)
+        ds = load_by_guid(guid, conn=conn, read_only=read_only)
         parsed_guid = parse_guid(guid)
         table.append(
             [

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -272,7 +272,6 @@ class DataSet(BaseDataSet):
         self._cache: DataSetCacheWithDBBackend = DataSetCacheWithDBBackend(self)
         self._results: list[dict[str, VALUE]] = []
         self._in_memory_cache = in_memory_cache
-        self._read_only = read_only
 
         if run_id is not None:
             if not run_exists(self.conn, run_id):
@@ -594,8 +593,6 @@ class DataSet(BaseDataSet):
             metadata: actual metadata
 
         """
-        if self._read_only:
-            raise RuntimeError("Cannot add metadata to a read-only dataset")
 
         self._metadata[tag] = metadata
         # `add_data_to_dynamic_columns` is not atomic by itself, hence using `atomic`
@@ -613,8 +610,6 @@ class DataSet(BaseDataSet):
             overwrite: force overwrite an existing snapshot
 
         """
-        if self._read_only:
-            raise RuntimeError("Cannot add snapshot to a read-only dataset")
         if self.snapshot is None or overwrite:
             with atomic(self.conn) as conn:
                 add_data_to_dynamic_columns(conn, self.run_id, {"snapshot": snapshot})

--- a/src/qcodes/dataset/sqlite/database.py
+++ b/src/qcodes/dataset/sqlite/database.py
@@ -303,7 +303,9 @@ def initialised_database_at(db_file_with_abs_path: str | Path) -> Iterator[None]
 
 
 def conn_from_dbpath_or_conn(
-    conn: AtomicConnection | None, path_to_db: str | Path | None
+    conn: AtomicConnection | None,
+    path_to_db: str | Path | None,
+    read_only: bool = False,
 ) -> AtomicConnection:
     """
     A small helper function to abstract the logic needed for functions
@@ -314,6 +316,8 @@ def conn_from_dbpath_or_conn(
     Args:
         conn: A AtomicConnection object pointing to a sqlite database
         path_to_db: The path to a db file.
+        read_only: whether to open the connection in read-only mode.
+            Only takes effect if `conn` is not given.
 
     Returns:
         A `AtomicConnection` object
@@ -328,7 +332,7 @@ def conn_from_dbpath_or_conn(
         path_to_db = get_DB_location()
 
     if conn is None and path_to_db is not None:
-        conn = connect(path_to_db, get_DB_debug())
+        conn = connect(path_to_db, get_DB_debug(), read_only=read_only)
     elif conn is not None:
         pass
     else:

--- a/src/qcodes/dataset/sqlite/database.py
+++ b/src/qcodes/dataset/sqlite/database.py
@@ -121,7 +121,7 @@ def _adapt_complex(value: complex | np.complexfloating) -> sqlite3.Binary:
 
 
 def connect(
-    name: str | Path, debug: bool = False, version: int = -1
+    name: str | Path, debug: bool = False, version: int = -1, read_only: bool = False
 ) -> AtomicConnection:
     """
     Connect or create  database. If debug the queries will be echoed back.
@@ -133,6 +133,7 @@ def connect(
         debug: should tracing be turned on.
         version: which version to create. We count from 0. -1 means 'latest'.
             Should always be left at -1 except when testing.
+        read_only: Should the database be opened in read only mode.
 
     Returns:
         connection object to the database (note, it is
@@ -144,10 +145,16 @@ def connect(
     # register binary(TEXT) -> numpy converter
     sqlite3.register_converter("array", _convert_array)
 
+    path = f"file:{name!s}"
+
+    if read_only:
+        path = path + "?mode=ro"
+
     conn = sqlite3.connect(
-        name,
+        path,
         detect_types=sqlite3.PARSE_DECLTYPES,
         check_same_thread=True,
+        uri=True,
         factory=AtomicConnection,
     )
 

--- a/tests/dataset/test_dataset_basic.py
+++ b/tests/dataset/test_dataset_basic.py
@@ -37,6 +37,8 @@ from tests.dataset.test_links import generate_some_links
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from qcodes.dataset.experiment_container import Experiment
+
 n_experiments = 0
 
 
@@ -1416,3 +1418,13 @@ def test_empty_ds_parameters() -> None:
     assert ds.parameters is None
     ds.mark_completed()
     assert ds.parameters is None
+
+
+def test_create_dataset_with_readonly_throws_error() -> None:
+    with pytest.raises(ValueError):
+        DataSet(read_only=True)
+
+
+@pytest.mark.usefixtures("experiment")
+def test_create_dataset_with_conn_ignores_readonly(experiment: "Experiment") -> None:
+    DataSet(conn=experiment.conn, read_only=True)


### PR DESCRIPTION
Note we probably want to make use of this in lots of places. However, I think its fine to merge this as is and then usage can be improved later. However, at a minimum the following should be done.

- [x] load_by ... should expose a read_only flag so its easy for data analysis + plotting to load as read only.
- [x] ~~Figure out how read only is exposed to the dataset. Ensure that adding metadata via call to `ds.add_metadata` on a read only dataset gives some kind of reasonable error.~~ Won't implement since the error from sqlite is informative enough.