### PR TITLE
Reduce "dataset already marked completed" warnings

### DIFF
--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
+
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.dataset.sqlite.queries import completed, load_new_data_for_rundescriber


### PR DESCRIPTION
`DataSetCacheWithDBBackEnd` can cause unnecessary warnings about a dataset being marked as completed that is already marked as completed.

This occurs if you load a dataset from a qcodes.db and then use the `plot_dataset` function. for a dataset that has already been marked as completed.

When `plot_dataset` loads the data, the underlying `DataSetCacheWithDBBackEnd` always re-marks the run as completed, generating a warning.

To address this, the datasets's `completed` property is only updated if necessary.