### PR TITLE
Try building docs with warnings as errors on 3.11, 3.12

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,11 +39,8 @@ jobs:
             python-version: 3.11
     env:
       OS: ${{ matrix.os }}
-      # we expect no warnings from Sphinx in 3.10
-      # The std-lib docstring of IntEnum in 3.11.0 is not valid
-      # causing errors like in the docstring of from_bytes (from Int)
-      # WARNING: Inline interpreted text or phrase reference start-string without end-string.
-      SPHINX_WARNINGS_AS_ERROR: ${{ matrix.python-version == '3.10' }}
+      # we expect no warnings from Sphinx in 3.10 and forward
+      SPHINX_WARNINGS_AS_ERROR: ${{ matrix.python-version == '3.10' || matrix.python-version == '3.11' || matrix.python-version == '3.12'}}
       SPHINX_OPTS: "-v -j 2"
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Looks like the original issue is fixed

Thou I am seeing a warning from building Lakeshore documentation. It looks like this is coming from the std lib documentation of 
``LakeshoreModel325Status`` Probably from the std lib docs of IntFlag