### PR TITLE
RFC: Drop python 39

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,10 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         exclude:
-          - os: windows-latest
-            python-version: 3.9
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,15 +30,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         min-version: [false]
         include:
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             min-version: true
         exclude:
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
           - os: windows-latest
             python-version: "3.11"
           - os: windows-latest

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To get a feeling of QCoDeS read
 and/or browse the Jupyter notebooks in `docs/examples
 <https://github.com/QCoDeS/Qcodes/tree/main/docs/examples>`__ .
 
-QCoDeS is compatible with Python 3.9+ (3.9 soon to be deprecated). It is
+QCoDeS is compatible with Python 3.10+. It is
 primarily intended for use from Jupyter notebooks, but can be used from
 traditional terminal-based shells and in stand-alone scripts as well. The
 features in `qcodes.utils.magic` are exclusively for Jupyter notebooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,8 @@ select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC"
 # code.
 # PLxxxx are pylint lints that generate a fair amount of warnings
 # it may be worth fixing some or these in the future
-ignore = ["E501", "G004", "NPY002", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901"]
+# UP038 this can result in slower code so we ignore it
+ignore = ["E501", "G004", "NPY002", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "UP038"]
 
 [tool.ruff.lint.isort]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,14 @@ classifiers = [
 license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
-    "broadbean>=0.9.1",
-    "h5netcdf>=0.10.0,!=0.14.0",
-    # see https://github.com/h5netcdf/h5netcdf/issues/154
+    "broadbean>=0.11.0",
+    "h5netcdf>=0.14.1",
     "h5py>=3.6.0",
     "ipywidgets>=8.0.0,<9.0.0",
     "ipykernel>=6.6.0", # implicitly required by ipywidgets >=8.0.5
     "jsonschema>=4.9.0",
     "matplotlib>=3.5.0",
-    "numpy>=1.22.0",
+    "numpy>=1.22.4",
     "packaging>=20.0",
     "pandas>=1.4.0",
     "pyarrow>=11.0.0", # will become a requirement of pandas. Installing explicitly silences a warning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,24 +25,24 @@ dependencies = [
     "broadbean>=0.9.1",
     "h5netcdf>=0.10.0,!=0.14.0",
     # see https://github.com/h5netcdf/h5netcdf/issues/154
-    "h5py>=3.0.0",
+    "h5py>=3.6.0",
     "ipywidgets>=8.0.0,<9.0.0",
     "ipykernel>=6.6.0", # implicitly required by ipywidgets >=8.0.5
     "jsonschema>=4.9.0",
-    "matplotlib>=3.3.3",
-    "numpy>=1.21.0",
+    "matplotlib>=3.5.0",
+    "numpy>=1.22.0",
     "packaging>=20.0",
-    "pandas>=1.2.0",
+    "pandas>=1.4.0",
     "pyarrow>=11.0.0", # will become a requirement of pandas. Installing explicitly silences a warning
     "pyvisa>=1.11.0, <1.15.0",
     "ruamel.yaml>=0.16.0,!=0.16.6",
-    "tabulate>=0.8.0",
+    "tabulate>=0.9.0",
     "typing_extensions>=4.5.0",
     "tqdm>=4.59.0",
     "uncertainties>=3.1.4",
     "versioningit>=2.2.1",
-    "websockets>=9.1",
-    "wrapt>=1.13.2; python_version < '3.12'",
+    "websockets>=11.0",
+    "wrapt>=1.14.0; python_version < '3.12'",
     "wrapt>=1.16.0; python_version >= '3.12'",
     "xarray>=2022.06.0",
     "cf_xarray>=0.8.4",
@@ -76,7 +76,7 @@ test = [
     "coverage[toml]>=6.0.0",
     "deepdiff>=5.0.2",
     "hypothesis>=6.85.0",
-    "lxml>=4.6.0",
+    "lxml>=4.8.0",
     "lxml-stubs>=0.4.0",
     "mypy>=0.971",
     "pandas-stubs>=1.2.0.1",
@@ -85,7 +85,7 @@ test = [
     "pytest-cov>=3.0.0",
     "pytest-mock>=3.0.0",
     "pytest-rerunfailures>=10.0",
-    "pytest-xdist>=2.0.0",
+    "pytest-xdist>=2.5.0",
     "PyVisa-sim>=0.6.0",
     "sphinx>=4.5.0",  # sphinx extension tests
     "types-jsonschema>=4.16.0",
@@ -110,7 +110,7 @@ docs = [
     "sphinx-rtd-theme>=1.0.0",
     "sphinxcontrib-towncrier>=0.3.0a0",
     "towncrier>=22.8.0",
-    "scipy>=1.7.0", # examples using scipy
+    "scipy>=1.8.0", # examples using scipy
     "qcodes_loop>=0.1.1", # legacy dataset import examples
     "jinja2>=3.1.3", # transitive dependency pin due to cve in earlier version
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "h5netcdf>=0.10.0,!=0.14.0",
     # see https://github.com/h5netcdf/h5netcdf/issues/154
     "h5py>=3.0.0",
-    "importlib-metadata>=4.4; python_version < '3.10'",
     "ipywidgets>=8.0.0,<9.0.0",
     "ipykernel>=6.6.0", # implicitly required by ipywidgets >=8.0.5
     "jsonschema>=4.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "broadbean>=0.9.1",
     "h5netcdf>=0.10.0,!=0.14.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,8 +115,7 @@ ipykernel==6.29.4
     # via
     #   qcodes (pyproject.toml)
     #   qcodes
-ipython==8.18.1; python_version == "3.9"
-ipython==8.25.0; python_version >= "3.10"
+ipython==8.25.0
     # via
     #   qcodes (pyproject.toml)
     #   ipykernel

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -6,7 +6,6 @@ import logging
 import os
 import time
 import warnings
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -50,7 +49,7 @@ from .exporters.export_info import ExportInfo
 from .linked_datasets.links import str_to_links
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     import pandas as pd
     import xarray as xr

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -6,8 +6,9 @@ import logging
 import os
 import time
 import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -32,13 +32,6 @@ from .descriptions.versioning.converters import new_to_old
 from .exporters.export_to_csv import dataframe_to_csv
 from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
 from .sqlite.queries import raw_time_to_str_time
-
-if sys.version_info >= (3, 10):
-    # new entrypoints api was added in 3.10
-    from importlib.metadata import entry_points
-else:
-    # 3.9 and earlier
-    from importlib_metadata import entry_points
 
 if TYPE_CHECKING:
     from typing import TypeAlias

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -4,13 +4,12 @@ import logging
 import os
 import sys
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Literal,
     Protocol,
     Union,
@@ -42,9 +41,10 @@ else:
     from importlib_metadata import entry_points
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     import pandas as pd
     import xarray as xr
-    from typing_extensions import TypeAlias
 
     from qcodes.dataset.descriptions.rundescriber import RunDescriber
     from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
@@ -61,17 +61,17 @@ _EXPORT_CALLBACKS = set(entry_points(group="qcodes.dataset.on_export"))
 # even with from __future__ import annotations
 # type aliases must use the old format until we drop 3.8/3.9
 array_like_types = (tuple, list, np.ndarray)
-scalar_res_types: TypeAlias = Union[
-    str, complex, np.integer, np.floating, np.complexfloating
-]
-values_type: TypeAlias = Union[scalar_res_types, np.ndarray, Sequence[scalar_res_types]]
+scalar_res_types: TypeAlias = (
+    str | complex | np.integer | np.floating | np.complexfloating
+)
+values_type: TypeAlias = scalar_res_types | np.ndarray | Sequence[scalar_res_types]
 res_type: TypeAlias = tuple[Union["ParameterBase", str], values_type]
 setpoints_type: TypeAlias = Sequence[Union[str, "ParameterBase"]]
 SPECS: TypeAlias = list[ParamSpec]
 # Transition period type: SpecsOrInterDeps. We will allow both as input to
 # the DataSet constructor for a while, then deprecate SPECS and finally remove
 # the ParamSpec class
-SpecsOrInterDeps: TypeAlias = Union[SPECS, InterDependencies_]
+SpecsOrInterDeps: TypeAlias = SPECS | InterDependencies_
 ParameterData: TypeAlias = dict[str, dict[str, np.ndarray]]
 
 LOG = logging.getLogger(__name__)

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -51,8 +51,6 @@ if TYPE_CHECKING:
 # twice here convert to set to ensure no duplication.
 _EXPORT_CALLBACKS = set(entry_points(group="qcodes.dataset.on_export"))
 
-# even with from __future__ import annotations
-# type aliases must use the old format until we drop 3.8/3.9
 array_like_types = (tuple, list, np.ndarray)
 scalar_res_types: TypeAlias = (
     str | complex | np.integer | np.floating | np.complexfloating

--- a/src/qcodes/dataset/descriptions/versioning/rundescribertypes.py
+++ b/src/qcodes/dataset/descriptions/versioning/rundescribertypes.py
@@ -15,7 +15,7 @@ interdependencies_, which is an instance of InterDependencies_
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from typing_extensions import TypedDict
 
@@ -53,10 +53,9 @@ class RunDescriberV2Dict(RunDescriberV0Dict):
 
 class RunDescriberV3Dict(RunDescriberV2Dict):
     shapes: Shapes | None
-    # dict from dependent to dict from depenency to num points in grid
+    # dict from dependent to dict from dependency to num points in grid
 
 
-RunDescriberDicts = Union[RunDescriberV0Dict,
-                          RunDescriberV1Dict,
-                          RunDescriberV2Dict,
-                          RunDescriberV3Dict]
+RunDescriberDicts = (
+    RunDescriberV0Dict | RunDescriberV1Dict | RunDescriberV2Dict | RunDescriberV3Dict
+)

--- a/src/qcodes/dataset/dond/do_nd.py
+++ b/src/qcodes/dataset/dond/do_nd.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import itertools
 import logging
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from opentelemetry import trace
@@ -88,7 +88,7 @@ class _Sweeper:
     ) -> tuple[tuple[tuple[SweepVarType, ...] | SweepVarType, ...], ...]:
         sweeps = tuple(sweep.get_setpoints() for sweep in self._sweeps)
         return cast(
-            tuple[tuple[Union[tuple[SweepVarType, ...], SweepVarType], ...], ...],
+            tuple[tuple[tuple[SweepVarType, ...] | SweepVarType, ...], ...],
             tuple(itertools.product(*sweeps)),
         )
 

--- a/src/qcodes/dataset/dond/do_nd_utils.py
+++ b/src/qcodes/dataset/dond/do_nd_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     import matplotlib.axes
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 ActionsT = Sequence[Callable[[], None]]
 BreakConditionT = Callable[[], bool]
 
-ParamMeasT = Union[ParameterBase, Callable[[], None]]
+ParamMeasT = ParameterBase | Callable[[], None]
 
 AxesTuple = tuple["matplotlib.axes.Axes", "matplotlib.colorbar.Colorbar"]
 AxesTupleList = tuple[
@@ -45,7 +45,7 @@ class BreakConditionInterrupt(Exception):
     pass
 
 
-MeasInterruptT = Union[KeyboardInterrupt, BreakConditionInterrupt, None]
+MeasInterruptT = KeyboardInterrupt | BreakConditionInterrupt | None
 
 
 def _register_parameters(

--- a/src/qcodes/dataset/dond/do_nd_utils.py
+++ b/src/qcodes/dataset/dond/do_nd_utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     import matplotlib.axes

--- a/src/qcodes/dataset/measurements.py
+++ b/src/qcodes/dataset/measurements.py
@@ -10,13 +10,13 @@ import io
 import logging
 import traceback as tb_module
 import warnings
-from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, MutableSequence, Sequence
 from contextlib import ExitStack
 from copy import deepcopy
 from inspect import signature
 from numbers import Number
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
 from opentelemetry import trace
@@ -64,7 +64,7 @@ TRACER = trace.get_tracer(__name__)
 
 ActionType = tuple[Callable[..., Any], Sequence[Any]]
 SubscriberType = tuple[
-    Callable[..., Any], Union[MutableSequence[Any], MutableMapping[Any, Any]]
+    Callable[..., Any], MutableSequence[Any] | MutableMapping[Any, Any]
 ]
 
 
@@ -341,7 +341,7 @@ class DataSaver:
             )
         for i in range(len(parameter.shapes)):
             # if this loop runs, then 'data' is a Sequence
-            data = cast(Sequence[Union[str, int, float, Any]], data)
+            data = cast(Sequence[str | int | float | Any], data)
 
             shape = parameter.shapes[i]
 

--- a/src/qcodes/dataset/sqlite/query_helpers.py
+++ b/src/qcodes/dataset/sqlite/query_helpers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy import ndarray
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     import sqlite3
 
 # represent the type of  data we can/want map to sqlite column
-VALUE = Union[str, complex, list, ndarray, bool, None]
+VALUE = str | complex | list | ndarray | bool | None
 VALUES = Sequence[VALUE]
 
 

--- a/src/qcodes/dataset/subscriber.py
+++ b/src/qcodes/dataset/subscriber.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import logging
 import time
-from collections.abc import Callable
 from queue import Empty, Queue
 from threading import Thread
 from typing import TYPE_CHECKING, Any
@@ -11,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from qcodes.dataset.sqlite.connection import atomic_transaction
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from qcodes.dataset.data_set import DataSet
 

--- a/src/qcodes/dataset/subscriber.py
+++ b/src/qcodes/dataset/subscriber.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import functools
 import logging
 import time
+from collections.abc import Callable
 from queue import Empty, Queue
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from qcodes.dataset.sqlite.connection import atomic_transaction
 

--- a/src/qcodes/dataset/threading.py
+++ b/src/qcodes/dataset/threading.py
@@ -9,8 +9,9 @@ import concurrent.futures
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Protocol, TypeVar, Union
+from typing import TYPE_CHECKING, Protocol, TypeVar, Union
 
 from qcodes.utils import RespondingThread
 

--- a/src/qcodes/extensions/_refactor.py
+++ b/src/qcodes/extensions/_refactor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
 from textwrap import dedent
-from typing import Union, cast
+from typing import cast
 
 try:
     import libcst as cst
@@ -99,7 +99,7 @@ class AddParameterTransformer(VisitorBasedCodemodCommand):
         if arg_is_docstring:
             self.annotations.docstring = str(
                 cast(
-                    Union[cst.SimpleString, cst.ConcatenatedString], node.value
+                    cst.SimpleString | cst.ConcatenatedString, node.value
                 ).evaluated_value
             )
         if arg_is_docstring_dedent:

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable, Iterable, Iterator, MutableSequence, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from qcodes.metadatable import MetadatableWithName
 from qcodes.parameters import (
@@ -461,7 +461,7 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
                 "Slicing is currently not supported for MultiParameters"
             )
         parameters = cast(
-            list[Union[Parameter, ArrayParameter]],
+            list[Parameter | ArrayParameter],
             [chan.parameters[name] for chan in self._channels],
         )
         names = tuple(f"{chan.name}_{name}" for chan in self._channels)

--- a/src/qcodes/instrument/mockers/simulated_ats_api.py
+++ b/src/qcodes/instrument/mockers/simulated_ats_api.py
@@ -8,8 +8,7 @@ any functionality whatsoever.
 
 
 import ctypes
-from collections.abc import Callable
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
@@ -20,6 +19,9 @@ from qcodes.instrument_drivers.AlazarTech.constants import (
     ReturnCode,
 )
 from qcodes.instrument_drivers.AlazarTech.dll_wrapper import _mark_params_as_updated
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class SimulatedATS9360API(AlazarATSAPI):
@@ -32,7 +34,7 @@ class SimulatedATS9360API(AlazarATSAPI):
     def __init__(
         self,
         dll_path: str | None = None,  # Need this for meta super class
-        buffer_generator: Callable[[np.ndarray], None] | None = None,
+        buffer_generator: "Callable[[np.ndarray], None] | None" = None,
     ):
         def _default_buffer_generator(buffer: np.ndarray) -> None:
             upper = buffer.size // 2

--- a/src/qcodes/instrument/mockers/simulated_ats_api.py
+++ b/src/qcodes/instrument/mockers/simulated_ats_api.py
@@ -8,7 +8,8 @@ any functionality whatsoever.
 
 
 import ctypes
-from typing import Any, Callable, ClassVar, Optional
+from collections.abc import Callable
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -29,9 +30,9 @@ class SimulatedATS9360API(AlazarATSAPI):
     }
 
     def __init__(
-            self,
-            dll_path: Optional[str] = None,  # Need this for meta super class
-            buffer_generator: Optional[Callable[[np.ndarray], None]] = None,
+        self,
+        dll_path: str | None = None,  # Need this for meta super class
+        buffer_generator: Callable[[np.ndarray], None] | None = None,
     ):
         def _default_buffer_generator(buffer: np.ndarray) -> None:
             upper = buffer.size // 2

--- a/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar
 
 from qcodes import validators as vals
 from qcodes.instrument import (
@@ -280,7 +280,7 @@ class AimTTi(VisaInstrument):
 
     # Interface Management
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """
         Returns the instrument identification including vendor, model, serial
         number and the firmware.
@@ -288,7 +288,7 @@ class AimTTi(VisaInstrument):
         IDNstr = self.ask_raw("*IDN?")
         vendor, model, serial, firmware = map(str.strip, IDNstr.split(","))
 
-        IDN: dict[str, Optional[str]] = {
+        IDN: dict[str, str | None] = {
             "vendor": vendor,
             "model": model,
             "serial": serial,

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -6,7 +6,7 @@ import sys
 import time
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 import numpy as np
 from typing_extensions import deprecated
@@ -28,13 +28,13 @@ logger = logging.getLogger(__name__)
 
 OutputType = TypeVar('OutputType')
 
-CtypesTypes = Union[
-    type[ctypes.c_uint8],
-    type[ctypes.c_uint16],
-    type[ctypes.c_uint32],
-    type[ctypes.c_int32],
-    type[ctypes.c_float],
-]
+CtypesTypes = (
+    type[ctypes.c_uint8]
+    | type[ctypes.c_uint16]
+    | type[ctypes.c_uint32]
+    | type[ctypes.c_int32]
+    | type[ctypes.c_float]
+)
 
 
 class AlazarTechATS(Instrument):

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -1,5 +1,5 @@
 import math
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -41,9 +41,9 @@ class DemodulationAcquisitionController(AcquisitionController[float]):
         self.records_per_buffer = 0
         self.buffers_per_acquisition = 0
         self.number_of_channels = 2
-        self.cos_list: Optional[np.ndarray] = None
-        self.sin_list: Optional[np.ndarray] = None
-        self.buffer: Optional[np.ndarray] = None
+        self.cos_list: np.ndarray | None = None
+        self.sin_list: np.ndarray | None = None
+        self.buffer: np.ndarray | None = None
         # make a call to the parent class and by extension, create the parameter
         # structure of this class
         super().__init__(name, alazar_name, **kwargs)
@@ -101,7 +101,7 @@ class DemodulationAcquisitionController(AcquisitionController[float]):
         pass
 
     def handle_buffer(
-        self, buffer: np.ndarray, buffer_number: Optional[int] = None
+        self, buffer: np.ndarray, buffer_number: int | None = None
     ) -> None:
         """
         See AcquisitionController

--- a/src/qcodes/instrument_drivers/Galil/dmc_41x3.py
+++ b/src/qcodes/instrument_drivers/Galil/dmc_41x3.py
@@ -4,7 +4,7 @@ This file holds the QCoDeS driver for the Galil DMC-41x3 motor controllers.
 Colloquially known as the "stepper motors".
 """
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -63,12 +63,12 @@ class GalilMotionController(Instrument):
         """
         self.g.GOpen(self._address + " --direct -s ALL")
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """
         Get Galil motion controller hardware information
         """
         data = self.g.GInfo().split(" ")
-        idparts: list[Optional[str]] = [
+        idparts: list[str | None] = [
             "Galil Motion Control, Inc.",
             data[1],
             data[4],
@@ -641,9 +641,9 @@ class GalilDMC4133Arm:
 
         # initialization (all these points will have values in quadrature
         # counts)
-        self._left_bottom_position: Optional[tuple[int, int, int]] = None
-        self._left_top_position: Optional[tuple[int, int, int]] = None
-        self._right_top_position: Optional[tuple[int, int, int]] = None
+        self._left_bottom_position: tuple[int, int, int] | None = None
+        self._left_top_position: tuple[int, int, int] | None = None
+        self._right_top_position: tuple[int, int, int] | None = None
 
         # motion directions (all these values are in quadrature counts)
         self._a: np.ndarray  # right_top - left_bottom
@@ -658,8 +658,8 @@ class GalilDMC4133Arm:
         self._plane_eqn: np.ndarray
 
         # current vars
-        self._current_row: Optional[int] = None
-        self._current_pad: Optional[int] = None
+        self._current_row: int | None = None
+        self._current_pad: int | None = None
 
         # chip details
         self.rows: int
@@ -677,23 +677,23 @@ class GalilDMC4133Arm:
         self._target: np.ndarray
 
     @property
-    def current_row(self) -> Optional[int]:
+    def current_row(self) -> int | None:
         return self._current_row
 
     @property
-    def current_pad(self) -> Optional[int]:
+    def current_pad(self) -> int | None:
         return self._current_pad
 
     @property
-    def left_bottom_position(self) -> Optional[tuple[int, int, int]]:
+    def left_bottom_position(self) -> tuple[int, int, int] | None:
         return self._left_bottom_position
 
     @property
-    def left_top_position(self) -> Optional[tuple[int, int, int]]:
+    def left_top_position(self) -> tuple[int, int, int] | None:
         return self._left_top_position
 
     @property
-    def right_top_position(self) -> Optional[tuple[int, int, int]]:
+    def right_top_position(self) -> tuple[int, int, int] | None:
         return self._right_top_position
 
     @property

--- a/src/qcodes/instrument_drivers/HP/HP_83650A.py
+++ b/src/qcodes/instrument_drivers/HP/HP_83650A.py
@@ -2,7 +2,7 @@
 #
 # Written by Bruno Buijtendorp (brunobuijtendorp@gmail.com)
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes import validators as vals
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
@@ -31,7 +31,7 @@ class HP83650A(VisaInstrument):
         address: str,
         verbose: int = 1,
         reset: bool = False,
-        server_name: Optional[str] = None,
+        server_name: str | None = None,
         **kwargs: "Unpack[VisaInstrumentKWArgs]",
     ):
 

--- a/src/qcodes/instrument_drivers/HP/HP_8753D.py
+++ b/src/qcodes/instrument_drivers/HP/HP_8753D.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -286,7 +286,7 @@ class HP8753D(VisaInstrument):
 
             self.ask(f"OPC?;NUMG{N}")
 
-    def invalidate_trace(self, cmd: str, value: Union[float, int, str]) -> None:
+    def invalidate_trace(self, cmd: str, value: float | int | str) -> None:
         """
         Wrapper for set_cmds that make the trace not ready
         """

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2000.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2000.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Bool, Enum, Ints, MultiType, Numbers
@@ -234,14 +235,14 @@ class Keithley2000(VisaInstrument):
 
     def _get_mode_param(
         self, parameter: str, parser: Callable[[str], Any]
-    ) -> Union[float, str, bool]:
+    ) -> float | str | bool:
         """Read the current Keithley mode and ask for a parameter"""
         mode = _parse_output_string(self._mode_map[self.mode()])
         cmd = f"{mode}:{parameter}?"
 
         return parser(self.ask(cmd))
 
-    def _set_mode_param(self, parameter: str, value: Union[float, str, bool]) -> None:
+    def _set_mode_param(self, parameter: str, value: float | str | bool) -> None:
         """Read the current Keithley mode and set a parameter"""
         if isinstance(value, bool):
             value = int(value)

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2000.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2000.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
@@ -6,6 +5,8 @@ from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Bool, Enum, Ints, MultiType, Numbers
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter
@@ -234,7 +235,7 @@ class Keithley2000(VisaInstrument):
         return float(self.ask("SENSE:DATA:FRESH?"))
 
     def _get_mode_param(
-        self, parameter: str, parser: Callable[[str], Any]
+        self, parameter: str, parser: "Callable[[str], Any]"
     ) -> float | str | bool:
         """Read the current Keithley mode and ask for a parameter"""
         mode = _parse_output_string(self._mode_map[self.mode()])

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 import numpy as np
 from typing_extensions import TypedDict, Unpack
@@ -38,9 +38,9 @@ class ParameterWithSetpointsCustomized(ParameterWithSetpoints):
     This customized class is used for the "sweep" parameter.
     """
 
-    _user_selected_data: Optional[list[Any]] = None
+    _user_selected_data: list[Any] | None = None
 
-    def get_selected(self) -> Optional[list[Any]]:
+    def get_selected(self) -> list[Any] | None:
         return self._user_selected_data
 
 
@@ -74,7 +74,7 @@ class Keithley2450Buffer(InstrumentChannel):
         self,
         parent: "Keithley2450",
         name: str,
-        size: Optional[int] = None,
+        size: int | None = None,
         style: str = "",
     ) -> None:
         super().__init__(parent, name)
@@ -136,8 +136,8 @@ class Keithley2450Buffer(InstrumentChannel):
 
     def __exit__(
         self,
-        exception_type: Optional[type[BaseException]],
-        value: Optional[BaseException],
+        exception_type: type[BaseException] | None,
+        value: BaseException | None,
         traceback: Optional["TracebackType"],
     ) -> None:
         self.delete()
@@ -330,7 +330,7 @@ class Keithley2450Sense(InstrumentChannel):
         )
         """The number of measurements to make when a measurement is requested."""
 
-    def _measure(self) -> Union[float, str]:
+    def _measure(self) -> float | str:
         if not self.parent.output_enabled():
             raise RuntimeError("Output needs to be on for a measurement")
         buffer_name = self.parent.buffer_name()
@@ -404,7 +404,7 @@ class Keithley2450Source(InstrumentChannel):
         unit = self.function_modes[self._proper_function]["unit"]
 
         self.function = self.parent.source_function
-        self._sweep_arguments: Optional[_SweepDict] = None
+        self._sweep_arguments: _SweepDict | None = None
 
         self.range: Parameter = self.add_parameter(
             "range",
@@ -767,7 +767,7 @@ class Keithley2450(VisaInstrument):
         return cast(Keithley2450Sense, submodule)
 
     def buffer(
-        self, name: str, size: Optional[int] = None, style: str = ""
+        self, name: str, size: int | None = None, style: str = ""
     ) -> Keithley2450Buffer:
         self.buffer_name(name)
         if f"_buffer_{name}" in self.submodules:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
@@ -1,7 +1,7 @@
 import itertools
 import textwrap
 import warnings
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import qcodes.validators as vals
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
@@ -269,13 +269,13 @@ class Keithley3706A(VisaInstrument):
     def _get_gpib_status(self) -> str:
         return self.ask("comm.gpib.enable")
 
-    def _set_gpib_status(self, val: Union[str, bool]) -> None:
+    def _set_gpib_status(self, val: str | bool) -> None:
         self.write(f"comm.gpib.enable = {val}")
 
     def _get_lan_status(self) -> str:
         return self.ask("comm.lan.enable")
 
-    def _set_lan_status(self, val: Union[str, bool]) -> None:
+    def _set_lan_status(self, val: str | bool) -> None:
         self.write(f"comm.lan.enable = {val}")
 
     def _get_gpib_address(self) -> int:
@@ -284,7 +284,7 @@ class Keithley3706A(VisaInstrument):
     def _set_gpib_address(self, val: int) -> None:
         self.write(f"gpib.address = {val}")
 
-    def get_closed_channels(self, val: str) -> Optional[list[str]]:
+    def get_closed_channels(self, val: str) -> list[str] | None:
         """
         Queries for the closed channels.
 
@@ -755,7 +755,7 @@ class Keithley3706A(VisaInstrument):
             "disconnect", slot_id, column_id, rows
         )
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """
         Overwrites the generic QCoDeS get IDN method. Returns
         a dictionary including the vendor, model, serial number and
@@ -765,7 +765,7 @@ class Keithley3706A(VisaInstrument):
         vendor, model, serial, firmware = map(str.strip, idnstr.split(","))
         model = model[6:]
 
-        idn: dict[str, Optional[str]] = {
+        idn: dict[str, str | None] = {
             "vendor": vendor,
             "model": model,
             "serial": serial,
@@ -794,7 +794,7 @@ class Keithley3706A(VisaInstrument):
                 switch_cards.append(sdict)
         return tuple(switch_cards)
 
-    def get_available_memory(self) -> dict[str, Optional[str]]:
+    def get_available_memory(self) -> dict[str, str | None]:
         """
         Returns the amount of memory that is currently available for
         storing scripts, configurations and channel patterns.
@@ -804,7 +804,7 @@ class Keithley3706A(VisaInstrument):
             str.strip, memstring.split(",")
         )
 
-        memory_available: dict[str, Optional[str]] = {
+        memory_available: dict[str, str | None] = {
             "System Memory  (%)": system_memory,
             "Script Memory  (%)": script_memory,
             "Pattern Memory (%)": pattern_memory,
@@ -837,7 +837,7 @@ class Keithley3706A(VisaInstrument):
             states.append({"slot_no": i, "state": interlock_status[state]})
         return tuple(states)
 
-    def get_interlock_state_by_slot(self, slot: Union[str, int]) -> Union[int, None]:
+    def get_interlock_state_by_slot(self, slot: str | int) -> int | None:
         state = self.ask(f"slot[{int(slot)}].interlock.state")
         if state == "nil":
             return None
@@ -856,7 +856,7 @@ class Keithley3706A(VisaInstrument):
         """
         self.write("lan.reset()")
 
-    def save_setup(self, val: Optional[str] = None) -> None:
+    def save_setup(self, val: str | None = None) -> None:
         """
         Saves the present setup.
 
@@ -871,7 +871,7 @@ class Keithley3706A(VisaInstrument):
         else:
             self.write("setup.save()")
 
-    def load_setup(self, val: Union[int, str]) -> None:
+    def load_setup(self, val: int | str) -> None:
         """
         Loads the settings from a saved setup.
 
@@ -901,7 +901,7 @@ class Keithley3706A(VisaInstrument):
         return True
 
     def connect_message(
-        self, idn_param: str = "IDN", begin_time: Optional[float] = None
+        self, idn_param: str = "IDN", begin_time: float | None = None
     ) -> None:
         """
         Overwrites the generic QCoDeS instrument connect message.

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, TypeVar
 
@@ -6,6 +5,8 @@ from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Bool, Enum, Ints, MultiType, Numbers
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter
@@ -255,7 +256,7 @@ class Keithley6500(VisaInstrument):
     def _read_next_value(self) -> float:
         return float(self.ask("READ?"))
 
-    def _get_mode_param(self, parameter: str, parser: Callable[[str], T]) -> T:
+    def _get_mode_param(self, parameter: str, parser: "Callable[[str], T]") -> T:
         """Reads the current mode of the multimeter and ask for the given parameter.
 
         Args:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Bool, Enum, Ints, MultiType, Numbers
@@ -33,7 +34,7 @@ def _parse_output_string(string_value: str) -> str:
     return s
 
 
-def _parse_output_bool(numeric_value: Union[float, str]) -> bool:
+def _parse_output_bool(numeric_value: float | str) -> bool:
     """Parses and converts the value to boolean type. True is 1.
 
     Args:
@@ -268,7 +269,7 @@ class Keithley6500(VisaInstrument):
         cmd = f"{mode}:{parameter}?"
         return parser(self.ask(cmd))
 
-    def _set_mode_param(self, parameter: str, value: Union[str, float, bool]) -> None:
+    def _set_mode_param(self, parameter: str, value: str | float | bool) -> None:
         """Gets the current mode of the multimeter and sets the given parameter.
 
         Args:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_7510.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_7510.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, cast
 
 import numpy as np
 
@@ -49,7 +49,7 @@ class DataArray7510(MultiParameter):
         for param_name in self.names:
             self.__dict__.update({param_name: []})
 
-    def get_raw(self) -> Optional[tuple[ParamRawDataType, ...]]:
+    def get_raw(self) -> tuple[ParamRawDataType, ...] | None:
         return self._data
 
 
@@ -109,7 +109,7 @@ class Keithley7510Buffer(InstrumentChannel):
         self,
         parent: "Keithley7510",
         name: str,
-        size: Optional[int] = None,
+        size: int | None = None,
         style: str = "",
     ) -> None:
         super().__init__(parent, name)
@@ -267,7 +267,7 @@ class Keithley7510Buffer(InstrumentChannel):
         return self.data_end() - self.data_start() + 1
 
     def set_setpoints(
-        self, start: Parameter, stop: Parameter, label: Optional[str] = None
+        self, start: Parameter, stop: Parameter, label: str | None = None
     ) -> None:
         self.setpoints_start.source = start
         self.setpoints_stop.source = stop
@@ -280,8 +280,8 @@ class Keithley7510Buffer(InstrumentChannel):
 
     def __exit__(
         self,
-        exception_type: Optional[type[BaseException]],
-        value: Optional[BaseException],
+        exception_type: type[BaseException] | None,
+        value: BaseException | None,
         traceback: Optional["TracebackType"],
     ) -> None:
         self.delete()
@@ -414,7 +414,7 @@ class Keithley7510Buffer(InstrumentChannel):
 class _FunctionMode(TypedDict):
     name: str
     unit: str
-    range_vals: Optional[Numbers]
+    range_vals: Numbers | None
 
 
 class Keithley7510Sense(InstrumentChannel):
@@ -617,7 +617,7 @@ class Keithley7510Sense(InstrumentChannel):
         )
         self.write(set_cmd)
 
-    def _measure(self) -> Union[float, str]:
+    def _measure(self) -> float | str:
         buffer_name = self.parent.buffer_name()
         return float(self.ask(f":MEASure? '{buffer_name}'"))
 
@@ -715,7 +715,7 @@ class Keithley7510DigitizeSense(InstrumentChannel):
         )
         """Set the number of measurements to digitize when a measurement is requested"""
 
-    def _measure(self) -> Union[float, str]:
+    def _measure(self) -> float | str:
         buffer_name = self.parent.buffer_name()
         return float(self.ask(f":MEASure:DIGitize? '{buffer_name}'"))
 
@@ -870,7 +870,7 @@ class Keithley7510(VisaInstrument):
         return cast(Keithley7510DigitizeSense, submodule)
 
     def buffer(
-        self, name: str, size: Optional[int] = None, style: str = ""
+        self, name: str, size: int | None = None, style: str = ""
     ) -> Keithley7510Buffer:
         self.buffer_name(name)
         if f"_buffer_{name}" in self.submodules:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_s46.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_s46.py
@@ -3,7 +3,7 @@ Driver for the Keithley S46 RF switch
 """
 import re
 from itertools import product
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from qcodes.instrument import (
     Instrument,
@@ -33,7 +33,7 @@ class KeithleyS46RelayLock:
 
     def __init__(self, relay_name: str):
         self.relay_name = relay_name
-        self._locked_by: Optional[int] = None
+        self._locked_by: int | None = None
 
     def acquire(self, channel_number: int) -> None:
         """
@@ -71,7 +71,7 @@ class S46Parameter(Parameter):
     def __init__(
         self,
         name: str,
-        instrument: Optional[Instrument],
+        instrument: Instrument | None,
         channel_number: int,
         lock: KeithleyS46RelayLock,
         **kwargs: Any,

--- a/src/qcodes/instrument_drivers/Keithley/__init__.py
+++ b/src/qcodes/instrument_drivers/Keithley/__init__.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ._Keithley_2600 import (
     Keithley2600,
     Keithley2600Channel,
@@ -41,18 +39,19 @@ from .Keithley_s46 import (
     KeithleyS46RelayLock,
 )
 
-Keithley26xx = Union[
-    Keithley2601B,
-    Keithley2602A,
-    Keithley2602B,
-    Keithley2604B,
-    Keithley2611B,
-    Keithley2612B,
-    Keithley2614B,
-    Keithley2634B,
-    Keithley2635B,
-    Keithley2636B,
-]
+Keithley26xx = (
+    Keithley2601B
+    | Keithley2602A
+    | Keithley2602B
+    | Keithley2604B
+    | Keithley2611B
+    | Keithley2612B
+    | Keithley2614B
+    | Keithley2634B
+    | Keithley2635B
+    | Keithley2636B
+)
+
 """
 Type alias for all Keithley 26xx SMUs supported by QCoDeS.
 """

--- a/src/qcodes/instrument_drivers/Keysight/Infiniium.py
+++ b/src/qcodes/instrument_drivers/Keysight/Infiniium.py
@@ -174,7 +174,7 @@ class DSOTraceParam(ParameterWithSetpoints):
         Update waveform parameters. Must be called before data
         acquisition if instr.cache_setpoints is False
         """
-        instrument: Union[KeysightInfiniiumChannel, KeysightInfiniiumFunction]
+        instrument: KeysightInfiniiumChannel | KeysightInfiniiumFunction
         instrument = self.instrument  # type: ignore[assignment]
         if preamble is None:
             instrument.write(f":WAV:SOUR {self._channel}")
@@ -1122,7 +1122,7 @@ class KeysightInfiniium(VisaInstrument):
         # Sample Rate
         try:
             # Set BW to auto in order to query this
-            bw_set: Union[float, Literal["AUTO"]] = float(self.ask(":ACQ:BAND?"))
+            bw_set: float | Literal["AUTO"] = float(self.ask(":ACQ:BAND?"))
             if np.isclose(bw_set, self.max_bw):
                 # Auto returns max bandwidth
                 bw_set = "AUTO"
@@ -1199,7 +1199,7 @@ class KeysightInfiniium(VisaInstrument):
             if channel.display():
                 channel.update_setpoints()
 
-    def digitize(self, timeout: Optional[int] = None) -> None:
+    def digitize(self, timeout: int | None = None) -> None:
         """
         Digitize a full waveform and block until the acquisition is complete.
 

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
 
@@ -51,7 +51,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel):
         """
         super().__init__(parent, name, **kwargs)
 
-        def val_parser(parser: type, inputstring: str) -> Union[float,int]:
+        def val_parser(parser: type, inputstring: str) -> float | int:
             """
             Parses return values from instrument. Meant to be used when a query
             can return a meaningful finite number or a numeric representation

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import (
     Instrument,
@@ -158,10 +158,10 @@ class KeysightB2962A(VisaInstrument):
 
         self.connect_message()
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         IDN_str = self.ask_raw('*IDN?')
         vendor, model, serial, firmware = map(str.strip, IDN_str.split(','))
-        IDN: dict[str, Optional[str]] = {
+        IDN: dict[str, str | None] = {
             'vendor': vendor, 'model': model,
             'serial': serial, 'firmware': firmware}
         return IDN

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import (
     Instrument,
@@ -115,10 +115,10 @@ class KeysightN6705B(VisaInstrument):
 
         self.connect_message()
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         IDNstr = self.ask_raw("*IDN?")
         vendor, model, serial, firmware = map(str.strip, IDNstr.split(","))
-        IDN: dict[str, Optional[str]] = {
+        IDN: dict[str, str | None] = {
             "vendor": vendor,
             "model": model,
             "serial": serial,

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -20,6 +19,8 @@ from qcodes.parameters import (
 from qcodes.validators import Arrays, Bool, Enum, Ints, Numbers
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
 

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 

--- a/src/qcodes/instrument_drivers/Keysight/KtM960x.py
+++ b/src/qcodes/instrument_drivers/Keysight/KtM960x.py
@@ -1,6 +1,6 @@
 import ctypes
 from functools import partial
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import qcodes.validators as vals
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
@@ -150,10 +150,10 @@ class KeysightM960x(Instrument):
         if status:
             raise SystemError(f"connection to device failed! error: {status}")
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """generates the ``*IDN`` dictionary for qcodes"""
 
-        id_dict: dict[str, Optional[str]] = {
+        id_dict: dict[str, str | None] = {
             'firmware': self._get_firmware_revision(),
             'model': self._get_model(),
             'serial': self._get_serial_number(),

--- a/src/qcodes/instrument_drivers/Keysight/KtMAwg.py
+++ b/src/qcodes/instrument_drivers/Keysight/KtMAwg.py
@@ -1,6 +1,6 @@
 import ctypes
 from functools import partial
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs, InstrumentChannel
 from qcodes.parameters import Parameter, create_on_off_val_mapping
@@ -38,7 +38,7 @@ class KeysightM9336AAWGChannel(InstrumentChannel):
         )
 
         # Used to access waveforms loaded into the driver
-        self._awg_handle: Optional[ctypes.c_int32] = None
+        self._awg_handle: ctypes.c_int32 | None = None
 
         self._catch_error = self.root_instrument._catch_error
 
@@ -301,10 +301,10 @@ class KeysightM9336A(Instrument):
         if status:
             raise SystemError(f"connection to device failed! error: {status}")
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """generates the ``*IDN`` dictionary for qcodes"""
 
-        id_dict: dict[str, Optional[str]] = {
+        id_dict: dict[str, str | None] = {
             "firmware": self._get_firmware_revision(),
             "model": self._get_model(),
             "serial": self._get_serial_number(),

--- a/src/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/src/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
 
@@ -117,10 +117,10 @@ class KeysightN51x1(VisaInstrument):
 
         self.connect_message()
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         IDN_str = self.ask_raw('*IDN?')
         vendor, model, serial, firmware = map(str.strip, IDN_str.split(','))
-        IDN: dict[str, Optional[str]] = {
+        IDN: dict[str, str | None] = {
             'vendor': vendor, 'model': model,
             'serial': serial, 'firmware': firmware}
         return IDN

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Union
 
 from qcodes import validators
 
@@ -100,7 +101,7 @@ class Keysight34934A(Keysight34980ASwitchMatrixSubModule):
         self.write(f'SYSTem:MODule:ROW:PROTection {self.slot}, {mode}')
 
     def to_channel_list(
-        self, paths: list[tuple[int, int]], wiring_config: Optional[str] = ""
+        self, paths: list[tuple[int, int]], wiring_config: str | None = ""
     ) -> str:
         """
         convert the (row, column) pair to a 4-digit channel number 'sxxx', where
@@ -131,9 +132,7 @@ class Keysight34934A(Keysight34980ASwitchMatrixSubModule):
 
     @staticmethod
     def get_numbering_function(
-            rows: int,
-            columns: int,
-            wiring_config: Optional[str] = ''
+        rows: int, columns: int, wiring_config: str | None = ""
     ) -> Callable[[int, int], str]:
         """
         to select the correct numbering function based on the matrix layout.

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Union
 
 from qcodes import validators
@@ -8,6 +7,8 @@ from qcodes import validators
 from .keysight_34980a_submodules import Keysight34980ASwitchMatrixSubModule
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
     from qcodes.instrument import (
@@ -133,7 +134,7 @@ class Keysight34934A(Keysight34980ASwitchMatrixSubModule):
     @staticmethod
     def get_numbering_function(
         rows: int, columns: int, wiring_config: str | None = ""
-    ) -> Callable[[int, int], str]:
+    ) -> "Callable[[int, int], str]":
         """
         to select the correct numbering function based on the matrix layout.
         On P168 of the user's guide for Agilent 34934A High Density Matrix

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import warnings
-from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 
@@ -14,6 +13,7 @@ from .keysight_34934a import Keysight34934A
 from .keysight_34980a_submodules import Keysight34980ASwitchMatrixSubModule
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Concatenate
 
     from typing_extensions import Unpack
@@ -26,8 +26,8 @@ T = TypeVar('T')
 
 
 def post_execution_status_poll(
-    func: Callable["Concatenate[S, P]", T],
-) -> Callable["Concatenate[S, P]", T]:
+    func: "Callable[Concatenate[S, P], T]",
+) -> "Callable[Concatenate[S, P], T]":
     """
     Generates a decorator that clears the instrument's status registers
     before executing the actual call and reads the status register after the

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
@@ -1,8 +1,9 @@
 import logging
 import re
 import warnings
+from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -13,7 +14,9 @@ from .keysight_34934a import Keysight34934A
 from .keysight_34980a_submodules import Keysight34980ASwitchMatrixSubModule
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, Unpack
+    from typing import Concatenate
+
+    from typing_extensions import Unpack
 
 KEYSIGHT_MODELS = {'34934A': Keysight34934A}
 
@@ -70,7 +73,7 @@ class Keysight34980A(VisaInstrument):
         super().__init__(name, address, **kwargs)
 
         self._total_slot = 8
-        self._system_slots_info_dict: Optional[dict[int, dict[str, str]]] = None
+        self._system_slots_info_dict: dict[int, dict[str, str]] | None = None
         self.module = dict.fromkeys(self.system_slots_info.keys())
         self.scan_slots()
         self.connect_message()
@@ -168,7 +171,7 @@ class Keysight34980A(VisaInstrument):
                 slots_dict[i] = dict(zip(keys, identity))
         return slots_dict
 
-    def disconnect_all(self, slot: Optional[int] = None) -> None:
+    def disconnect_all(self, slot: int | None = None) -> None:
         """
         to open/disconnect all connections on select module
 

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34980a_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34980a_submodules.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
 
@@ -21,7 +21,7 @@ class KeysightSubModule(InstrumentChannel):
     """
     def __init__(
         self,
-        parent: Union[VisaInstrument, InstrumentChannel],
+        parent: VisaInstrument | InstrumentChannel,
         name: str,
         slot: int,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
@@ -34,7 +34,7 @@ class KeysightSubModule(InstrumentChannel):
 class Keysight34980ASwitchMatrixSubModule(InstrumentChannel):
     def __init__(
         self,
-        parent: Union[VisaInstrument, InstrumentChannel],
+        parent: VisaInstrument | InstrumentChannel,
         name: str,
         slot: int,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
@@ -64,7 +64,7 @@ class Keysight34980ASwitchMatrixSubModule(InstrumentChannel):
         raise NotImplementedError("Please subclass this")
 
     def to_channel_list(
-        self, paths: list[tuple[int, int]], wiring_config: Optional[str] = None
+        self, paths: list[tuple[int, int]], wiring_config: str | None = None
     ) -> str:
         """
         convert the (row, column) pair to a 4-digit channel number 'sxxx', where

--- a/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
@@ -1,6 +1,5 @@
 import re
 import warnings
-from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 
@@ -10,7 +9,7 @@ from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Enum, Ints, Lists, MultiType
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from typing import Concatenate
 
     from typing_extensions import Unpack
@@ -23,8 +22,8 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 def post_execution_status_poll(
-    func: Callable["Concatenate[S, P]", T],
-) -> Callable["Concatenate[S, P]", T]:
+    func: "Callable[Concatenate[S, P], T]",
+) -> "Callable[Concatenate[S, P], T]":
     """
     Generates a decorator that clears the instrument's status registers
     before executing the actual call and reads the status register after the

--- a/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
@@ -1,7 +1,8 @@
 import re
 import warnings
+from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -10,8 +11,9 @@ from qcodes.validators import Enum, Ints, Lists, MultiType
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Concatenate
 
-    from typing_extensions import Concatenate, Unpack
+    from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter
 

--- a/src/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from packaging import version
 from pyvisa.errors import VisaIOError
@@ -226,7 +226,7 @@ class KeysightE4980A(VisaInstrument):
         ) >= version.parse(convert_legacy_version_to_supported_version("A.02.10"))
 
         self.has_option_001 = '001' in self._options()
-        self._dc_bias_v_level_range: Union[Numbers, Enum]
+        self._dc_bias_v_level_range: Numbers | Enum
         if self.has_option_001:
             self._v_level_range = Numbers(0, 20)
             self._i_level_range = Numbers(0, 0.1)

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -1,7 +1,7 @@
 import re
 import textwrap
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.parameters import MultiParameter, Parameter, create_on_off_val_mapping
@@ -160,7 +160,7 @@ class KeysightB1500(VisaInstrument):
 
     @staticmethod
     def from_model_name(
-        model: str, slot_nr: int, parent: "KeysightB1500", name: Optional[str] = None
+        model: str, slot_nr: int, parent: "KeysightB1500", name: str | None = None
     ) -> "KeysightB1500Module":
         """Creates the correct instance of instrument module by model name.
 
@@ -187,8 +187,7 @@ class KeysightB1500(VisaInstrument):
             raise NotImplementedError(f"Module type {model} in slot"
                                       f" {slot_nr} not yet supported.")
 
-    def enable_channels(self, channels: Optional[constants.ChannelList] = None
-                        ) -> None:
+    def enable_channels(self, channels: constants.ChannelList | None = None) -> None:
         """Enable specified channels.
 
         If channels is omitted or `None`, then all channels are enabled.
@@ -197,10 +196,7 @@ class KeysightB1500(VisaInstrument):
 
         self.write(msg.message)
 
-    def disable_channels(
-            self,
-            channels: Optional[constants.ChannelList] = None
-    ) -> None:
+    def disable_channels(self, channels: constants.ChannelList | None = None) -> None:
         """Disable specified channels.
 
         If channels is omitted or `None`, then all channels are disabled.
@@ -213,11 +209,12 @@ class KeysightB1500(VisaInstrument):
     parse_spot_measurement_response = parse_spot_measurement_response
     parse_module_query_response = parse_module_query_response
 
-    def _setup_integration_time(self,
-                                adc_type: constants.AIT.Type,
-                                mode: Union[constants.AIT.Mode, int],
-                                coeff: Optional[int] = None
-                                ) -> None:
+    def _setup_integration_time(
+        self,
+        adc_type: constants.AIT.Type,
+        mode: constants.AIT.Mode | int,
+        coeff: int | None = None,
+    ) -> None:
         """See :meth:`MessageBuilder.ait` for information"""
         if coeff is not None:
             coeff = int(coeff)
@@ -236,8 +233,7 @@ class KeysightB1500(VisaInstrument):
             assert isinstance(param, _ParameterWithStatus)
             param._measurement_status = None
 
-    def use_nplc_for_high_speed_adc(
-            self, n: Optional[int] = None) -> None:
+    def use_nplc_for_high_speed_adc(self, n: int | None = None) -> None:
         """
         Set the high-speed ADC to NPLC mode, with optionally defining number
         of averaging samples via argument `n`.
@@ -262,8 +258,7 @@ class KeysightB1500(VisaInstrument):
             coeff=n
         )
 
-    def use_nplc_for_high_resolution_adc(
-            self, n: Optional[int] = None) -> None:
+    def use_nplc_for_high_resolution_adc(self, n: int | None = None) -> None:
         """
         Set the high-resolution ADC to NPLC mode, with optionally defining
         the number of PLCs per sample via argument `n`.
@@ -285,8 +280,7 @@ class KeysightB1500(VisaInstrument):
             coeff=n
         )
 
-    def use_manual_mode_for_high_speed_adc(
-            self, n: Optional[int] = None) -> None:
+    def use_manual_mode_for_high_speed_adc(self, n: int | None = None) -> None:
         """
         Set the high-speed ADC to manual mode, with optionally defining number
         of averaging samples via argument `n`.
@@ -309,9 +303,9 @@ class KeysightB1500(VisaInstrument):
     def _set_autozero(self, do_autozero: bool) -> None:
         self.write(MessageBuilder().az(do_autozero=do_autozero).message)
 
-    def self_calibration(self,
-                         slot: Optional[Union[constants.SlotNr, int]] = None
-                         ) -> constants.CALResponse:
+    def self_calibration(
+        self, slot: constants.SlotNr | int | None = None
+    ) -> constants.CALResponse:
         """
         Performs the self calibration of the specified module (SMU) and
         returns the result. Failed modules are disabled, and can only be
@@ -337,8 +331,7 @@ class KeysightB1500(VisaInstrument):
             response = self.ask(msg.message)
         return constants.CALResponse(int(response))
 
-    def error_message(self, mode: Optional[Union[constants.ERRX.Mode,
-                                                 int]] = None) -> str:
+    def error_message(self, mode: constants.ERRX.Mode | int | None = None) -> str:
         """
         This method reads one error code from the head of the error
         queue and removes that code from the queue. The read error is
@@ -370,7 +363,7 @@ class KeysightB1500(VisaInstrument):
         msg = MessageBuilder().err_query()
         self.write(msg.message)
 
-    def clear_timer_count(self, chnum: Optional[int] = None) -> None:
+    def clear_timer_count(self, chnum: int | None = None) -> None:
         """
         This command clears the timer count. This command is effective for
         all measurement modes, regardless of the TSC setting. This command
@@ -392,10 +385,11 @@ class KeysightB1500(VisaInstrument):
         msg = MessageBuilder().tsr(chnum=chnum)
         self.write(msg.message)
 
-    def set_measurement_mode(self,
-                             mode: Union[constants.MM.Mode, int],
-                             channels: Optional[constants.ChannelList] = None
-                             ) -> None:
+    def set_measurement_mode(
+        self,
+        mode: constants.MM.Mode | int,
+        channels: constants.ChannelList | None = None,
+    ) -> None:
         """
         This method specifies the measurement mode and the channels used
         for measurements. This method must be entered to specify the
@@ -413,7 +407,7 @@ class KeysightB1500(VisaInstrument):
         msg = MessageBuilder().mm(mode=mode, channels=channels).message
         self.write(msg)
 
-    def get_measurement_mode(self) -> dict[str, Union[constants.MM.Mode, list[int]]]:
+    def get_measurement_mode(self) -> dict[str, constants.MM.Mode | list[int]]:
         """
         This method gets the measurement mode(MM) and the channels used
         for measurements. It outputs a dictionary with 'mode' and
@@ -427,7 +421,7 @@ class KeysightB1500(VisaInstrument):
         if not match:
             raise ValueError('Measurement Mode (MM) not found.')
 
-        out_dict: dict[str, Union[constants.MM.Mode, list[int]]] = {}
+        out_dict: dict[str, constants.MM.Mode | list[int]] = {}
         resp_dict = match.groupdict()
         out_dict['mode'] = constants.MM.Mode(int(resp_dict['mode']))
         out_dict['channels'] = list(map(int, resp_dict['channels'].split(',')))
@@ -435,7 +429,7 @@ class KeysightB1500(VisaInstrument):
 
     def get_response_format_and_mode(
         self,
-    ) -> dict[str, Union[constants.FMT.Format, constants.FMT.Mode]]:
+    ) -> dict[str, constants.FMT.Format | constants.FMT.Mode]:
         """
         This method queries the the data output format and mode.
         """
@@ -448,7 +442,7 @@ class KeysightB1500(VisaInstrument):
         if not match:
             raise ValueError('Measurement Mode (FMT) not found.')
 
-        out_dict: dict[str, Union[constants.FMT.Format, constants.FMT.Mode]] = {}
+        out_dict: dict[str, constants.FMT.Format | constants.FMT.Mode] = {}
         resp_dict = match.groupdict()
         out_dict['format'] = constants.FMT.Format(int(resp_dict[
                                                           'format']))
@@ -456,9 +450,7 @@ class KeysightB1500(VisaInstrument):
         return out_dict
 
     def enable_smu_filters(
-            self,
-            enable_filter: bool,
-            channels: Optional[constants.ChannelList] = None
+        self, enable_filter: bool, channels: constants.ChannelList | None = None
     ) -> None:
         """
         This methods sets the connection mode of a SMU filter for each channel.
@@ -583,10 +575,7 @@ class IVSweepMeasurement(MultiParameter, StatusMixin):
         self.set_setpoint_name_label_and_unit()
 
     def set_setpoint_name_label_and_unit(
-            self,
-            name: Optional[str] = None,
-            label: Optional[str] = None,
-            unit: Optional[str] = None
+        self, name: str | None = None, label: str | None = None, unit: str | None = None
     ) -> None:
         """
         Set name, label, and unit of the setpoint of the MultiParameter.

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -1,6 +1,6 @@
 import re
 from collections import namedtuple
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from typing_extensions import TypedDict, Unpack, deprecated
@@ -87,7 +87,7 @@ _pattern_lrn = re.compile(
 )
 
 
-def parse_dcv_measurement_response(response: str) -> dict[str, Union[str, float]]:
+def parse_dcv_measurement_response(response: str) -> dict[str, str | float]:
     """
     Extract status, channel number, value  and accompanying metadata from
     the string and return them as a dictionary.
@@ -101,7 +101,7 @@ def parse_dcv_measurement_response(response: str) -> dict[str, Union[str, float]
         raise ValueError(f"{response!r} didn't match {_pattern_lrn!r} pattern")
 
     dd = match.groupdict()
-    d = cast(dict[str, Union[str, float]], dd)
+    d = cast(dict[str, str | float], dd)
     return d
 
 
@@ -288,7 +288,7 @@ class KeysightB1500Module(InstrumentChannel):
     def __init__(
         self,
         parent: "qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500",
-        name: Optional[str],
+        name: str | None,
         slot_nr: int,
         **kwargs: Unpack[InstrumentBaseKWArgs],
     ):

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1511B.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1511B.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from .constants import IMeasRange, IOutputRange
 from .KeysightB1517A import KeysightB1517A
@@ -24,7 +24,7 @@ class KeysightB1511B(KeysightB1517A):
     def __init__(
         self,
         parent: "qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500",
-        name: Optional[str],
+        name: str | None,
         slot_nr: int,
         **kwargs: Any
     ):

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -1,6 +1,6 @@
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 
 import numpy as np
 from typing_extensions import NotRequired, TypedDict, Unpack
@@ -39,14 +39,14 @@ class SweepSteps(TypedDict):
     sweep (WV).
     """
 
-    chan: NotRequired[Union[int, constants.ChNr]]
-    sweep_mode: Union[constants.SweepMode, int]
-    sweep_range: Union[constants.VOutputRange, int]
+    chan: NotRequired[int | constants.ChNr]
+    sweep_mode: constants.SweepMode | int
+    sweep_range: constants.VOutputRange | int
     sweep_start: float
     sweep_end: float
     sweep_steps: int
-    current_compliance: Optional[float]
-    power_compliance: Optional[float]
+    current_compliance: float | None
+    power_compliance: float | None
 
 
 class KeysightB1500IVSweeper(InstrumentChannel):
@@ -497,23 +497,23 @@ class KeysightB1500IVSweeper(InstrumentChannel):
         sweep_steps = self._get_sweep_steps_parameters('sweep_steps')
         return sweep_steps
 
-    def _set_current_compliance(self, value: Optional[float]) -> None:
+    def _set_current_compliance(self, value: float | None) -> None:
         self._sweep_step_parameters["current_compliance"] = value
         self._set_from_sweep_step_parameters()
 
-    def _get_current_compliance(self) -> Optional[float]:
+    def _get_current_compliance(self) -> float | None:
         current_compliance = self._get_sweep_steps_parameters(
             'current_compliance')
         return current_compliance
 
-    def _set_power_compliance(self, value: Optional[float]) -> None:
+    def _set_power_compliance(self, value: float | None) -> None:
         if self._sweep_step_parameters['current_compliance'] is None:
             raise ValueError('Current compliance must be set before setting '
                              'power compliance')
         self._sweep_step_parameters["power_compliance"] = value
         self._set_from_sweep_step_parameters()
 
-    def _get_power_compliance(self) -> Optional[float]:
+    def _get_power_compliance(self) -> float | None:
         power_compliance = self._get_sweep_steps_parameters('power_compliance')
         return power_compliance
 
@@ -551,12 +551,11 @@ class KeysightB1500IVSweeper(InstrumentChannel):
         out_dict = {key: float(value) for key, value in resp_dict.items()}
         return out_dict
 
-    def _set_sweep_auto_abort(self, val: Union[bool, constants.Abort]) -> None:
+    def _set_sweep_auto_abort(self, val: bool | constants.Abort) -> None:
         msg = MessageBuilder().wm(abort=val)
         self.write(msg.message)
 
-    def _set_post_sweep_voltage_condition(
-            self, val: Union[constants.WM.Post, int]) -> None:
+    def _set_post_sweep_voltage_condition(self, val: constants.WM.Post | int) -> None:
         msg = MessageBuilder().wm(abort=self.sweep_auto_abort(), post=val)
         self.write(msg.message)
 
@@ -587,19 +586,19 @@ class KeysightB1500IVSweeper(InstrumentChannel):
     def _get_sweep_steps_parameters(
             self,
             name: Literal['chan']
-    ) -> Union[int, constants.ChNr]: ...
+    ) -> int | constants.ChNr: ...
 
     @overload
     def _get_sweep_steps_parameters(
             self,
             name: Literal['sweep_mode']
-    ) -> Union[constants.SweepMode, int]: ...
+    ) -> constants.SweepMode | int: ...
 
     @overload
     def _get_sweep_steps_parameters(
             self,
             name: Literal['sweep_range']
-    ) -> Union[constants.VOutputRange, int]: ...
+    ) -> constants.VOutputRange | int: ...
 
     @overload
     def _get_sweep_steps_parameters(
@@ -619,20 +618,28 @@ class KeysightB1500IVSweeper(InstrumentChannel):
             self,
             name: Literal['current_compliance',
                           'power_compliance']
-    ) -> Optional[float]: ...
+    ) -> float | None: ...
 
     def _get_sweep_steps_parameters(
-            self,
-            name: Literal['chan',
-                          'sweep_mode',
-                          'sweep_range',
-                          'sweep_start',
-                          'sweep_end',
-                          'sweep_steps',
-                          'current_compliance',
-                          'power_compliance']
-    ) -> Union[constants.ChNr, constants.SweepMode,
-               constants.VOutputRange, int, float, None]:
+        self,
+        name: Literal[
+            "chan",
+            "sweep_mode",
+            "sweep_range",
+            "sweep_start",
+            "sweep_end",
+            "sweep_steps",
+            "current_compliance",
+            "power_compliance",
+        ],
+    ) -> (
+        constants.ChNr
+        | constants.SweepMode
+        | constants.VOutputRange
+        | int
+        | float
+        | None
+    ):
         msg = MessageBuilder().lrn_query(
             type_id=constants.LRN.Type.STAIRCASE_SWEEP_MEASUREMENT_SETTINGS
         )
@@ -698,15 +705,15 @@ class _ParameterWithStatus(Parameter):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-        self._measurement_status: Optional[MeasurementStatus] = None
+        self._measurement_status: MeasurementStatus | None = None
 
     @property
-    def measurement_status(self) -> Optional[MeasurementStatus]:
+    def measurement_status(self) -> MeasurementStatus | None:
         return self._measurement_status
 
     def snapshot_base(
         self,
-        update: Optional[bool] = True,
+        update: bool | None = True,
         params_to_skip_update: Optional["Sequence[str]"] = None,
     ) -> dict[Any, Any]:
         snapshot = super().snapshot_base(
@@ -823,18 +830,18 @@ class KeysightB1517A(KeysightB1500Module):
     def __init__(
         self,
         parent: "KeysightB1500",
-        name: Optional[str],
+        name: str | None,
         slot_nr: int,
         **kwargs: Unpack[InstrumentBaseKWArgs],
     ):
         super().__init__(parent, name, slot_nr, **kwargs)
         self.channels = (ChNr(slot_nr),)
-        self._measure_config: dict[str, Optional[Any]] = {
+        self._measure_config: dict[str, Any | None] = {
             k: None for k in ("v_measure_range", "i_measure_range",)}
-        self._source_config: dict[str, Optional[Any]] = {
+        self._source_config: dict[str, Any | None] = {
             k: None for k in ("output_range", "compliance",
                               "compl_polarity", "min_compliance_range")}
-        self._timing_parameters: dict[str, Optional[Any]] = {
+        self._timing_parameters: dict[str, Any | None] = {
             k: None for k in ("h_bias", "interval", "number", "h_base")}
 
         # We want to snapshot these configuration dictionaries
@@ -1058,11 +1065,9 @@ class KeysightB1517A(KeysightB1500Module):
         return total_time
 
     def _set_current_measurement_range(
-            self,
-            i_range: Union[constants.IMeasRange, int]
-        ) -> None:
-        msg = MessageBuilder().ri(chnum=self.channels[0],
-                                  i_range=i_range)
+        self, i_range: constants.IMeasRange | int
+    ) -> None:
+        msg = MessageBuilder().ri(chnum=self.channels[0], i_range=i_range)
         self.write(msg.message)
 
     def _get_current_measurement_range(
@@ -1079,19 +1084,14 @@ class KeysightB1517A(KeysightB1500Module):
         ]
         return response_list
 
-    def _set_measurement_mode(self, mode: Union[MM.Mode, int]) -> None:
+    def _set_measurement_mode(self, mode: MM.Mode | int) -> None:
         self.write(MessageBuilder()
                    .mm(mode=mode,
                        channels=[self.channels[0]])
                    .message)
 
-    def _set_measurement_operation_mode(self,
-                                        mode: Union[constants.CMM.Mode, int]
-                                        ) -> None:
-        self.write(MessageBuilder()
-                   .cmm(mode=mode,
-                        chnum=self.channels[0])
-                   .message)
+    def _set_measurement_operation_mode(self, mode: constants.CMM.Mode | int) -> None:
+        self.write(MessageBuilder().cmm(mode=mode, chnum=self.channels[0]).message)
 
     def _get_measurement_operation_mode(
         self,
@@ -1127,11 +1127,11 @@ class KeysightB1517A(KeysightB1500Module):
         )
 
     def source_config(
-            self,
-            output_range: constants.OutputRange,
-            compliance: Optional[Union[float, int]] = None,
-            compl_polarity: Optional[constants.CompliancePolarityMode] = None,
-            min_compliance_range: Optional[constants.MeasureRange] = None,
+        self,
+        output_range: constants.OutputRange,
+        compliance: float | int | None = None,
+        compl_polarity: constants.CompliancePolarityMode | None = None,
+        min_compliance_range: constants.MeasureRange | None = None,
     ) -> None:
         """Configure sourcing voltage/current
 
@@ -1204,12 +1204,9 @@ class KeysightB1517A(KeysightB1500Module):
 
         self._measure_config["i_measure_range"] = i_measure_range
 
-    def timing_parameters(self,
-                          h_bias: float,
-                          interval: float,
-                          number: int,
-                          h_base: Optional[float] = None
-                          ) -> None:
+    def timing_parameters(
+        self, h_bias: float, interval: float, number: int, h_base: float | None = None
+    ) -> None:
         """
         This command sets the timing parameters of the sampling measurement
         mode (:attr:`.MM.Mode.SAMPLING`, ``10``).
@@ -1300,26 +1297,22 @@ class KeysightB1517A(KeysightB1500Module):
         self._average_coefficient = number
 
     def setup_staircase_sweep(
-            self,
-            v_start: float,
-            v_end: float,
-            n_steps: int,
-            post_sweep_voltage_val: Union[constants.WMDCV.Post,
-                                          int] = constants.WMDCV.Post.STOP,
-            av_coef: int = -1,
-            enable_filter: bool = True,
-            v_src_range: constants.OutputRange = constants.VOutputRange.AUTO,
-            i_comp: float = 10e-6,
-            i_meas_range: Optional[
-                constants.MeasureRange] = constants.IMeasRange.FIX_10uA,
-            hold_time: float = 0,
-            delay: float = 0,
-            step_delay: float = 0,
-            measure_delay: float = 0,
-            abort_enabled: Union[constants.Abort,
-                                 int] = constants.Abort.ENABLED,
-            sweep_mode: Union[constants.SweepMode,
-                              int] = constants.SweepMode.LINEAR
+        self,
+        v_start: float,
+        v_end: float,
+        n_steps: int,
+        post_sweep_voltage_val: constants.WMDCV.Post | int = constants.WMDCV.Post.STOP,
+        av_coef: int = -1,
+        enable_filter: bool = True,
+        v_src_range: constants.OutputRange = constants.VOutputRange.AUTO,
+        i_comp: float = 10e-6,
+        i_meas_range: constants.MeasureRange | None = constants.IMeasRange.FIX_10uA,
+        hold_time: float = 0,
+        delay: float = 0,
+        step_delay: float = 0,
+        measure_delay: float = 0,
+        abort_enabled: constants.Abort | int = constants.Abort.ENABLED,
+        sweep_mode: constants.SweepMode | int = constants.SweepMode.LINEAR,
     ) -> None:
         """
         Setup the staircase sweep measurement using the same set of commands

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1530A.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1530A.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from .constants import ChNr, ModuleKind
 from .KeysightB1500_module import KeysightB1500Module
@@ -32,7 +32,7 @@ class KeysightB1530A(KeysightB1500Module):
     def __init__(
         self,
         parent: "KeysightB1500",
-        name: Optional[str],
+        name: str | None,
         slot_nr: int,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
@@ -135,7 +135,7 @@ class ChNr(IntEnum):
     SLOT_10_CH2 = 1002
 
 
-ChannelList = Sequence[Union[ChNr, int]]
+ChannelList = Sequence[ChNr | int]
 
 
 class Abort(IntEnum):

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
@@ -1,7 +1,6 @@
 import sys
 from collections.abc import Sequence
 from enum import Enum, IntEnum, IntFlag
-from typing import Union
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -296,9 +295,9 @@ class IMeasRange(IntEnum):
     FIX_2000A = -28
 
 
-OutputRange = Union[VOutputRange, IOutputRange]
+OutputRange = VOutputRange | IOutputRange
 
-MeasureRange = Union[VMeasRange, IMeasRange]
+MeasureRange = VMeasRange | IMeasRange
 
 
 class RangingMode(IntEnum):

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
 from functools import wraps
 from operator import xor
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from . import constants
 
@@ -79,10 +80,9 @@ class MessageBuilder:
     def clear_message_queue(self) -> None:
         self._msg.clear()
 
-    def aad(self,
-            chnum: Union[constants.ChNr, int],
-            adc_type: Union[constants.AAD.Type, int]
-            ) -> 'MessageBuilder':
+    def aad(
+        self, chnum: constants.ChNr | int, adc_type: constants.AAD.Type | int
+    ) -> "MessageBuilder":
         """
         This command is used to specify the type of the A/D converter (ADC) for
         each measurement channel.
@@ -153,10 +153,11 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ach(self,
-            actual: Optional[Union[constants.ChNr, int]] = None,
-            program: Optional[Union[constants.ChNr, int]] = None
-            ) -> 'MessageBuilder':
+    def ach(
+        self,
+        actual: constants.ChNr | int | None = None,
+        program: constants.ChNr | int | None = None,
+    ) -> "MessageBuilder":
         """
         The ACH command translates the specified program channel number to
         the specified actual channel number at the program execution. This
@@ -195,10 +196,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def act(self,
-            mode: Union[constants.ACT.Mode, int],
-            coeff: Optional[int] = None
-            ) -> 'MessageBuilder':
+    def act(
+        self, mode: constants.ACT.Mode | int, coeff: int | None = None
+    ) -> "MessageBuilder":
         """
         This command sets the number of averaging samples or the averaging
         time set to the A/D converter of the MFCMU.
@@ -232,10 +232,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def acv(self,
-            chnum: Union[constants.ChNr, int],
-            voltage: float
-            ) -> 'MessageBuilder':
+    def acv(self, chnum: constants.ChNr | int, voltage: float) -> "MessageBuilder":
         """
         This command sets the output signal level of the MFCMU, and starts
         the AC voltage output. Output signal frequency is set by the FC
@@ -255,10 +252,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def adj(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.ADJ.Mode, int]
-            ) -> 'MessageBuilder':
+    def adj(
+        self, chnum: constants.ChNr | int, mode: constants.ADJ.Mode | int
+    ) -> "MessageBuilder":
         """
         This command selects the MFCMU phase compensation mode. This command
         initializes the MFCMU.
@@ -287,10 +283,11 @@ class MessageBuilder:
         return self
 
     @final_command
-    def adj_query(self,
-                  chnum: Union[constants.ChNr, int],
-                  mode: Optional[Union[constants.ADJQuery.Mode, int]] = None
-                  ) -> 'MessageBuilder':
+    def adj_query(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.ADJQuery.Mode | int | None = None,
+    ) -> "MessageBuilder":
         """
         This command performs the MFCMU phase compensation, and sets the
         compensation data to the KeysightB1500. This command also returns the
@@ -325,11 +322,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ait(self,
-            adc_type: Union[constants.AIT.Type, int],
-            mode: Union[constants.AIT.Mode, int],
-            coeff: Optional[Union[int, float]] = None
-            ) -> 'MessageBuilder':
+    def ait(
+        self,
+        adc_type: constants.AIT.Type | int,
+        mode: constants.AIT.Mode | int,
+        coeff: int | float | None = None,
+    ) -> "MessageBuilder":
         """
         This command is used to set the operation mode and the setup
         parameter of the A/D converter (ADC) for each ADC type.
@@ -364,8 +362,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def aitm(self, operation_type: Union[constants.APIVersion, int]
-             ) -> 'MessageBuilder':
+    def aitm(self, operation_type: constants.APIVersion | int) -> "MessageBuilder":
         """
         Only for the current measurement by using HRSMU. This command sets
         the operation type of the high-resolution ADC that is set to the
@@ -398,10 +395,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def als(self,
-            chnum: Union[constants.ChNr, int],
-            n_bytes: int,
-            block: bytes) -> None:
+    def als(self, chnum: constants.ChNr | int, n_bytes: int, block: bytes) -> None:
         # The format specification in the manual is a bit unclear, and I do
         # not have the module installed to test this command, hence:
         raise NotImplementedError
@@ -414,7 +408,7 @@ class MessageBuilder:
         # return self
 
     @final_command
-    def als_query(self, chnum: Union[constants.ChNr, int]) -> 'MessageBuilder':
+    def als_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
         """
         This query command returns the ALWG sequence data of the specified
         SPGU channel.
@@ -431,10 +425,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def alw(self,
-            chnum: Union[constants.ChNr, int],
-            n_bytes: int,
-            block: bytes) -> None:
+    def alw(self, chnum: constants.ChNr | int, n_bytes: int, block: bytes) -> None:
         # The format specification in the manual is a bit unclear, and I do
         # not have the module installed to test this command, hence:
         raise NotImplementedError
@@ -446,7 +437,7 @@ class MessageBuilder:
         # return self
 
     @final_command
-    def alw_query(self, chnum: Union[constants.ChNr, int]) -> 'MessageBuilder':
+    def alw_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
         """
         This query command returns the ALWG pattern data of the specified
         SPGU channel.
@@ -463,10 +454,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def av(self,
-           number: int,
-           mode: Optional[Union[constants.AV.Mode, int]] = None
-           ) -> 'MessageBuilder':
+    def av(
+        self, number: int, mode: constants.AV.Mode | int | None = None
+    ) -> "MessageBuilder":
         """
         This command sets the number of averaging samples of the high-speed
         ADC (A/D converter). This command is not effective for the
@@ -545,10 +535,11 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bdm(self,
-            interval: Union[constants.BDM.Interval, int],
-            mode: Optional[Union[constants.BDM.Mode, int]] = None
-            ) -> 'MessageBuilder':
+    def bdm(
+        self,
+        interval: constants.BDM.Interval | int,
+        mode: constants.BDM.Mode | int | None = None,
+    ) -> "MessageBuilder":
         """
         The BDM command specifies the settling detection interval and the
         measurement mode; voltage or current, for the quasi-pulsed
@@ -602,13 +593,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bdv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Union[constants.VOutputRange, int],
-            start: float,
-            stop: float,
-            i_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
+    def bdv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         The BDV command specifies the quasi-pulsed voltage source and its
         parameters.
@@ -647,13 +639,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bgi(self,
-            chnum: Union[constants.ChNr, int],
-            searchmode: Union[constants.BinarySearchMode, int],
-            stop_condition: Union[float, int],
-            i_range: Union[constants.IMeasRange, int],
-            target: float
-            ) -> 'MessageBuilder':
+    def bgi(
+        self,
+        chnum: constants.ChNr | int,
+        searchmode: constants.BinarySearchMode | int,
+        stop_condition: float | int,
+        i_range: constants.IMeasRange | int,
+        target: float,
+    ) -> "MessageBuilder":
         """
         The BGI command sets the current monitor channel for the binary
         search measurement (MM15). This command setting clears, and is
@@ -718,13 +711,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bgv(self,
-            chnum: Union[constants.ChNr, int],
-            searchmode: Union[constants.BinarySearchMode, int],
-            stop_condition: Union[float, int],
-            v_range: Union[constants.VMeasRange, int],
-            target: float
-            ) -> 'MessageBuilder':
+    def bgv(
+        self,
+        chnum: constants.ChNr | int,
+        searchmode: constants.BinarySearchMode | int,
+        stop_condition: float | int,
+        v_range: constants.VMeasRange | int,
+        target: float,
+    ) -> "MessageBuilder":
         """
         The BGV command specifies the voltage monitor channel and its search
         parameters for the binary search measurement (MM15). This command
@@ -788,13 +782,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bsi(self,
-            chnum: Union[constants.ChNr, int],
-            i_range: Union[constants.IOutputRange, int],
-            start: float,
-            stop: float,
-            v_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
+    def bsi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        start: float,
+        stop: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         The BSI command sets the current search source for the binary search
         measurement (MM15). After search stops, the search channel forces the
@@ -837,11 +832,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bsm(self,
-            mode: Union[constants.BSM.Mode, int],
-            abort: Union[constants.Abort, int],
-            post: Optional[Union[constants.BSM.Post, int]] = None
-            ) -> 'MessageBuilder':
+    def bsm(
+        self,
+        mode: constants.BSM.Mode | int,
+        abort: constants.Abort | int,
+        post: constants.BSM.Post | int | None = None,
+    ) -> "MessageBuilder":
         """
         The BSM command specifies the search source control mode in the
         binary search measurement (MM15), and enables or disables the
@@ -924,12 +920,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bssi(self,
-             chnum: Union[constants.ChNr, int],
-             polarity: Union[constants.Polarity, int],
-             offset: float,
-             v_comp: Optional[float] = None
-             ) -> 'MessageBuilder':
+    def bssi(
+        self,
+        chnum: constants.ChNr | int,
+        polarity: constants.Polarity | int,
+        offset: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         The BSSI command sets the synchronous current source for the binary
         search measurement (MM15). The synchronous source output will be:
@@ -970,12 +967,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bssv(self,
-             chnum: Union[constants.ChNr, int],
-             polarity: Union[constants.Polarity, int],
-             offset: float,
-             i_comp: Optional[float] = None
-             ) -> 'MessageBuilder':
+    def bssv(
+        self,
+        chnum: constants.ChNr | int,
+        polarity: constants.Polarity | int,
+        offset: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         The BSSV command sets the synchronous voltage source for the binary
         search measurement (MM15). The synchronous source output will be:
@@ -1041,13 +1039,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bsv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Union[constants.VOutputRange, int],
-            start: float,
-            stop: float,
-            i_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
+    def bsv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         The BSV command sets the voltage search source for the binary search
         measurement (MM15). After search stops, the search channel forces the
@@ -1091,8 +1090,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def bsvm(self, mode: Union[constants.BSVM.DataOutputMode, int]
-             ) -> 'MessageBuilder':
+    def bsvm(self, mode: constants.BSVM.DataOutputMode | int) -> "MessageBuilder":
         """
         The BSVM command selects the data output mode for the binary search
         measurement (MM15).
@@ -1110,8 +1108,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ca(self, slot: Optional[Union[constants.SlotNr, int]] = None
-           ) -> 'MessageBuilder':
+    def ca(self, slot: constants.SlotNr | int | None = None) -> "MessageBuilder":
         """
         This command performs the self-calibration.
 
@@ -1159,8 +1156,7 @@ class MessageBuilder:
         return self
 
     @final_command
-    def cal_query(self, slot: Optional[Union[constants.SlotNr, int]] = None
-                  ) -> 'MessageBuilder':
+    def cal_query(self, slot: constants.SlotNr | int | None = None) -> "MessageBuilder":
         """
         This query command performs the self-calibration, and returns the
         results. After this command, read the results soon. Module condition
@@ -1190,8 +1186,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def cl(self, channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def cl(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'CL'
         elif len(channels) > 15:
@@ -1202,10 +1197,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def clcorr(self,
-               chnum: Union[constants.ChNr, int],
-               mode: Union[constants.CLCORR.Mode, int]
-               ) -> 'MessageBuilder':
+    def clcorr(
+        self, chnum: constants.ChNr | int, mode: constants.CLCORR.Mode | int
+    ) -> "MessageBuilder":
         """
         This query command disables the open/short/load correction function
         and clears the frequency list for the correction data measurement.
@@ -1235,17 +1229,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def cmm(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.CMM.Mode, int]
-            ) -> 'MessageBuilder':
-        cmd = f'CMM {chnum},{mode}'
+    def cmm(
+        self, chnum: constants.ChNr | int, mode: constants.CMM.Mode | int
+    ) -> "MessageBuilder":
+        cmd = f"CMM {chnum},{mode}"
 
         self._msg.append(cmd)
         return self
 
-    def cn(self, channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def cn(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'CN'
         elif len(channels) > 15:
@@ -1256,8 +1248,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def cnx(self, channels: Optional[constants.ChannelList] = None
-            ) -> 'MessageBuilder':
+    def cnx(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'CNX'
         elif len(channels) > 15:
@@ -1269,18 +1260,17 @@ class MessageBuilder:
         return self
 
     @final_command
-    def corr_query(self,
-                   chnum: Union[constants.ChNr, int],
-                   corr: Union[constants.CalibrationType, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'CORR? {chnum},{corr}'
+    def corr_query(
+        self, chnum: constants.ChNr | int, corr: constants.CalibrationType | int
+    ) -> "MessageBuilder":
+        cmd = f"CORR? {chnum},{corr}"
 
         self._msg.append(cmd)
         return self
 
     def corrdt(
         self,
-        chnum: Union[constants.ChNr, int],
+        chnum: constants.ChNr | int,
         freq: float,
         open_r: float,
         open_i: float,
@@ -1298,26 +1288,23 @@ class MessageBuilder:
         return self
 
     @final_command
-    def corrdt_query(self, chnum: Union[constants.ChNr, int], index: int
-                     ) -> 'MessageBuilder':
-        cmd = f'CORRDT? {chnum},{index}'
+    def corrdt_query(self, chnum: constants.ChNr | int, index: int) -> "MessageBuilder":
+        cmd = f"CORRDT? {chnum},{index}"
 
         self._msg.append(cmd)
         return self
 
-    def corrl(self, chnum: Union[constants.ChNr, int], freq: float
-              ) -> 'MessageBuilder':
-        cmd = f'CORRL {chnum},{freq}'
+    def corrl(self, chnum: constants.ChNr | int, freq: float) -> "MessageBuilder":
+        cmd = f"CORRL {chnum},{freq}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def corrl_query(self,
-                    chnum: Union[constants.ChNr, int],
-                    index: Optional[int] = None
-                    ) -> 'MessageBuilder':
-        cmd = f'CORRL? {chnum}'
+    def corrl_query(
+        self, chnum: constants.ChNr | int, index: int | None = None
+    ) -> "MessageBuilder":
+        cmd = f"CORRL? {chnum}"
 
         if index is not None:
             cmd += f',{index}'
@@ -1328,7 +1315,7 @@ class MessageBuilder:
     @final_command
     def corrser_query(
         self,
-        chnum: Union[constants.ChNr, int],
+        chnum: constants.ChNr | int,
         use_immediately: bool,
         delay: float,
         interval: float,
@@ -1339,49 +1326,49 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def corrst(self,
-               chnum: Union[constants.ChNr, int],
-               corr: Union[constants.CalibrationType, int],
-               state: bool
-               ) -> 'MessageBuilder':
-        cmd = f'CORRST {chnum},{corr},{int(state)}'
+    def corrst(
+        self,
+        chnum: constants.ChNr | int,
+        corr: constants.CalibrationType | int,
+        state: bool,
+    ) -> "MessageBuilder":
+        cmd = f"CORRST {chnum},{corr},{int(state)}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def corrst_query(self,
-                     chnum: Union[constants.ChNr, int],
-                     corr: Union[constants.CalibrationType, int]
-                     ) -> 'MessageBuilder':
-        cmd = f'CORRST? {chnum},{corr}'
+    def corrst_query(
+        self, chnum: constants.ChNr | int, corr: constants.CalibrationType | int
+    ) -> "MessageBuilder":
+        cmd = f"CORRST? {chnum},{corr}"
 
         self._msg.append(cmd)
         return self
 
-    def dcorr(self, chnum: Union[constants.ChNr, int],
-              corr: Union[constants.CalibrationType, int],
-              mode: Union[constants.DCORR.Mode, int],
-              primary: float,
-              secondary: float
-              ) -> 'MessageBuilder':
-        cmd = f'DCORR {chnum},{corr},{mode},{primary},{secondary}'
+    def dcorr(
+        self,
+        chnum: constants.ChNr | int,
+        corr: constants.CalibrationType | int,
+        mode: constants.DCORR.Mode | int,
+        primary: float,
+        secondary: float,
+    ) -> "MessageBuilder":
+        cmd = f"DCORR {chnum},{corr},{mode},{primary},{secondary}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def dcorr_query(self,
-                    chnum: Union[constants.ChNr, int],
-                    corr: Union[constants.CalibrationType, int]
-                    ) -> 'MessageBuilder':
-        cmd = f'DCORR? {chnum},{corr}'
+    def dcorr_query(
+        self, chnum: constants.ChNr | int, corr: constants.CalibrationType | int
+    ) -> "MessageBuilder":
+        cmd = f"DCORR? {chnum},{corr}"
 
         self._msg.append(cmd)
         return self
 
-    def dcv(self, chnum: Union[constants.ChNr, int], voltage: float
-            ) -> 'MessageBuilder':
+    def dcv(self, chnum: constants.ChNr | int, voltage: float) -> "MessageBuilder":
         """
         This command forces DC bias (voltage, up to +- 25 V) from the MFCMU.
         When the SCUU (SMU CMU unify unit) is connected, output up to +- 100 V
@@ -1418,16 +1405,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def di(self,
-           chnum: Union[constants.ChNr, int],
-           i_range: Union[constants.IOutputRange, int],
-           current: float,
-           v_comp: Optional[float] = None,
-           comp_polarity: Optional[Union[constants.CompliancePolarityMode,
-                                         int]] = None,
-           v_range: Optional[Union[constants.VOutputRange, int]] = None
-           ) -> 'MessageBuilder':
-        cmd = f'DI {chnum},{i_range},{current}'
+    def di(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        current: float,
+        v_comp: float | None = None,
+        comp_polarity: constants.CompliancePolarityMode | int | None = None,
+        v_range: constants.VOutputRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"DI {chnum},{i_range},{current}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -1442,9 +1429,8 @@ class MessageBuilder:
         return self
 
     @final_command
-    def diag_query(self, item: Union[constants.DIAG.Item, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'DIAG? {item}'
+    def diag_query(self, item: constants.DIAG.Item | int) -> "MessageBuilder":
+        cmd = f"DIAG? {item}"
 
         self._msg.append(cmd)
         return self
@@ -1458,28 +1444,27 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def dsmplarm(self, chnum: Union[constants.ChNr, int], count: int
-                 ) -> 'MessageBuilder':
+    def dsmplarm(self, chnum: constants.ChNr | int, count: int) -> "MessageBuilder":
         event_type = 1  # No other option in user manual, so hard coded here
         cmd = f'DSMPLARM {chnum},{event_type},{count}'
 
         self._msg.append(cmd)
         return self
 
-    def dsmplflush(self, chnum: Union[constants.ChNr, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'DSMPLFLUSH {chnum}'
+    def dsmplflush(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"DSMPLFLUSH {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def dsmplsetup(self,
-                   chnum: Union[constants.ChNr, int],
-                   count: int,
-                   interval: float,
-                   delay: Optional[float] = None
-                   ) -> 'MessageBuilder':
-        cmd = f'DSMPLSETUP {chnum},{count},{interval}'
+    def dsmplsetup(
+        self,
+        chnum: constants.ChNr | int,
+        count: int,
+        interval: float,
+        delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"DSMPLSETUP {chnum},{count},{interval}"
 
         if delay is not None:
             cmd += f',{delay}'
@@ -1487,16 +1472,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def dv(self,
-           chnum: Union[constants.ChNr, int],
-           v_range: Union[constants.VOutputRange, int],
-           voltage: float,
-           i_comp: Optional[float] = None,
-           comp_polarity: Optional[Union[constants.CompliancePolarityMode,
-                                         int]] = None,
-           i_range: Optional[Union[constants.IOutputRange, int]] = None
-           ) -> 'MessageBuilder':
-        cmd = f'DV {chnum},{v_range},{voltage}'
+    def dv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        voltage: float,
+        i_comp: float | None = None,
+        comp_polarity: constants.CompliancePolarityMode | int | None = None,
+        i_range: constants.IOutputRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"DV {chnum},{v_range},{voltage}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -1510,8 +1495,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def dz(self, channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def dz(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'DZ'
         elif len(channels) > 15:
@@ -1542,12 +1526,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ercmaa(self,
-               mfcmu: Union[constants.SlotNr, int],
-               hvsmu: Union[constants.SlotNr, int],
-               mpsmu: Union[constants.SlotNr, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERCMAA {mfcmu},{hvsmu},{mpsmu}'
+    def ercmaa(
+        self,
+        mfcmu: constants.SlotNr | int,
+        hvsmu: constants.SlotNr | int,
+        mpsmu: constants.SlotNr | int,
+    ) -> "MessageBuilder":
+        cmd = f"ERCMAA {mfcmu},{hvsmu},{mpsmu}"
 
         self._msg.append(cmd)
         return self
@@ -1559,11 +1544,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ercmagrd(self,
-                 guard_mode: Optional[Union[constants.ERCMAGRD.Guard,
-                                            int]] = None
-                 ) -> 'MessageBuilder':
-        cmd = 'ERCMAGRD'
+    def ercmagrd(
+        self, guard_mode: constants.ERCMAGRD.Guard | int | None = None
+    ) -> "MessageBuilder":
+        cmd = "ERCMAGRD"
 
         if guard_mode is not None:
             cmd += f' {guard_mode}'
@@ -1609,12 +1593,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhpa(self,
-              hvsmu: Union[constants.ChNr, int],
-              hcsmu: Union[constants.ChNr, int],
-              hpsmu: Union[constants.ChNr, int]
-              ) -> 'MessageBuilder':
-        cmd = f'ERHPA {hvsmu},{hcsmu},{hpsmu}'
+    def erhpa(
+        self,
+        hvsmu: constants.ChNr | int,
+        hcsmu: constants.ChNr | int,
+        hpsmu: constants.ChNr | int,
+    ) -> "MessageBuilder":
+        cmd = f"ERHPA {hvsmu},{hcsmu},{hpsmu}"
 
         self._msg.append(cmd)
         return self
@@ -1652,9 +1637,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhpp(self, path: Union[constants.ERHPP.Path, int]
-              ) -> 'MessageBuilder':
-        cmd = f'ERHPP {path}'
+    def erhpp(self, path: constants.ERHPP.Path | int) -> "MessageBuilder":
+        cmd = f"ERHPP {path}"
 
         self._msg.append(cmd)
         return self
@@ -1666,9 +1650,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhpqg(self, state: Union[constants.ERHPQG.State, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERHPQG {state}'
+    def erhpqg(self, state: constants.ERHPQG.State | int) -> "MessageBuilder":
+        cmd = f"ERHPQG {state}"
 
         self._msg.append(cmd)
         return self
@@ -1709,12 +1692,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhvca(self,
-               vsmu: Union[constants.SlotNr, int],
-               ismu: Union[constants.SlotNr, int],
-               hvsmu: Union[constants.SlotNr, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERHVCA {vsmu},{ismu},{hvsmu}'
+    def erhvca(
+        self,
+        vsmu: constants.SlotNr | int,
+        ismu: constants.SlotNr | int,
+        hvsmu: constants.SlotNr | int,
+    ) -> "MessageBuilder":
+        cmd = f"ERHVCA {vsmu},{ismu},{hvsmu}"
 
         self._msg.append(cmd)
         return self
@@ -1733,9 +1717,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhvp(self, state: Union[constants.ERHVP.State, int]
-              ) -> 'MessageBuilder':
-        cmd = f'ERHVP {state}'
+    def erhvp(self, state: constants.ERHVP.State | int) -> "MessageBuilder":
+        cmd = f"ERHVP {state}"
 
         self._msg.append(cmd)
         return self
@@ -1747,9 +1730,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erhvpv(self, state: Union[constants.ERHVPV.State, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERHVPV {state}'
+    def erhvpv(self, state: constants.ERHVPV.State | int) -> "MessageBuilder":
+        cmd = f"ERHVPV {state}"
 
         self._msg.append(cmd)
         return self
@@ -1773,11 +1755,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ermod(self,
-              mode: Union[constants.ERMOD.Mode, int],
-              option: Optional[bool] = None
-              ) -> 'MessageBuilder':
-        cmd = f'ERMOD {mode}'
+    def ermod(
+        self, mode: constants.ERMOD.Mode | int, option: bool | None = None
+    ) -> "MessageBuilder":
+        cmd = f"ERMOD {mode}"
 
         if option is not None:
             cmd += f',{option}'
@@ -1792,11 +1773,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erpfda(self,
-               hvsmu: Union[constants.SlotNr, int],
-               smu: Union[constants.SlotNr, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERPFDA {hvsmu},{smu}'
+    def erpfda(
+        self, hvsmu: constants.SlotNr | int, smu: constants.SlotNr | int
+    ) -> "MessageBuilder":
+        cmd = f"ERPFDA {hvsmu},{smu}"
 
         self._msg.append(cmd)
         return self
@@ -1808,9 +1788,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erpfdp(self, state: Union[constants.ERPFDP.State, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERPFDP {state}'
+    def erpfdp(self, state: constants.ERPFDP.State | int) -> "MessageBuilder":
+        cmd = f"ERPFDP {state}"
 
         self._msg.append(cmd)
         return self
@@ -1835,8 +1814,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erpfga(self, gsmu: Union[constants.SlotNr, int]) -> 'MessageBuilder':
-        cmd = f'ERPFGA {gsmu}'
+    def erpfga(self, gsmu: constants.SlotNr | int) -> "MessageBuilder":
+        cmd = f"ERPFGA {gsmu}"
 
         self._msg.append(cmd)
         return self
@@ -1848,9 +1827,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erpfgp(self, state: Union[constants.ERPFGP.State, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERPFGP {state}'
+    def erpfgp(self, state: constants.ERPFGP.State | int) -> "MessageBuilder":
+        cmd = f"ERPFGP {state}"
 
         self._msg.append(cmd)
         return self
@@ -1862,9 +1840,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erpfgr(self, state: Union[constants.ERPFGR.State, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERPFGR {state}'
+    def erpfgr(self, state: constants.ERPFGR.State | int) -> "MessageBuilder":
+        cmd = f"ERPFGR {state}"
 
         self._msg.append(cmd)
         return self
@@ -1890,18 +1867,16 @@ class MessageBuilder:
         return self
 
     @final_command
-    def erpftemp_query(self, chnum: Union[constants.ChNr, int]
-                       ) -> 'MessageBuilder':
-        cmd = f'ERPFTEMP? {chnum}'
+    def erpftemp_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"ERPFTEMP? {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def erpfuhca(self,
-                 vsmu: Union[constants.SlotNr, int],
-                 ismu: Union[constants.SlotNr, int]
-                 ) -> 'MessageBuilder':
-        cmd = f'ERPFUHCA {vsmu},{ismu}'
+    def erpfuhca(
+        self, vsmu: constants.SlotNr | int, ismu: constants.SlotNr | int
+    ) -> "MessageBuilder":
+        cmd = f"ERPFUHCA {vsmu},{ismu}"
 
         self._msg.append(cmd)
         return self
@@ -1934,8 +1909,9 @@ class MessageBuilder:
         return self
 
     @final_command
-    def err_query(self, mode: Optional[Union[constants.ERR.Mode, int]] = None
-                  ) -> 'MessageBuilder':
+    def err_query(
+        self, mode: constants.ERR.Mode | int | None = None
+    ) -> "MessageBuilder":
         if mode is None:
             cmd = 'ERR?'
         else:
@@ -1945,9 +1921,10 @@ class MessageBuilder:
         return self
 
     @final_command
-    def errx_query(self, mode: Optional[Union[constants.ERRX.Mode, int]] = None
-                   ) -> 'MessageBuilder':
-        cmd = 'ERRX?'
+    def errx_query(
+        self, mode: constants.ERRX.Mode | int | None = None
+    ) -> "MessageBuilder":
+        cmd = "ERRX?"
 
         if mode is not None:
             cmd += f' {mode}'
@@ -1962,28 +1939,25 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def erssp(self,
-              port: Union[constants.ERSSP.Port, int],
-              status: Union[constants.ERSSP.Status, int]
-              ) -> 'MessageBuilder':
-        cmd = f'ERSSP {port},{status}'
+    def erssp(
+        self, port: constants.ERSSP.Port | int, status: constants.ERSSP.Status | int
+    ) -> "MessageBuilder":
+        cmd = f"ERSSP {port},{status}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def erssp_query(self, port: Union[constants.ERSSP.Port, int]
-                    ) -> 'MessageBuilder':
-        cmd = f'ERSSP? {port}'
+    def erssp_query(self, port: constants.ERSSP.Port | int) -> "MessageBuilder":
+        cmd = f"ERSSP? {port}"
 
         self._msg.append(cmd)
         return self
 
-    def eruhva(self,
-               vsmu: Union[constants.SlotNr, int],
-               ismu: Union[constants.SlotNr, int]
-               ) -> 'MessageBuilder':
-        cmd = f'ERUHVA {vsmu},{ismu}'
+    def eruhva(
+        self, vsmu: constants.SlotNr | int, ismu: constants.SlotNr | int
+    ) -> "MessageBuilder":
+        cmd = f"ERUHVA {vsmu},{ismu}"
 
         self._msg.append(cmd)
         return self
@@ -1995,17 +1969,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def fc(self, chnum: Union[constants.ChNr, int], freq: float
-           ) -> 'MessageBuilder':
-        cmd = f'FC {chnum},{freq}'
+    def fc(self, chnum: constants.ChNr | int, freq: float) -> "MessageBuilder":
+        cmd = f"FC {chnum},{freq}"
 
         self._msg.append(cmd)
         return self
 
-    def fl(self,
-           enable_filter: bool,
-           channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def fl(
+        self, enable_filter: bool, channels: constants.ChannelList | None = None
+    ) -> "MessageBuilder":
         if channels is None:
             cmd = f'FL {int(enable_filter)}'
         elif len(channels) > 10:
@@ -2016,11 +1988,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def fmt(self,
-            format_id: Union[constants.FMT.Format, int],
-            mode: Optional[Union[constants.FMT.Mode, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'FMT {format_id}'
+    def fmt(
+        self,
+        format_id: constants.FMT.Format | int,
+        mode: constants.FMT.Mode | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"FMT {format_id}"
 
         if mode is not None:
             cmd += f',{mode}'
@@ -2028,10 +2001,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def hvsmuop(self,
-                src_range: Union[constants.HVSMUOP.SourceRange, int]
-                ) -> 'MessageBuilder':
-        cmd = f'HVSMUOP {src_range}'
+    def hvsmuop(
+        self, src_range: constants.HVSMUOP.SourceRange | int
+    ) -> "MessageBuilder":
+        cmd = f"HVSMUOP {src_range}"
 
         self._msg.append(cmd)
         return self
@@ -2050,15 +2023,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def imp(self, mode: Union[constants.IMP.MeasurementMode, int]
-            ) -> 'MessageBuilder':
-        cmd = f'IMP {mode}'
+    def imp(self, mode: constants.IMP.MeasurementMode | int) -> "MessageBuilder":
+        cmd = f"IMP {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def in_(self, channels: Optional[constants.ChannelList] = None
-            ) -> 'MessageBuilder':
+    def in_(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = "IN"
         elif len(channels) > 15:
@@ -2082,41 +2053,39 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lgi(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.LinearSearchMode, int],
-            i_range: Union[constants.IMeasRange, int],
-            target: float
-            ) -> 'MessageBuilder':
-        cmd = f'LGI {chnum},{mode},{i_range},{target}'
+    def lgi(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.LinearSearchMode | int,
+        i_range: constants.IMeasRange | int,
+        target: float,
+    ) -> "MessageBuilder":
+        cmd = f"LGI {chnum},{mode},{i_range},{target}"
 
         self._msg.append(cmd)
         return self
 
-    def lgv(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.LinearSearchMode, int],
-            v_range: Union[constants.VMeasRange, int],
-            target: float
-            ) -> 'MessageBuilder':
-        cmd = f'LGV {chnum},{mode},{v_range},{target}'
+    def lgv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.LinearSearchMode | int,
+        v_range: constants.VMeasRange | int,
+        target: float,
+    ) -> "MessageBuilder":
+        cmd = f"LGV {chnum},{mode},{v_range},{target}"
 
         self._msg.append(cmd)
         return self
 
-    def lim(self,
-            mode: Union[constants.LIM.Mode, int],
-            limit: float
-            ) -> 'MessageBuilder':
-        cmd = f'LIM {mode},{limit}'
+    def lim(self, mode: constants.LIM.Mode | int, limit: float) -> "MessageBuilder":
+        cmd = f"LIM {mode},{limit}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def lim_query(self, mode: Union[constants.LIM.Mode, int]
-                  ) -> 'MessageBuilder':
-        cmd = f'LIM? {mode}'
+    def lim_query(self, mode: constants.LIM.Mode | int) -> "MessageBuilder":
+        cmd = f"LIM? {mode}"
 
         self._msg.append(cmd)
         return self
@@ -2135,22 +2104,22 @@ class MessageBuilder:
         return self
 
     @final_command
-    def lrn_query(self, type_id: Union[constants.LRN.Type, int]
-                  ) -> 'MessageBuilder':
-        cmd = f'*LRN? {type_id}'
+    def lrn_query(self, type_id: constants.LRN.Type | int) -> "MessageBuilder":
+        cmd = f"*LRN? {type_id}"
 
         self._msg.append(cmd)
         return self
 
-    def lsi(self,
-            chnum: Union[constants.ChNr, int],
-            i_range: Union[constants.IOutputRange, int],
-            start: float,
-            stop: float,
-            step: float,
-            v_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'LSI {chnum},{i_range},{start},{stop},{step}'
+    def lsi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        start: float,
+        stop: float,
+        step: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"LSI {chnum},{i_range},{start},{stop},{step}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -2158,11 +2127,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lsm(self,
-            abort: Union[constants.Abort, int],
-            post: Optional[Union[constants.LSM.Post, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'LSM {abort}'
+    def lsm(
+        self, abort: constants.Abort | int, post: constants.LSM.Post | int | None = None
+    ) -> "MessageBuilder":
+        cmd = f"LSM {abort}"
 
         if post is not None:
             cmd += f',{post}'
@@ -2170,13 +2138,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lssi(self,
-             chnum: Union[constants.ChNr, int],
-             polarity: Union[constants.Polarity, int],
-             offset: float,
-             v_comp: Optional[float] = None
-             ) -> 'MessageBuilder':
-        cmd = f'LSSI {chnum},{polarity},{offset}'
+    def lssi(
+        self,
+        chnum: constants.ChNr | int,
+        polarity: constants.Polarity | int,
+        offset: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"LSSI {chnum},{polarity},{offset}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -2184,13 +2153,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lssv(self,
-             chnum: Union[constants.ChNr, int],
-             polarity: Union[constants.Polarity, int],
-             offset: float,
-             i_comp: Optional[float] = None
-             ) -> 'MessageBuilder':
-        cmd = f'LSSV {chnum},{polarity},{offset}'
+    def lssv(
+        self,
+        chnum: constants.ChNr | int,
+        polarity: constants.Polarity | int,
+        offset: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"LSSV {chnum},{polarity},{offset}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2220,15 +2190,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lsv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Union[constants.VOutputRange, int],
-            start: float,
-            stop: float,
-            step: float,
-            i_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'LSV {chnum},{v_range},{start},{stop},{step}'
+    def lsv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        step: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"LSV {chnum},{v_range},{start},{stop},{step}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2236,15 +2207,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def lsvm(self, mode: Union[constants.LSVM.DataOutputMode, int]
-             ) -> 'MessageBuilder':
-        cmd = f'LSVM {mode}'
+    def lsvm(self, mode: constants.LSVM.DataOutputMode | int) -> "MessageBuilder":
+        cmd = f"LSVM {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def mcc(self, channels: Optional[constants.ChannelList] = None
-            ) -> 'MessageBuilder':
+    def mcc(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = "MCC"
         elif len(channels) > 15:
@@ -2255,26 +2224,25 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mcpnt(self,
-              chnum: Union[constants.ChNr, int],
-              delay: float,
-              width: float
-              ) -> 'MessageBuilder':
-        cmd = f'MCPNT {chnum},{delay},{width}'
+    def mcpnt(
+        self, chnum: constants.ChNr | int, delay: float, width: float
+    ) -> "MessageBuilder":
+        cmd = f"MCPNT {chnum},{delay},{width}"
 
         self._msg.append(cmd)
         return self
 
-    def mcpnx(self,
-              n: int,
-              chnum: Union[constants.ChNr, int],
-              mode: Union[constants.MCPNX.Mode, int],
-              src_range: Union[constants.VOutputRange, constants.IOutputRange],
-              base: float,
-              pulse: float,
-              comp: Optional[float] = None
-              ) -> 'MessageBuilder':
-        cmd = f'MCPNX {n},{chnum},{mode},{src_range},{base},{pulse}'
+    def mcpnx(
+        self,
+        n: int,
+        chnum: constants.ChNr | int,
+        mode: constants.MCPNX.Mode | int,
+        src_range: constants.VOutputRange | constants.IOutputRange,
+        base: float,
+        pulse: float,
+        comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MCPNX {n},{chnum},{mode},{src_range},{base},{pulse}"
 
         if comp is not None:
             cmd += f',{comp}'
@@ -2282,13 +2250,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mcpt(self,
-             hold: float,
-             period: Optional[Union[float, constants.AutoPeriod]] = None,
-             measurement_delay: Optional[float] = None,
-             average: Optional[int] = None
-             ) -> 'MessageBuilder':
-        cmd = f'MCPT {hold}'
+    def mcpt(
+        self,
+        hold: float,
+        period: float | constants.AutoPeriod | None = None,
+        measurement_delay: float | None = None,
+        average: int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MCPT {hold}"
 
         if period is not None:
             cmd += f',{period}'
@@ -2302,28 +2271,25 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mcpws(self,
-              mode: Union[constants.SweepMode, int],
-              step: int
-              ) -> 'MessageBuilder':
-        cmd = f'MCPWS {mode},{step}'
+    def mcpws(self, mode: constants.SweepMode | int, step: int) -> "MessageBuilder":
+        cmd = f"MCPWS {mode},{step}"
 
         self._msg.append(cmd)
         return self
 
-    def mcpwnx(self,
-               n: int,
-               chnum: Union[constants.ChNr, int],
-               mode: Union[constants.MCPWNX.Mode, int],
-               src_range: Union[constants.VOutputRange,
-                                constants.IOutputRange],
-               base: float,
-               start: float,
-               stop: float,
-               comp: Optional[float] = None,
-               p_comp: Optional[float] = None
-               ) -> 'MessageBuilder':
-        cmd = f'MCPWNX {n},{chnum},{mode},{src_range},{base},{start},{stop}'
+    def mcpwnx(
+        self,
+        n: int,
+        chnum: constants.ChNr | int,
+        mode: constants.MCPWNX.Mode | int,
+        src_range: constants.VOutputRange | constants.IOutputRange,
+        base: float,
+        start: float,
+        stop: float,
+        comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MCPWNX {n},{chnum},{mode},{src_range},{base},{start},{stop}"
 
         if comp is not None:
             cmd += f',{comp}'
@@ -2334,13 +2300,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mdcv(self,
-             chnum: Union[constants.ChNr, int],
-             base: float,
-             bias: float,
-             post: Optional[float] = None
-             ) -> 'MessageBuilder':
-        cmd = f'MDCV {chnum},{base},{bias}'
+    def mdcv(
+        self,
+        chnum: constants.ChNr | int,
+        base: float,
+        bias: float,
+        post: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MDCV {chnum},{base},{bias}"
 
         if post is not None:
             cmd += f',{post}'
@@ -2348,14 +2315,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mi(self,
-           chnum: Union[constants.ChNr, int],
-           i_range: Union[constants.IOutputRange, int],
-           base: float,
-           bias: float,
-           v_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'MI {chnum},{i_range},{base},{bias}'
+    def mi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        base: float,
+        bias: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MI {chnum},{i_range},{base},{bias}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -2363,16 +2331,17 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ml(self, mode: Union[constants.ML.Mode, int]) -> 'MessageBuilder':
-        cmd = f'ML {mode}'
+    def ml(self, mode: constants.ML.Mode | int) -> "MessageBuilder":
+        cmd = f"ML {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def mm(self,
-           mode: Union[constants.MM.Mode, int],
-           channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def mm(
+        self,
+        mode: constants.MM.Mode | int,
+        channels: constants.ChannelList | None = None,
+    ) -> "MessageBuilder":
         if mode in (1, 2, 10, 16, 18, 27, 28):
             if channels is None:
                 raise ValueError('Specify channels for this mode')
@@ -2402,11 +2371,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def msc(self,
-            abort: Union[constants.Abort, int],
-            post: Optional[Union[constants.MSC.Post, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'MSC {abort}'
+    def msc(
+        self, abort: constants.Abort | int, post: constants.MSC.Post | int | None = None
+    ) -> "MessageBuilder":
+        cmd = f"MSC {abort}"
 
         if post is not None:
             cmd += f',{post}'
@@ -2414,12 +2382,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def msp(self,
-            chnum: Union[constants.ChNr, int],
-            post: Optional[float] = None,
-            base: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'MSP {chnum}'
+    def msp(
+        self,
+        chnum: constants.ChNr | int,
+        post: float | None = None,
+        base: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MSP {chnum}"
 
         if post is not None:
             cmd += f',{post}'
@@ -2430,12 +2399,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mt(self,
-           h_bias: float,
-           interval: float,
-           number: int,
-           h_base: Optional[float] = None
-           ) -> 'MessageBuilder':
+    def mt(
+        self, h_bias: float, interval: float, number: int, h_base: float | None = None
+    ) -> "MessageBuilder":
         """
         This command sets the timing parameters of the sampling measurement
         mode (:attr:`.MM.Mode.SAMPLING`, ``10``).
@@ -2474,13 +2440,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mtdcv(self,
-              h_bias: float,
-              interval: float,
-              number: int,
-              h_base: Optional[float] = None
-              ) -> 'MessageBuilder':
-        cmd = f'MTDCV {h_bias},{interval},{number}'
+    def mtdcv(
+        self, h_bias: float, interval: float, number: int, h_base: float | None = None
+    ) -> "MessageBuilder":
+        cmd = f"MTDCV {h_bias},{interval},{number}"
 
         if h_base is not None:
             cmd = f',{h_base}'
@@ -2488,14 +2451,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def mv(self,
-           chnum: Union[constants.ChNr, int],
-           v_range: Union[constants.VOutputRange, int],
-           base: float,
-           bias: float,
-           i_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'MV {chnum},{v_range},{base},{bias}'
+    def mv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        base: float,
+        bias: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"MV {chnum},{v_range},{base},{bias}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2510,15 +2474,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def odsw(self,
-             chnum: Union[constants.ChNr, int],
-             enable_pulse_switch: bool,
-             switch_normal_state: Optional[
-                 Union[constants.ODSW.SwitchNormalState, int]] = None,
-             delay: Optional[float] = None,
-             width: Optional[float] = None
-             ) -> 'MessageBuilder':
-        cmd = f'ODSW {chnum},{int(enable_pulse_switch)}'
+    def odsw(
+        self,
+        chnum: constants.ChNr | int,
+        enable_pulse_switch: bool,
+        switch_normal_state: constants.ODSW.SwitchNormalState | int | None = None,
+        delay: float | None = None,
+        width: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"ODSW {chnum},{int(enable_pulse_switch)}"
 
         if switch_normal_state is not None:
             cmd += f',{switch_normal_state}'
@@ -2534,9 +2498,8 @@ class MessageBuilder:
         return self
 
     @final_command
-    def odsw_query(self, chnum: Union[constants.ChNr, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'ODSW? {chnum}'
+    def odsw_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"ODSW? {chnum}"
 
         self._msg.append(cmd)
         return self
@@ -2554,11 +2517,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def osx(self,
-            port: Union[constants.TriggerPort, int],
-            level: Optional[Union[constants.OSX.Level, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'OSX {port}'
+    def osx(
+        self,
+        port: constants.TriggerPort | int,
+        level: constants.OSX.Level | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"OSX {port}"
 
         if level is not None:
             cmd += f',{level}'
@@ -2566,8 +2530,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pa(self, wait_time: Optional[float] = None) -> 'MessageBuilder':
-        cmd = 'PA'
+    def pa(self, wait_time: float | None = None) -> "MessageBuilder":
+        cmd = "PA"
 
         if wait_time is not None:
             cmd += f' {wait_time}'
@@ -2581,11 +2545,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pax(self,
-            port: Union[constants.TriggerPort, int],
-            wait_time: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'PAX {port}'
+    def pax(
+        self, port: constants.TriggerPort | int, wait_time: float | None = None
+    ) -> "MessageBuilder":
+        cmd = f"PAX {port}"
 
         if wait_time is not None:
             cmd += f',{wait_time}'
@@ -2593,11 +2556,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pch(self,
-            controller: Union[constants.ChNr, int],
-            worker: Union[constants.ChNr, int],
-            ) -> 'MessageBuilder':
-        cmd = f'PCH {controller},{worker}'
+    def pch(
+        self,
+        controller: constants.ChNr | int,
+        worker: constants.ChNr | int,
+    ) -> "MessageBuilder":
+        cmd = f"PCH {controller},{worker}"
 
         self._msg.append(cmd)
         return self
@@ -2612,24 +2576,23 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pdcv(self,
-             chnum: Union[constants.ChNr, int],
-             base: float,
-             pulse: float
-             ) -> 'MessageBuilder':
-        cmd = f'PDCV {chnum},{base},{pulse}'
+    def pdcv(
+        self, chnum: constants.ChNr | int, base: float, pulse: float
+    ) -> "MessageBuilder":
+        cmd = f"PDCV {chnum},{base},{pulse}"
 
         self._msg.append(cmd)
         return self
 
-    def pi(self,
-           chnum: Union[constants.ChNr, int],
-           i_range: Union[constants.IOutputRange, int],
-           base: float,
-           pulse: float,
-           v_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'PI {chnum},{i_range},{base},{pulse}'
+    def pi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        base: float,
+        pulse: float,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PI {chnum},{i_range},{base},{pulse}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -2637,13 +2600,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pt(self,
-           hold: float,
-           width: float,
-           period: Optional[Union[float, constants.AutoPeriod]] = None,
-           t_delay: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'PT {hold},{width}'
+    def pt(
+        self,
+        hold: float,
+        width: float,
+        period: float | constants.AutoPeriod | None = None,
+        t_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PT {hold},{width}"
 
         if period is not None:
             cmd += f',{period}'
@@ -2654,13 +2618,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ptdcv(self,
-              hold: float,
-              width: float,
-              period: Optional[float] = None,
-              t_delay: Optional[float] = None
-              ) -> 'MessageBuilder':
-        cmd = f'PTDCV {hold},{width}'
+    def ptdcv(
+        self,
+        hold: float,
+        width: float,
+        period: float | None = None,
+        t_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PTDCV {hold},{width}"
 
         if period is not None:
             cmd += f',{period}'
@@ -2671,14 +2636,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pv(self,
-           chnum: Union[constants.ChNr, int],
-           v_range: Union[constants.VOutputRange, int],
-           base: float,
-           pulse: float,
-           i_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'PV {chnum},{v_range},{base},{pulse}'
+    def pv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        base: float,
+        pulse: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PV {chnum},{v_range},{base},{pulse}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2686,31 +2652,33 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pwdcv(self,
-              chnum: Union[constants.ChNr, int],
-              mode: Union[constants.LinearSweepMode, int],
-              base: float,
-              start: float,
-              stop: float,
-              step: float
-              ) -> 'MessageBuilder':
-        cmd = f'PWDCV {chnum},{mode},{base},{start},{stop},{step}'
+    def pwdcv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.LinearSweepMode | int,
+        base: float,
+        start: float,
+        stop: float,
+        step: float,
+    ) -> "MessageBuilder":
+        cmd = f"PWDCV {chnum},{mode},{base},{start},{stop},{step}"
 
         self._msg.append(cmd)
         return self
 
-    def pwi(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.SweepMode, int],
-            i_range: Union[constants.IOutputRange, int],
-            base: float,
-            start: float,
-            stop: float,
-            step: float,
-            v_comp: Optional[float] = None,
-            p_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'PWI {chnum},{mode},{i_range},{base},{start},{stop},{step}'
+    def pwi(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        i_range: constants.IOutputRange | int,
+        base: float,
+        start: float,
+        stop: float,
+        step: float,
+        v_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PWI {chnum},{mode},{i_range},{base},{start},{stop},{step}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -2721,18 +2689,19 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def pwv(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.SweepMode, int],
-            v_range: Union[constants.VOutputRange, int],
-            base: float,
-            start: float,
-            stop: float,
-            step: float,
-            i_comp: Optional[float] = None,
-            p_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'PWI {chnum},{mode},{v_range},{base},{start},{stop},{step}'
+    def pwv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        v_range: constants.VOutputRange | int,
+        base: float,
+        start: float,
+        stop: float,
+        step: float,
+        i_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"PWI {chnum},{mode},{v_range},{base},{start},{stop},{step}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2743,8 +2712,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsc(self, mode: Union[constants.APIVersion, int]) -> 'MessageBuilder':
-        cmd = f'QSC {mode}'
+    def qsc(self, mode: constants.APIVersion | int) -> "MessageBuilder":
+        cmd = f"QSC {mode}"
 
         self._msg.append(cmd)
         return self
@@ -2760,11 +2729,10 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsm(self,
-            abort: Union[constants.Abort, int],
-            post: Optional[Union[constants.QSM.Post, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'QSM {abort}'
+    def qsm(
+        self, abort: constants.Abort | int, post: constants.QSM.Post | int | None = None
+    ) -> "MessageBuilder":
+        cmd = f"QSM {abort}"
 
         if post is not None:
             cmd += f',{post}'
@@ -2772,12 +2740,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qso(self,
-            enable_smart_operation: bool,
-            chnum: Optional[Union[constants.ChNr, int]] = None,
-            v_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'QSO {int(enable_smart_operation)}'
+    def qso(
+        self,
+        enable_smart_operation: bool,
+        chnum: constants.ChNr | int | None = None,
+        v_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"QSO {int(enable_smart_operation)}"
 
         if chnum is not None:
             cmd += f',{chnum}'
@@ -2788,21 +2757,21 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsr(self, i_range: Union[constants.IMeasRange, int]
-            ) -> 'MessageBuilder':
-        cmd = f'QSR {i_range}'
+    def qsr(self, i_range: constants.IMeasRange | int) -> "MessageBuilder":
+        cmd = f"QSR {i_range}"
 
         self._msg.append(cmd)
         return self
 
-    def qst(self,
-            cinteg: float,
-            linteg: float,
-            hold: float,
-            delay1: float,
-            delay2: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'QST {cinteg},{linteg},{hold},{delay1}'
+    def qst(
+        self,
+        cinteg: float,
+        linteg: float,
+        hold: float,
+        delay1: float,
+        delay2: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"QST {cinteg},{linteg},{hold},{delay1}"
 
         if delay2 is not None:
             cmd += f',{delay2}'
@@ -2810,17 +2779,18 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsv(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.LinearSweepMode, int],
-            v_range: Union[constants.VOutputRange, int],
-            start: float,
-            stop: float,
-            cvoltage: float,
-            step: float,
-            i_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'QSV {chnum},{mode},{v_range},{start},{stop},{cvoltage},{step}'
+    def qsv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.LinearSweepMode | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        cvoltage: float,
+        step: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"QSV {chnum},{mode},{v_range},{start},{stop},{cvoltage},{step}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -2828,8 +2798,8 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsz(self, mode: Union[constants.QSZ.Mode, int]) -> 'MessageBuilder':
-        cmd = f'QSZ {mode}'
+    def qsz(self, mode: constants.QSZ.Mode | int) -> "MessageBuilder":
+        cmd = f"QSZ {mode}"
 
         self._msg.append(cmd)
 
@@ -2839,11 +2809,12 @@ class MessageBuilder:
 
         return self
 
-    def rc(self,
-           chnum: Union[constants.ChNr, int],
-           ranging_mode: Union[constants.RangingMode, int],
-           measurement_range: Optional[int] = None
-           ) -> 'MessageBuilder':
+    def rc(
+        self,
+        chnum: constants.ChNr | int,
+        ranging_mode: constants.RangingMode | int,
+        measurement_range: int | None = None,
+    ) -> "MessageBuilder":
         if measurement_range is None:
             if ranging_mode != 0:
                 raise ValueError('measurement_range must be specified for '
@@ -2855,28 +2826,26 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def rcv(self,
-            slot: Optional[Union[constants.SlotNr, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = 'RCV' if slot is None else f'RCV {slot}'
+    def rcv(self, slot: constants.SlotNr | int | None = None) -> "MessageBuilder":
+        cmd = "RCV" if slot is None else f"RCV {slot}"
 
         self._msg.append(cmd)
         return self
 
-    def ri(self,
-           chnum: Union[constants.ChNr, int],
-           i_range: Union[constants.IMeasRange, int]
-           ) -> 'MessageBuilder':
-        cmd = f'RI {chnum},{i_range}'
+    def ri(
+        self, chnum: constants.ChNr | int, i_range: constants.IMeasRange | int
+    ) -> "MessageBuilder":
+        cmd = f"RI {chnum},{i_range}"
 
         self._msg.append(cmd)
         return self
 
-    def rm(self,
-           chnum: Union[constants.ChNr, int],
-           mode: Union[constants.RM.Mode, int],
-           rate: Optional[int] = None
-           ) -> 'MessageBuilder':
+    def rm(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.RM.Mode | int,
+        rate: int | None = None,
+    ) -> "MessageBuilder":
         if rate is None:
             cmd = f'RM {chnum},{mode}'
         else:
@@ -2899,17 +2868,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def rv(self,
-           chnum: Union[constants.ChNr, int],
-           v_range: Union[constants.VMeasRange, int]
-           ) -> 'MessageBuilder':
-        cmd = f'RV {chnum},{v_range}'
+    def rv(
+        self, chnum: constants.ChNr | int, v_range: constants.VMeasRange | int
+    ) -> "MessageBuilder":
+        cmd = f"RV {chnum},{v_range}"
 
         self._msg.append(cmd)
         return self
 
-    def rz(self, channels: Optional[constants.ChannelList] = None
-           ) -> 'MessageBuilder':
+    def rz(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'RZ'
         elif len(channels) > 15:
@@ -2920,28 +2887,25 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def sal(self,
-            chnum: Union[constants.ChNr, int],
-            enable_status_led: bool
-            ) -> 'MessageBuilder':
-        cmd = f'SAL {chnum},{int(enable_status_led)}'
+    def sal(
+        self, chnum: constants.ChNr | int, enable_status_led: bool
+    ) -> "MessageBuilder":
+        cmd = f"SAL {chnum},{int(enable_status_led)}"
 
         self._msg.append(cmd)
         return self
 
-    def sap(self,
-            chnum: Union[constants.ChNr, int],
-            path: Union[constants.SAP.Path, int]
-            ) -> 'MessageBuilder':
-        cmd = f'SAP {chnum},{path}'
+    def sap(
+        self, chnum: constants.ChNr | int, path: constants.SAP.Path | int
+    ) -> "MessageBuilder":
+        cmd = f"SAP {chnum},{path}"
 
         self._msg.append(cmd)
         return self
 
-    def sar(self,
-            chnum: Union[constants.ChNr, int],
-            enable_picoamp_autoranging: bool
-            ) -> 'MessageBuilder':
+    def sar(
+        self, chnum: constants.ChNr | int, enable_picoamp_autoranging: bool
+    ) -> "MessageBuilder":
         # For reasons only known to the designer of the KeysightB1500's API the
         # logic of enabled=1 and disabled=0 is inverted JUST for this command.
         cmd = f'SAR {chnum},{int(not enable_picoamp_autoranging)}'
@@ -2949,28 +2913,27 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def scr(self, pnum: Optional[int] = None) -> 'MessageBuilder':
-        cmd = 'SCR' if pnum is None else f'SCR {pnum}'
+    def scr(self, pnum: int | None = None) -> "MessageBuilder":
+        cmd = "SCR" if pnum is None else f"SCR {pnum}"
 
         self._msg.append(cmd)
         return self
 
-    def ser(self, chnum: Union[constants.ChNr, int], load_z: float
-            ) -> 'MessageBuilder':
-        cmd = f'SER {chnum},{load_z}'
+    def ser(self, chnum: constants.ChNr | int, load_z: float) -> "MessageBuilder":
+        cmd = f"SER {chnum},{load_z}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def ser_query(self, chnum: Union[constants.ChNr, int]) -> 'MessageBuilder':
-        cmd = f'SER? {chnum}'
+    def ser_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"SER? {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def sim(self, mode: Union[constants.SIM.Mode, int]) -> 'MessageBuilder':
-        cmd = f'SIM {mode}'
+    def sim(self, mode: constants.SIM.Mode | int) -> "MessageBuilder":
+        cmd = f"SIM {mode}"
 
         self._msg.append(cmd)
         return self
@@ -2982,48 +2945,43 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def sopc(self, chnum: Union[constants.ChNr, int], power: float
-             ) -> 'MessageBuilder':
-        cmd = f'SOPC {chnum},{power}'
+    def sopc(self, chnum: constants.ChNr | int, power: float) -> "MessageBuilder":
+        cmd = f"SOPC {chnum},{power}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def sopc_query(self, chnum: Union[constants.ChNr, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'SOPC? {chnum}'
+    def sopc_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"SOPC? {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def sovc(self, chnum: Union[constants.ChNr, int], voltage: float
-             ) -> 'MessageBuilder':
-        cmd = f'SOVC {chnum},{voltage}'
-
-        self._msg.append(cmd)
-        return self
-
-    @final_command
-    def sovc_query(self, chnum: Union[constants.ChNr, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'SOVC? {chnum}'
-
-        self._msg.append(cmd)
-        return self
-
-    def spm(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.SPM.Mode, int]
-            ) -> 'MessageBuilder':
-        cmd = f'SPM {chnum},{mode}'
+    def sovc(self, chnum: constants.ChNr | int, voltage: float) -> "MessageBuilder":
+        cmd = f"SOVC {chnum},{voltage}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def spm_query(self, chnum: Union[constants.ChNr, int]) -> 'MessageBuilder':
-        cmd = f'SPM? {chnum}'
+    def sovc_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"SOVC? {chnum}"
+
+        self._msg.append(cmd)
+        return self
+
+    def spm(
+        self, chnum: constants.ChNr | int, mode: constants.SPM.Mode | int
+    ) -> "MessageBuilder":
+        cmd = f"SPM {chnum},{mode}"
+
+        self._msg.append(cmd)
+        return self
+
+    @final_command
+    def spm_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"SPM? {chnum}"
 
         self._msg.append(cmd)
         return self
@@ -3048,10 +3006,7 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def sprm(self,
-             mode: Union[constants.SPRM.Mode, int],
-             condition=None
-             ) -> 'MessageBuilder':
+    def sprm(self, mode: constants.SPRM.Mode | int, condition=None) -> "MessageBuilder":
         if condition is None:
             cmd = f'SPRM {mode}'
         else:
@@ -3074,15 +3029,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def spt(self,
-            chnum: Union[constants.ChNr, int],
-            src: Union[constants.SPT.Src, int],
-            delay: float,
-            width: float,
-            leading: float,
-            trailing: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'SPT {chnum},{src},{delay},{width},{leading}'
+    def spt(
+        self,
+        chnum: constants.ChNr | int,
+        src: constants.SPT.Src | int,
+        delay: float,
+        width: float,
+        leading: float,
+        trailing: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"SPT {chnum},{src},{delay},{width},{leading}"
 
         if trailing is not None:
             cmd += f',{trailing}'
@@ -3091,17 +3047,15 @@ class MessageBuilder:
         return self
 
     @final_command
-    def spt_query(self,
-                  chnum: Union[constants.ChNr, int],
-                  src: Union[constants.SPT.Src, int]
-                  ) -> 'MessageBuilder':
-        cmd = f'SPT? {chnum},{src}'
+    def spt_query(
+        self, chnum: constants.ChNr | int, src: constants.SPT.Src | int
+    ) -> "MessageBuilder":
+        cmd = f"SPT? {chnum},{src}"
 
         self._msg.append(cmd)
         return self
 
-    def spupd(self, channels: Optional[constants.ChannelList] = None
-              ) -> 'MessageBuilder':
+    def spupd(self, channels: constants.ChannelList | None = None) -> "MessageBuilder":
         if channels is None:
             cmd = 'SPUPD'
         elif len(channels) > 10:
@@ -3112,13 +3066,14 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def spv(self,
-            chnum: Union[constants.ChNr, int],
-            src: Union[constants.SPV.Src, int],
-            base: float,
-            peak: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'SPV {chnum},{src},{base}'
+    def spv(
+        self,
+        chnum: constants.ChNr | int,
+        src: constants.SPV.Src | int,
+        base: float,
+        peak: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"SPV {chnum},{src},{base}"
 
         if peak is not None:
             cmd += f',{peak}'
@@ -3127,17 +3082,16 @@ class MessageBuilder:
         return self
 
     @final_command
-    def spv_query(self,
-                  chnum: Union[constants.ChNr, int],
-                  src: Union[constants.SPV.Src, int]
-                  ) -> 'MessageBuilder':
-        cmd = f'SPV? {chnum},{src}'
+    def spv_query(
+        self, chnum: constants.ChNr | int, src: constants.SPV.Src | int
+    ) -> "MessageBuilder":
+        cmd = f"SPV? {chnum},{src}"
 
         self._msg.append(cmd)
         return self
 
-    def sre(self, flags: Union[constants.SRE, int]) -> 'MessageBuilder':
-        cmd = f'*SRE {flags}'
+    def sre(self, flags: constants.SRE | int) -> "MessageBuilder":
+        cmd = f"*SRE {flags}"
 
         self._msg.append(cmd)
         return self
@@ -3155,29 +3109,26 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ssl(self,
-            chnum: Union[constants.ChNr, int],
-            enable_indicator_led: bool
-            ) -> 'MessageBuilder':
-        cmd = f'SSL {chnum},{int(enable_indicator_led)}'
+    def ssl(
+        self, chnum: constants.ChNr | int, enable_indicator_led: bool
+    ) -> "MessageBuilder":
+        cmd = f"SSL {chnum},{int(enable_indicator_led)}"
 
         self._msg.append(cmd)
         return self
 
-    def ssp(self,
-            chnum: Union[constants.ChNr, int],
-            path: Union[constants.SSP.Path, int]
-            ) -> 'MessageBuilder':
-        cmd = f'SSP {chnum},{path}'
+    def ssp(
+        self, chnum: constants.ChNr | int, path: constants.SSP.Path | int
+    ) -> "MessageBuilder":
+        cmd = f"SSP {chnum},{path}"
 
         self._msg.append(cmd)
         return self
 
-    def ssr(self,
-            chnum: Union[constants.ChNr, int],
-            enable_series_resistor: bool
-            ) -> 'MessageBuilder':
-        cmd = f'SSR {chnum},{int(enable_series_resistor)}'
+    def ssr(
+        self, chnum: constants.ChNr | int, enable_series_resistor: bool
+    ) -> "MessageBuilder":
+        cmd = f"SSR {chnum},{int(enable_series_resistor)}"
 
         self._msg.append(cmd)
         return self
@@ -3195,36 +3146,36 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def stgp(self,
-             chnum: Union[constants.ChNr, int],
-             trigger_timing: Union[constants.STGP.TriggerTiming, int]
-             ) -> 'MessageBuilder':
-        cmd = f'STGP {chnum},{trigger_timing}'
+    def stgp(
+        self,
+        chnum: constants.ChNr | int,
+        trigger_timing: constants.STGP.TriggerTiming | int,
+    ) -> "MessageBuilder":
+        cmd = f"STGP {chnum},{trigger_timing}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def stgp_query(self, chnum: Union[constants.ChNr, int]
-                   ) -> 'MessageBuilder':
-        cmd = f'STGP? {chnum}'
+    def stgp_query(self, chnum: constants.ChNr | int) -> "MessageBuilder":
+        cmd = f"STGP? {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def tacv(self, chnum: Union[constants.ChNr, int], voltage: float
-             ) -> 'MessageBuilder':
-        cmd = f'TACV {chnum},{voltage}'
+    def tacv(self, chnum: constants.ChNr | int, voltage: float) -> "MessageBuilder":
+        cmd = f"TACV {chnum},{voltage}"
 
         self._msg.append(cmd)
         return self
 
-    def tc(self,
-           chnum: Union[constants.ChNr, int],
-           mode: Union[constants.RangingMode, int],
-           ranging_type=None
-           ) -> 'MessageBuilder':
-        cmd = f'TC {chnum},{mode}'
+    def tc(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.RangingMode | int,
+        ranging_type=None,
+    ) -> "MessageBuilder":
+        cmd = f"TC {chnum},{mode}"
 
         if ranging_type is not None:
             cmd += f',{ranging_type}'
@@ -3232,25 +3183,22 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tdcv(self,
-             chnum: Union[constants.ChNr, int],
-             voltage: float
-             ) -> 'MessageBuilder':
-        cmd = f'TDCV {chnum},{voltage}'
+    def tdcv(self, chnum: constants.ChNr | int, voltage: float) -> "MessageBuilder":
+        cmd = f"TDCV {chnum},{voltage}"
 
         self._msg.append(cmd)
         return self
 
-    def tdi(self,
-            chnum: Union[constants.ChNr, int],
-            i_range: Union[constants.IOutputRange, int],
-            current: float,
-            v_comp: Optional[float] = None,
-            comp_polarity: Optional[
-                Union[constants.CompliancePolarityMode, int]] = None,
-            v_range: Optional[Union[constants.VOutputRange, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TDI {chnum},{i_range},{current}'
+    def tdi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        current: float,
+        v_comp: float | None = None,
+        comp_polarity: constants.CompliancePolarityMode | int | None = None,
+        v_range: constants.VOutputRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TDI {chnum},{i_range},{current}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -3264,16 +3212,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tdv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Union[constants.VOutputRange, int],
-            voltage: float,
-            i_comp: Optional[float] = None,
-            comp_polarity: Optional[
-                Union[constants.CompliancePolarityMode, int]] = None,
-            i_range: Optional[Union[constants.IOutputRange, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TDV {chnum},{v_range},{voltage}'
+    def tdv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        voltage: float,
+        i_comp: float | None = None,
+        comp_polarity: constants.CompliancePolarityMode | int | None = None,
+        i_range: constants.IOutputRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TDV {chnum},{v_range},{voltage}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -3287,20 +3235,20 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tgmo(self, mode: Union[constants.TGMO.Mode, int]) -> 'MessageBuilder':
-        cmd = f'TGMO {mode}'
+    def tgmo(self, mode: constants.TGMO.Mode | int) -> "MessageBuilder":
+        cmd = f"TGMO {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def tgp(self,
-            port: Union[constants.TriggerPort, int],
-            terminal: Union[constants.TGP.TerminalType, int],
-            polarity: Union[constants.TGP.Polarity, int],
-            trigger_type: Optional[Union[constants.TGP.TriggerType,
-                                         int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TGP {port},{terminal},{polarity}'
+    def tgp(
+        self,
+        port: constants.TriggerPort | int,
+        terminal: constants.TGP.TerminalType | int,
+        polarity: constants.TGP.Polarity | int,
+        trigger_type: constants.TGP.TriggerType | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TGP {port},{terminal},{polarity}"
 
         if trigger_type is not None:
             cmd += f',{trigger_type}'
@@ -3309,7 +3257,7 @@ class MessageBuilder:
         return self
 
     def tgpc(
-        self, ports: Optional[list[constants.TriggerPort]] = None
+        self, ports: list[constants.TriggerPort] | None = None
     ) -> "MessageBuilder":
         if ports is None:
             cmd = 'TGPC'
@@ -3321,29 +3269,30 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tgsi(self, mode: Union[constants.TGSI.Mode, int]) -> 'MessageBuilder':
-        cmd = f'TGSI {mode}'
+    def tgsi(self, mode: constants.TGSI.Mode | int) -> "MessageBuilder":
+        cmd = f"TGSI {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def tgso(self, mode: Union[constants.TGSO.Mode, int]) -> 'MessageBuilder':
-        cmd = f'TGSO {mode}'
+    def tgso(self, mode: constants.TGSO.Mode | int) -> "MessageBuilder":
+        cmd = f"TGSO {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def tgxo(self, mode: Union[constants.TGXO.Mode, int]) -> 'MessageBuilder':
-        cmd = f'TGXO {mode}'
+    def tgxo(self, mode: constants.TGXO.Mode | int) -> "MessageBuilder":
+        cmd = f"TGXO {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def ti(self,
-           chnum: Union[constants.ChNr, int],
-           i_range: Optional[Union[constants.IMeasRange, int]] = None
-           ) -> 'MessageBuilder':
-        cmd = f'TI {chnum}'
+    def ti(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IMeasRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TI {chnum}"
 
         if i_range is not None:
             cmd += f',{i_range}'
@@ -3351,11 +3300,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tiv(self,
-            chnum: Union[constants.ChNr, int],
-            i_range: Optional[Union[constants.IMeasRange, int]] = None,
-            v_range: Optional[Union[constants.VMeasRange, int]] = None
-            ) -> 'MessageBuilder':
+    def tiv(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IMeasRange | int | None = None,
+        v_range: constants.VMeasRange | int | None = None,
+    ) -> "MessageBuilder":
         if i_range is None and v_range is None:
             cmd = f'TIV {chnum}'
         elif i_range is None or v_range is None:
@@ -3367,18 +3317,19 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tm(self, mode: Union[constants.TM.Mode, int]) -> 'MessageBuilder':
-        cmd = f'TM {mode}'
+    def tm(self, mode: constants.TM.Mode | int) -> "MessageBuilder":
+        cmd = f"TM {mode}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def tmacv(self,
-              chnum: Union[constants.ChNr, int],
-              mode: Union[constants.RangingMode, int],
-              meas_range: Optional[Union[constants.TMACV.Range, str]] = None
-              ) -> 'MessageBuilder':
+    def tmacv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.RangingMode | int,
+        meas_range: constants.TMACV.Range | str | None = None,
+    ) -> "MessageBuilder":
         """
         This command monitors the MFCMU AC voltage output signal level,
         and returns the measurement data.
@@ -3404,12 +3355,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tmdcv(self,
-              chnum: Union[constants.ChNr, int],
-              mode: Union[constants.RangingMode, int],
-              meas_range: Optional[Union[constants.TMDCV.Range, int]] = None
-              ) -> 'MessageBuilder':
-        cmd = f'TMDCV {chnum},{mode}'
+    def tmdcv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.RangingMode | int,
+        meas_range: constants.TMDCV.Range | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TMDCV {chnum},{mode}"
 
         if meas_range is not None:
             cmd += f',{meas_range}'
@@ -3443,17 +3395,18 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tsr(self, chnum: Optional[int] = None) -> "MessageBuilder":
+    def tsr(self, chnum: int | None = None) -> "MessageBuilder":
         cmd = "TSR" if chnum is None else f"TSR {chnum}"
 
         self._msg.append(cmd)
         return self
 
-    def tst(self,
-            slot: Optional[Union[constants.SlotNr, int]] = None,
-            option: Optional[Union[constants.TST.Option, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = '*TST?'
+    def tst(
+        self,
+        slot: constants.SlotNr | int | None = None,
+        option: constants.TST.Option | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = "*TST?"
 
         if slot is not None:
             cmd += f' {slot}'
@@ -3464,12 +3417,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ttc(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.RangingMode, int],
-            meas_range: Optional[Union[constants.TTC.Range, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TTC {chnum},{mode}'
+    def ttc(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.RangingMode | int,
+        meas_range: constants.TTC.Range | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TTC {chnum},{mode}"
 
         if meas_range is not None:
             cmd += f',{meas_range}'
@@ -3477,11 +3431,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tti(self,
-            chnum: Union[constants.ChNr, int],
-            ranging_type: Optional[Union[constants.IMeasRange, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TTI {chnum}'
+    def tti(
+        self,
+        chnum: constants.ChNr | int,
+        ranging_type: constants.IMeasRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TTI {chnum}"
 
         if ranging_type is not None:
             cmd += f',{ranging_type}'
@@ -3489,11 +3444,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ttiv(self,
-             chnum: Union[constants.ChNr, int],
-             i_range: Optional[Union[constants.IMeasRange, int]] = None,
-             v_range: Optional[Union[constants.VMeasRange, int]] = None
-             ) -> 'MessageBuilder':
+    def ttiv(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IMeasRange | int | None = None,
+        v_range: constants.VMeasRange | int | None = None,
+    ) -> "MessageBuilder":
         if i_range is None and v_range is None:
             cmd = f'TTIV {chnum}'
         elif i_range is None or v_range is None:
@@ -3505,11 +3461,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ttv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Optional[Union[constants.VMeasRange, int]] = None
-            ) -> 'MessageBuilder':
-        cmd = f'TTV {chnum}'
+    def ttv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VMeasRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TTV {chnum}"
 
         if v_range is not None:
             cmd += f',{v_range}'
@@ -3517,11 +3474,12 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def tv(self,
-           chnum: Union[constants.ChNr, int],
-           v_range: Optional[Union[constants.VMeasRange, int]] = None
-           ) -> 'MessageBuilder':
-        cmd = f'TV {chnum}'
+    def tv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VMeasRange | int | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"TV {chnum}"
 
         if v_range is not None:
             cmd += f',{v_range}'
@@ -3530,51 +3488,48 @@ class MessageBuilder:
         return self
 
     @final_command
-    def unt_query(self, mode: Optional[Union[constants.UNT.Mode, int]] = None
-                  ) -> 'MessageBuilder':
-        cmd = 'UNT?' if mode is None else f'UNT? {mode}'
+    def unt_query(
+        self, mode: constants.UNT.Mode | int | None = None
+    ) -> "MessageBuilder":
+        cmd = "UNT?" if mode is None else f"UNT? {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def var(self,
-            variable_type: Union[constants.VAR.Type, int],
-            n: int,
-            value: Union[int, float]
-            ) -> 'MessageBuilder':
-        cmd = f'VAR {variable_type},{n},{value}'
+    def var(
+        self, variable_type: constants.VAR.Type | int, n: int, value: int | float
+    ) -> "MessageBuilder":
+        cmd = f"VAR {variable_type},{n},{value}"
 
         self._msg.append(cmd)
         return self
 
     @final_command
-    def var_query(self,
-                  variable_type: Union[constants.VAR.Type, int],
-                  n: int
-                  ) -> 'MessageBuilder':
-        cmd = f'VAR? {variable_type},{n}'
+    def var_query(
+        self, variable_type: constants.VAR.Type | int, n: int
+    ) -> "MessageBuilder":
+        cmd = f"VAR? {variable_type},{n}"
 
         self._msg.append(cmd)
         return self
 
-    def wacv(self,
-             chnum: Union[constants.ChNr, int],
-             mode: Union[constants.SweepMode, int],
-             start: float,
-             stop: float,
-             step: float
-             ) -> 'MessageBuilder':
-        cmd = f'WACV {chnum},{mode},{start},{stop},{step}'
+    def wacv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        start: float,
+        stop: float,
+        step: float,
+    ) -> "MessageBuilder":
+        cmd = f"WACV {chnum},{mode},{start},{stop},{step}"
 
         self._msg.append(cmd)
         return self
 
-    def wat(self,
-            wait_time_type: Union[constants.WAT.Type, int],
-            coeff: float,
-            offset=None
-            ) -> 'MessageBuilder':
-        cmd = f'WAT {wait_time_type},{coeff}'
+    def wat(
+        self, wait_time_type: constants.WAT.Type | int, coeff: float, offset=None
+    ) -> "MessageBuilder":
+        cmd = f"WAT {wait_time_type},{coeff}"
 
         if offset is not None:
             cmd += f',{offset}'
@@ -3582,14 +3537,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wdcv(self,
-             chnum: Union[constants.ChNr, int],
-             mode: Union[constants.SweepMode, int],
-             start: float,
-             stop: float,
-             step: float,
-             i_comp: Optional[float] = None
-             ) -> 'MessageBuilder':
+    def wdcv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        start: float,
+        stop: float,
+        step: float,
+        i_comp: float | None = None,
+    ) -> "MessageBuilder":
         """
         This command sets the DC bias sweep source used for the CV (DC bias)
         sweep measurement (MM18). The sweep source will be MFCMU or SMU.
@@ -3644,29 +3600,31 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wfc(self,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.SweepMode, int],
-            start: float,
-            stop: float,
-            step: float
-            ) -> 'MessageBuilder':
-        cmd = f'WFC {chnum},{mode},{start},{stop},{step}'
+    def wfc(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        start: float,
+        stop: float,
+        step: float,
+    ) -> "MessageBuilder":
+        cmd = f"WFC {chnum},{mode},{start},{stop},{step}"
 
         self._msg.append(cmd)
         return self
 
-    def wi(self,
-           chnum: Union[constants.ChNr, int],
-           mode: Union[constants.SweepMode, int],
-           i_range: Union[constants.IOutputRange, int],
-           start: float,
-           stop: float,
-           step: float,
-           v_comp: Optional[float] = None,
-           p_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'WI {chnum},{mode},{i_range},{start},{stop},{step}'
+    def wi(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        i_range: constants.IOutputRange | int,
+        start: float,
+        stop: float,
+        step: float,
+        v_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WI {chnum},{mode},{i_range},{start},{stop},{step}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -3677,10 +3635,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wm(self,
-           abort: Union[bool, constants.Abort],
-           post: Optional[Union[constants.WM.Post, int]] = None
-           ) -> 'MessageBuilder':
+    def wm(
+        self, abort: bool | constants.Abort, post: constants.WM.Post | int | None = None
+    ) -> "MessageBuilder":
         if isinstance(abort, bool):
             _abort = constants.Abort.ENABLED if abort \
                 else constants.Abort.DISABLED
@@ -3699,10 +3656,11 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wmacv(self,
-              abort: Union[bool, constants.Abort],
-              post: Optional[Union[constants.WMACV.Post, int]] = None
-              ) -> 'MessageBuilder':
+    def wmacv(
+        self,
+        abort: bool | constants.Abort,
+        post: constants.WMACV.Post | int | None = None,
+    ) -> "MessageBuilder":
         if isinstance(abort, bool):
             _abort = constants.Abort.ENABLED if abort \
                 else constants.Abort.DISABLED
@@ -3721,10 +3679,11 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wmdcv(self,
-              abort: Union[bool, constants.Abort],
-              post: Optional[Union[constants.WMDCV.Post, int]] = None
-              ) -> 'MessageBuilder':
+    def wmdcv(
+        self,
+        abort: bool | constants.Abort,
+        post: constants.WMDCV.Post | int | None = None,
+    ) -> "MessageBuilder":
         """
         This command enables or disables the automatic abort function for
         the CV (AC level) sweep measurement. The automatic abort
@@ -3770,10 +3729,9 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wmfc(self,
-             abort: Union[bool, constants.Abort],
-             post: Optional[Union[constants.WMFC.Post, int]]
-             ) -> 'MessageBuilder':
+    def wmfc(
+        self, abort: bool | constants.Abort, post: constants.WMFC.Post | int | None
+    ) -> "MessageBuilder":
         if isinstance(abort, bool):
             _abort = constants.Abort.ENABLED if abort \
                 else constants.Abort.DISABLED
@@ -3805,18 +3763,18 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wnx(self,
-            n: int,
-            chnum: Union[constants.ChNr, int],
-            mode: Union[constants.WNX.Mode, int],
-            ranging_type: Union[constants.IOutputRange,
-                                constants.VOutputRange],
-            start: float,
-            stop: float,
-            comp: Optional[float] = None,
-            p_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'WNX {n},{chnum},{mode},{ranging_type},{start},{stop}'
+    def wnx(
+        self,
+        n: int,
+        chnum: constants.ChNr | int,
+        mode: constants.WNX.Mode | int,
+        ranging_type: constants.IOutputRange | constants.VOutputRange,
+        start: float,
+        stop: float,
+        comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WNX {n},{chnum},{mode},{ranging_type},{start},{stop}"
 
         if comp is not None:
             cmd += f',{comp}'
@@ -3827,22 +3785,22 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def ws(self, mode: Optional[Union[constants.WS.Mode, int]] = None
-           ) -> 'MessageBuilder':
-        cmd = 'WS' if mode is None else f'WS {mode}'
+    def ws(self, mode: constants.WS.Mode | int | None = None) -> "MessageBuilder":
+        cmd = "WS" if mode is None else f"WS {mode}"
 
         self._msg.append(cmd)
         return self
 
-    def wsi(self,
-            chnum: Union[constants.ChNr, int],
-            i_range: Union[constants.IOutputRange, int],
-            start: float,
-            stop: float,
-            v_comp: Optional[float] = None,
-            p_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'WSI {chnum},{i_range},{start},{stop}'
+    def wsi(
+        self,
+        chnum: constants.ChNr | int,
+        i_range: constants.IOutputRange | int,
+        start: float,
+        stop: float,
+        v_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WSI {chnum},{i_range},{start},{stop}"
 
         if v_comp is not None:
             cmd += f',{v_comp}'
@@ -3853,15 +3811,16 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wsv(self,
-            chnum: Union[constants.ChNr, int],
-            v_range: Union[constants.VOutputRange, int],
-            start: float,
-            stop: float,
-            i_comp: Optional[float] = None,
-            p_comp: Optional[float] = None
-            ) -> 'MessageBuilder':
-        cmd = f'WSV {chnum},{v_range},{start},{stop}'
+    def wsv(
+        self,
+        chnum: constants.ChNr | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        i_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WSV {chnum},{v_range},{start},{stop}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -3872,14 +3831,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wt(self,
-           hold: float,
-           delay: float,
-           step_delay: Optional[float] = None,
-           trigger_delay: Optional[float] = None,
-           measure_delay: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'WT {hold},{delay}'
+    def wt(
+        self,
+        hold: float,
+        delay: float,
+        step_delay: float | None = None,
+        trigger_delay: float | None = None,
+        measure_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WT {hold},{delay}"
 
         if step_delay is not None:
             cmd += f',{step_delay}'
@@ -3893,14 +3853,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wtacv(self,
-              hold: float,
-              delay: float,
-              step_delay: Optional[float] = None,
-              trigger_delay: Optional[float] = None,
-              measure_delay: Optional[float] = None
-              ) -> 'MessageBuilder':
-        cmd = f'WTACV {hold},{delay}'
+    def wtacv(
+        self,
+        hold: float,
+        delay: float,
+        step_delay: float | None = None,
+        trigger_delay: float | None = None,
+        measure_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WTACV {hold},{delay}"
 
         if step_delay is not None:
             cmd += f',{step_delay}'
@@ -3914,14 +3875,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wtdcv(self,
-              hold: float,
-              delay: float,
-              step_delay: Optional[float] = None,
-              trigger_delay: Optional[float] = None,
-              measure_delay: Optional[float] = None
-              ) -> 'MessageBuilder':
-        cmd = f'WTDCV {hold},{delay}'
+    def wtdcv(
+        self,
+        hold: float,
+        delay: float,
+        step_delay: float | None = None,
+        trigger_delay: float | None = None,
+        measure_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WTDCV {hold},{delay}"
 
         if step_delay is not None:
             cmd += f',{step_delay}'
@@ -3935,14 +3897,15 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wtfc(self,
-             hold: float,
-             delay: float,
-             step_delay: Optional[float] = None,
-             trigger_delay: Optional[float] = None,
-             measure_delay: Optional[float] = None
-             ) -> 'MessageBuilder':
-        cmd = f'WTFC {hold},{delay}'
+    def wtfc(
+        self,
+        hold: float,
+        delay: float,
+        step_delay: float | None = None,
+        trigger_delay: float | None = None,
+        measure_delay: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WTFC {hold},{delay}"
 
         if step_delay is not None:
             cmd += f',{step_delay}'
@@ -3956,17 +3919,18 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def wv(self,
-           chnum: Union[constants.ChNr, int],
-           mode: Union[constants.SweepMode, int],
-           v_range: Union[constants.VOutputRange, int],
-           start: float,
-           stop: float,
-           step: float,
-           i_comp: Optional[float] = None,
-           p_comp: Optional[float] = None
-           ) -> 'MessageBuilder':
-        cmd = f'WV {chnum},{mode},{v_range},{start},{stop},{step}'
+    def wv(
+        self,
+        chnum: constants.ChNr | int,
+        mode: constants.SweepMode | int,
+        v_range: constants.VOutputRange | int,
+        start: float,
+        stop: float,
+        step: float,
+        i_comp: float | None = None,
+        p_comp: float | None = None,
+    ) -> "MessageBuilder":
+        cmd = f"WV {chnum},{mode},{v_range},{start},{stop},{step}"
 
         if i_comp is not None:
             cmd += f',{i_comp}'
@@ -3978,8 +3942,8 @@ class MessageBuilder:
         return self
 
     @final_command
-    def wz_query(self, timeout: Optional[float] = None) -> 'MessageBuilder':
-        cmd = 'WZ?' if timeout is None else f'WZ? {timeout}'
+    def wz_query(self, timeout: float | None = None) -> "MessageBuilder":
+        cmd = "WZ?" if timeout is None else f"WZ? {timeout}"
 
         self._msg.append(cmd)
         return self

--- a/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -2,7 +2,7 @@ import textwrap
 from bisect import bisect_left
 from contextlib import ExitStack
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from packaging import version
@@ -1241,9 +1241,7 @@ mode."""
         self.range.get()
 
     def increase_range(
-        self,
-        range_value: Optional[float] = None,
-        increase_by: int = 1
+        self, range_value: float | None = None, increase_by: int = 1
     ) -> None:
         """
         Increases the voltage range by a certain amount with default of 1.
@@ -1271,9 +1269,7 @@ mode."""
             self.range(self.ranges[-1])
 
     def decrease_range(
-        self,
-        range_value: Optional[float] = None,
-        decrease_by: int = -1
+        self, range_value: float | None = None, decrease_by: int = -1
     ) -> None:
         """
         Decrease the voltage range by a certain amount with default of -1.

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_325.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_325.py
@@ -4,11 +4,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     SupportsBytes,
     SupportsIndex,
     TextIO,
-    Union,
     cast,
 )
 
@@ -104,7 +102,7 @@ class LakeshoreModel325Status(IntFlag):
     @classmethod
     def from_bytes(
         cls: "type[Self]",
-        bytes: "Union[Iterable[SupportsIndex], SupportsBytes, Buffer]",
+        bytes: "Iterable[SupportsIndex] | SupportsBytes | Buffer",
         byteorder: Literal["big", "little"] = "big",
         *,
         signed: bool = False,
@@ -270,7 +268,7 @@ class LakeshoreModel325Curve(InstrumentChannel):
         return sensor_unit
 
     def set_data(
-        self, data_dict: dict[Any, Any], sensor_unit: Optional[str] = None
+        self, data_dict: dict[Any, Any], sensor_unit: str | None = None
     ) -> None:
         """
         Set the curve data according to the values found the the dictionary.

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -1,6 +1,6 @@
 import time
 from bisect import bisect
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 from typing_extensions import deprecated
@@ -323,10 +323,10 @@ class LakeshoreBaseOutput(InstrumentChannel):
         self.setpoint(temperature)
 
     def wait_until_set_point_reached(
-            self,
-            wait_cycle_time: Optional[float] = None,
-            wait_tolerance: Optional[float] = None,
-            wait_equilibration_time: Optional[float] = None
+        self,
+        wait_cycle_time: float | None = None,
+        wait_tolerance: float | None = None,
+        wait_equilibration_time: float | None = None,
     ) -> None:
         """
         This function runs a loop that monitors the value of the heater's

--- a/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
@@ -4,7 +4,7 @@ A mixin module for USB Human Interface Device instruments
 import os
 import struct
 import time
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
 
@@ -51,7 +51,7 @@ class USBHIDMixin(Instrument):
     def __init__(
         self,
         name: str,
-        instance_id: Optional[str] = None,
+        instance_id: str | None = None,
         timeout: float = 2,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):
@@ -82,7 +82,7 @@ class USBHIDMixin(Instrument):
         self._device = devs[0]
         self._device.open()
 
-        self._data_buffer: Optional[bytes] = None
+        self._data_buffer: bytes | None = None
         self._device.set_raw_data_handler(self._handler)
 
         self._timeout = timeout
@@ -93,7 +93,7 @@ class USBHIDMixin(Instrument):
     def _handler(self, data: bytes) -> None:
         self._data_buffer = data
 
-    def _get_data_buffer(self) -> Optional[bytes]:
+    def _get_data_buffer(self) -> bytes | None:
         data = self._data_buffer
         self._data_buffer = None
         return data
@@ -191,7 +191,7 @@ class MiniCircuitsHIDMixin(Instrument):
     def __init__(
         self,
         name: str,
-        instance_id: Optional[str] = None,
+        instance_id: str | None = None,
         timeout: float = 2,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):
@@ -235,7 +235,7 @@ class MiniCircuitsHIDMixin(Instrument):
         self._device = devs[0]
         self._device.open()
 
-        self._data_buffer: Optional[bytes] = None
+        self._data_buffer: bytes | None = None
         self._device.set_raw_data_handler(self._handler)
 
         self._timeout = timeout
@@ -246,7 +246,7 @@ class MiniCircuitsHIDMixin(Instrument):
     def _handler(self, data: bytes) -> None:
         self._data_buffer = data
 
-    def _get_data_buffer(self) -> Optional[bytes]:
+    def _get_data_buffer(self) -> bytes | None:
         data = self._data_buffer
         self._data_buffer = None
         return data

--- a/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rc_sp4t.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rc_sp4t.py
@@ -1,5 +1,5 @@
 import math
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes import validators as vals
 from qcodes.instrument import (
@@ -118,12 +118,12 @@ class MiniCircuitsRCSP4T(IPInstrument):
         ret = ret.strip()
         return ret
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         fw = self.ask("FIRMWARE?")
         MN = self.ask("MN?")
         SN = self.ask("SN?")
 
-        id_dict: dict[str, Optional[str]] = {
+        id_dict: dict[str, str | None] = {
             "firmware": fw,
             "model": MN[3:],
             "serial": SN[3:],

--- a/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rc_spdt.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rc_spdt.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes import validators as vals
 from qcodes.instrument import (
@@ -98,12 +98,12 @@ class MiniCircuitsRCSPDT(IPInstrument):
         ret = ret.strip()
         return ret
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         fw = self.ask("FIRMWARE?")
         MN = self.ask("MN?")
         SN = self.ask("SN?")
 
-        id_dict: dict[str, Optional[str]] = {
+        id_dict: dict[str, str | None] = {
             "firmware": fw,
             "model": MN[3:],
             "serial": SN[3:],

--- a/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rudat_13g_90.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_rudat_13g_90.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
 
@@ -53,7 +53,7 @@ class MiniCircuitsRudat13G90Base(Instrument):
 
         self.connect_message()
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         model = self.model_name()
         serial = self.serial_number()
         firmware = self.firmware()

--- a/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_usb_spdt.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/_minicircuits_usb_spdt.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 # QCoDeS imports
 from qcodes.instrument_drivers.Minicircuits.Base_SPDT import (
@@ -39,8 +39,8 @@ class MiniCircuitsUsbSPDT(MiniCircuitsSPDTBase):
     def __init__(
         self,
         name: str,
-        driver_path: Optional[str] = None,
-        serial_number: Optional[str] = None,
+        driver_path: str | None = None,
+        serial_number: str | None = None,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):
         """
@@ -98,7 +98,7 @@ class MiniCircuitsUsbSPDT(MiniCircuitsSPDTBase):
         self.connect_message()
         self.add_channels()
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         # the arguments in those functions is the serial number or none if
         # there is only one switch.
         fw = self.switch.GetFirmware()

--- a/src/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/src/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import pyvisa
 import pyvisa.constants
@@ -140,7 +140,7 @@ class QDevQDacChannel(InstrumentChannel):
 
     def snapshot_base(
         self,
-        update: Optional[bool] = False,
+        update: bool | None = False,
         params_to_skip_update: Optional["Sequence[str]"] = None,
     ) -> dict[Any, Any]:
         update_currents = self._parent._update_currents and update
@@ -259,7 +259,7 @@ class QDevQDac(VisaInstrument):
         self.num_chans = num_chans
 
         # Assigned slopes. Entries will eventually be [chan, slope]
-        self._slopes: list[tuple[int, Union[str, float]]] = []
+        self._slopes: list[tuple[int, str | float]] = []
         # Function generators (used in _set_voltage)
         self._fgs = set(range(1, 9))
         self._assigned_fgs: dict[int, int] = {}  # {chan: fg}
@@ -318,7 +318,7 @@ class QDevQDac(VisaInstrument):
 
     def snapshot_base(
         self,
-        update: Optional[bool] = False,
+        update: bool | None = False,
         params_to_skip_update: Optional["Sequence[str]"] = None,
     ) -> dict[Any, Any]:
         update_currents = self._update_currents and update is True
@@ -582,7 +582,7 @@ class QDevQDac(VisaInstrument):
         else:
             return 0
 
-    def _setslope(self, chan: int, slope: Union[float, str]) -> None:
+    def _setslope(self, chan: int, slope: float | str) -> None:
         """
         set_cmd for the chXX_slope parameter, the maximum slope of a channel.
 
@@ -632,7 +632,7 @@ class QDevQDac(VisaInstrument):
         self._slopes.append((chan, slope))
         return
 
-    def _getslope(self, chan: int) -> Union[str, float]:
+    def _getslope(self, chan: int) -> str | float:
         """
         get_cmd of the chXX_slope parameter
         """
@@ -732,7 +732,7 @@ class QDevQDac(VisaInstrument):
         self.visa_handle.clear()
 
     def connect_message(
-        self, idn_param: str = "IDN", begin_time: Optional[float] = None
+        self, idn_param: str = "IDN", begin_time: float | None = None
     ) -> None:
         """
         Override of the standard Instrument class connect_message.

--- a/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
+++ b/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
@@ -1,14 +1,12 @@
 import warnings
+from collections.abc import Callable
 from functools import partial
 from time import sleep
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Literal,
-    Optional,
-    Union,
     cast,
 )
 
@@ -266,7 +264,7 @@ class DynaCool(VisaInstrument):
         """
         return parser(resp.split(', ')[which_one])
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         response = self.ask('*IDN?')
         # just clip out the error code
         id_parts = response[2:].split(', ')
@@ -348,7 +346,7 @@ class DynaCool(VisaInstrument):
 
     def _field_getter(
         self, param_name: Literal["field_target", "field_rate", "field_approach"]
-    ) -> Union[int, float]:
+    ) -> int | float:
         """
         The combined get function for the three field parameters,
         field_setpoint, field_rate, and field_approach
@@ -371,7 +369,7 @@ class DynaCool(VisaInstrument):
         """
         temporary_values = list(self.parameters[p].raw_value
                                 for p in self.field_params)
-        values = cast(list[Union[int, float]], temporary_values)
+        values = cast(list[int | float], temporary_values)
         values[self.field_params.index(param)] = value
 
         self.write(f'FELD {values[0]}, {values[1]}, {values[2]}, 0')
@@ -381,7 +379,7 @@ class DynaCool(VisaInstrument):
         param_name: Literal[
             "temperature_setpoint", "temperature_rate", "temperature_settling"
         ],
-    ) -> Union[int, float]:
+    ) -> int | float:
         """
         This function queries the last temperature setpoint (w. rate and mode)
         from the instrument.
@@ -406,7 +404,7 @@ class DynaCool(VisaInstrument):
         """
         temp_values = list(self.parameters[par].raw_value
                            for par in self.temp_params)
-        values = cast(list[Union[int, float]], temp_values)
+        values = cast(list[int | float], temp_values)
         values[self.temp_params.index(param)] = value
 
         self.write(f'TEMP {values[0]}, {values[1]}, {values[2]}')

--- a/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
+++ b/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
@@ -1,5 +1,4 @@
 import warnings
-from collections.abc import Callable
 from functools import partial
 from time import sleep
 from typing import (
@@ -17,6 +16,8 @@ import qcodes.validators as vals
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter
@@ -46,7 +47,7 @@ class DynaCool(VisaInstrument):
     temp_params = ("temperature_setpoint", "temperature_rate", "temperature_settling")
     field_params = ("field_target", "field_rate", "field_approach")
 
-    _errors: ClassVar[dict[int, Callable[[], None]]] = {
+    _errors: ClassVar[dict[int, "Callable[[], None]"]] = {
         -2: lambda: warnings.warn("Unknown command"),
         1: lambda: None,
         0: lambda: None,

--- a/src/qcodes/instrument_drivers/agilent/Agilent_E8257D.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_E8257D.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -24,7 +24,7 @@ class AgilentE8257D(VisaInstrument):
         self,
         name: str,
         address: str,
-        step_attenuator: Optional[bool] = None,
+        step_attenuator: bool | None = None,
         **kwargs: "Unpack[VisaInstrumentKWArgs]",
     ) -> None:
         super().__init__(name, address, **kwargs)
@@ -146,12 +146,12 @@ class AgilentE8257D(VisaInstrument):
     # functions to convert between rad and deg
     @staticmethod
     def deg_to_rad(
-        angle_deg: Union[float, str, np.floating, np.integer]
+        angle_deg: float | str | np.floating | np.integer,
     ) -> "np.floating[Any]":
         return np.deg2rad(float(angle_deg))
 
     @staticmethod
     def rad_to_deg(
-        angle_rad: Union[float, str, np.floating, np.integer]
+        angle_rad: float | str | np.floating | np.integer,
     ) -> "np.floating[Any]":
         return np.rad2deg(float(angle_rad))

--- a/src/qcodes/instrument_drivers/agilent/Agilent_E8267C.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_E8267C.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -117,12 +117,12 @@ class AgilentE8267C(VisaInstrument):
     # functions to convert between rad and deg
     @staticmethod
     def deg_to_rad(
-        angle_deg: Union[float, str, np.floating, np.integer]
+        angle_deg: float | str | np.floating | np.integer,
     ) -> "np.floating[Any]":
         return np.deg2rad(float(angle_deg))
 
     @staticmethod
     def rad_to_deg(
-        angle_rad: Union[float, str, np.floating, np.integer]
+        angle_rad: float | str | np.floating | np.integer,
     ) -> "np.floating[Any]":
         return np.rad2deg(float(angle_rad))

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -8,9 +8,10 @@ import numbers
 import time
 import warnings
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import ExitStack
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 
 import numpy as np
 from typing_extensions import deprecated

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -5,14 +5,14 @@ import numbers
 import time
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack
 from functools import partial
-from typing import TYPE_CHECKING, Callable, ClassVar, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Concatenate, TypeVar, cast
 
 import numpy as np
 from pyvisa import VisaIOError
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from qcodes.instrument import (
     Instrument,

--- a/src/qcodes/instrument_drivers/basel/BaselSP983.py
+++ b/src/qcodes/instrument_drivers/basel/BaselSP983.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
 from qcodes.parameters import DelegateParameter, Parameter
@@ -38,7 +38,7 @@ class BaselSP983(Instrument):
     def __init__(
         self,
         name: str,
-        input_offset_voltage: Optional[Parameter] = None,
+        input_offset_voltage: Parameter | None = None,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):
         super().__init__(name, **kwargs)
@@ -76,7 +76,7 @@ class BaselSP983(Instrument):
         )
         """Parameter offset_voltage"""
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = "Physics Basel"
         model = "SP 983"
         serial = None

--- a/src/qcodes/instrument_drivers/basel/BaselSP983a.py
+++ b/src/qcodes/instrument_drivers/basel/BaselSP983a.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -32,7 +32,7 @@ class BaselSP983a(VisaInstrument):
         self,
         name: str,
         address: str,
-        input_offset_voltage: Optional[Parameter] = None,
+        input_offset_voltage: Parameter | None = None,
         **kwargs: "Unpack[VisaInstrumentKWArgs]",
     ) -> None:
         super().__init__(name, address, **kwargs)
@@ -84,7 +84,7 @@ class BaselSP983a(VisaInstrument):
         )
         """Parameter offset_voltage"""
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = "Physics Basel"
         model = "SP 983A"
         serial = None

--- a/src/qcodes/instrument_drivers/basel/BaselSP983c.py
+++ b/src/qcodes/instrument_drivers/basel/BaselSP983c.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from .BaselSP983 import BaselSP983
 
@@ -29,7 +28,7 @@ class BaselSP983c(BaselSP983):
             connected to the "Offset Input Voltage" connector of the SP983C.
     """
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = "Physics Basel"
         model = "SP 983c"
         serial = None

--- a/src/qcodes/instrument_drivers/basel/sp983c.py
+++ b/src/qcodes/instrument_drivers/basel/sp983c.py
@@ -3,13 +3,12 @@ Legacy module kept around for backwards compatibility reasons.
 Will eventually be deprecated and removed
 
 """
-from typing import Optional
 
 from .BaselSP983c import BaselSP983c
 
 
 class SP983C(BaselSP983c):
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = "Physics Basel"
         model = "SP 983(c)"
         serial = None

--- a/src/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
+++ b/src/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
 from qcodes.parameters import MultiParameter, Parameter, ParamRawDataType
@@ -130,7 +130,7 @@ class Ithaco1211(Instrument):
         )
         """Parameter risetime"""
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = 'Ithaco (DL Instruments)'
         model = '1211'
         serial = None

--- a/src/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/src/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, cast
 
@@ -19,6 +18,8 @@ from qcodes.instrument import (
 from qcodes.math_utils import FieldVector
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter

--- a/src/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/src/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.typing as npt

--- a/src/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
+++ b/src/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from qcodes import validators as vals
 from qcodes.instrument import (
@@ -311,7 +311,7 @@ class RigolDG1062Channel(InstrumentChannel):
         Get all the parameters of the current waveform and
         """
 
-        def to_float(string: str) -> Union[float, str]:
+        def to_float(string: str) -> float | str:
             try:
                 return float(string)
             except ValueError:
@@ -321,7 +321,7 @@ class RigolDG1062Channel(InstrumentChannel):
         parts = waveform_str.strip('"').split(",")
 
         current_waveform = self.waveform_translate[parts[0]]
-        param_vals: list[Union[str, float]] = [current_waveform]
+        param_vals: list[str | float] = [current_waveform]
         param_vals += [to_float(i) for i in parts[1:]]
         param_names = ["waveform"] + list(self.waveform_params[current_waveform])
         params_dict = dict(zip(param_names, param_vals))
@@ -342,7 +342,7 @@ class RigolDG1062Channel(InstrumentChannel):
 
         return self._set_waveform_params(**params_dict)
 
-    def _set_waveform_params(self, **params_dict: Union[int, float]) -> None:
+    def _set_waveform_params(self, **params_dict: int | float) -> None:
         """
         Apply a waveform with values given in a dictionary.
         """

--- a/src/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
+++ b/src/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
@@ -36,7 +36,7 @@ def clean_string(s: str) -> str:
     return s
 
 
-def parse_string_output(s: str) -> Union[float, str]:
+def parse_string_output(s: str) -> float | str:
     """Parse an output of the VISA instrument into either text of a number"""
     s = clean_string(s)
 
@@ -51,14 +51,14 @@ def parse_string_output(s: str) -> Union[float, str]:
     return s
 
 
-def parse_single_output(i: int, s: str) -> Union[float, str]:
+def parse_single_output(i: int, s: str) -> float | str:
     """Used as a partial function to parse output i in string s"""
     parts = clean_string(s).split(",")
 
     return parse_string_output(parts[i])
 
 
-def parse_multiple_outputs(s: str) -> list[Union[float, str]]:
+def parse_multiple_outputs(s: str) -> list[float | str]:
     """Parse an output such as 'sin,1.5,0,2' and return a parsed array"""
     parts = clean_string(s).split(",")
 

--- a/src/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -4,7 +4,7 @@
 import logging
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from packaging import version
@@ -540,7 +540,7 @@ class RohdeSchwarzRTO1000(VisaInstrument):
         name: str,
         address: str,
         *,
-        model: Optional[str] = None,
+        model: str | None = None,
         HD: bool = True,
         **kwargs: "Unpack[VisaInstrumentKWArgs]",
     ) -> None:

--- a/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from typing_extensions import deprecated
@@ -360,8 +360,8 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
         parent: "RohdeSchwarzZNBBase",
         name: str,
         channel: int,
-        vna_parameter: Optional[str] = None,
-        existing_trace_to_bind_to: Optional[str] = None,
+        vna_parameter: str | None = None,
+        existing_trace_to_bind_to: str | None = None,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ) -> None:
         """

--- a/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -2,7 +2,7 @@ import ctypes as ct
 import logging
 from enum import IntEnum
 from time import sleep
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -192,7 +192,7 @@ class SignalHoundUSBSA124B(Instrument):
     def __init__(
         self,
         name: str,
-        dll_path: Optional[str] = None,
+        dll_path: str | None = None,
         **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ):
         """
@@ -590,7 +590,7 @@ class SignalHoundUSBSA124B(Instrument):
         # the third argument to saInitiate is a flag that is
         # currently not used
         err = self.dll.saInitiate(self.deviceHandle, mode, 0)
-        extrainfo: Optional[str] = None
+        extrainfo: str | None = None
         if err == saStatus.saInvalidParameterErr:
             extrainfo = """
                  In real-time mode, this value may be returned if the span
@@ -657,7 +657,7 @@ class SignalHoundUSBSA124B(Instrument):
         log.info("Stopping acquisition")
 
         err = self.dll.saAbort(self.deviceHandle)
-        extrainfo: Optional[str] = None
+        extrainfo: str | None = None
         if err == saStatus.saDeviceNotConfiguredErr:
             extrainfo = (
                 "Device was already idle! Did you call abort "
@@ -783,7 +783,7 @@ class SignalHoundUSBSA124B(Instrument):
         return max_power
 
     @staticmethod
-    def check_for_error(err: int, source: str, extrainfo: Optional[str] = None) -> None:
+    def check_for_error(err: int, source: str, extrainfo: str | None = None) -> None:
         if err != saStatus.saNoError:
             err_str = saStatus(err).name
             if err > 0:
@@ -808,8 +808,8 @@ class SignalHoundUSBSA124B(Instrument):
                 msg = msg + f"\n Extra info: {extrainfo}"
             log.info(msg)
 
-    def get_idn(self) -> dict[str, Optional[str]]:
-        output: dict[str, Optional[str]] = {}
+    def get_idn(self) -> dict[str, str | None]:
+        output: dict[str, str | None] = {}
         output["vendor"] = "Signal Hound"
         output["model"] = self._get_device_type()
         serialnumber = ct.c_int32()

--- a/src/qcodes/instrument_drivers/stahl/stahl.py
+++ b/src/qcodes/instrument_drivers/stahl/stahl.py
@@ -5,9 +5,9 @@ This is a driver for the Stahl power supplies
 import logging
 import re
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pyvisa.resources.serial import SerialInstrument
@@ -274,7 +274,7 @@ class Stahl(VisaInstrument):
             for (name, converter), value in zip(converters.items(), result.groups())
         }
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         """
         The Stahl sends a uncommon IDN string which does not include a
         firmware version.

--- a/src/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
 from qcodes.parameters import MultiParameter, Parameter, ParamRawDataType
@@ -131,7 +131,7 @@ class SR560(Instrument):
         )
         """Parameter gain"""
 
-    def get_idn(self) -> dict[str, Optional[str]]:
+    def get_idn(self) -> dict[str, str | None]:
         vendor = 'Stanford Research Systems'
         model = 'SR560'
         serial = None

--- a/src/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 

--- a/src/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -17,7 +16,7 @@ from qcodes.parameters import ArrayParameter
 from qcodes.validators import ComplexNumbers, Enum, Ints, Numbers
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from typing_extensions import Unpack
 

--- a/src/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -12,8 +12,6 @@ from typing import (
     ClassVar,
     Literal,
     NamedTuple,
-    Optional,
-    Union,
     cast,
 )
 
@@ -171,9 +169,7 @@ class TektronixAWG5014(VisaInstrument):
         self._address = address
         self.num_channels = num_channels
 
-        self._values: dict[
-            str, dict[str, dict[str, Union[np.ndarray, float, None]]]
-        ] = {}
+        self._values: dict[str, dict[str, dict[str, np.ndarray | float | None]]] = {}
         self._values["files"] = {}
 
         self.add_function('reset', call_cmd='*RST')
@@ -830,10 +826,7 @@ class TektronixAWG5014(VisaInstrument):
     ######################
 
     def _pack_record(
-            self,
-            name: str,
-            value: Union[float, str, Sequence[Any], np.ndarray],
-            dtype: str
+        self, name: str, value: float | str | Sequence[Any] | np.ndarray, dtype: str
     ) -> bytes:
         """
         packs awg_file record into a struct in the folowing way:
@@ -924,7 +917,7 @@ class TektronixAWG5014(VisaInstrument):
         }
         return AWG_sequence_cfg
 
-    def generate_channel_cfg(self) -> dict[str, Optional[float]]:
+    def generate_channel_cfg(self) -> dict[str, float | None]:
         """
         Function to query if the current channel settings that have
         been changed from their default value and put them in a
@@ -996,7 +989,7 @@ class TektronixAWG5014(VisaInstrument):
 
         # the return value of the parameter is different from what goes
         # into the .awg file, so we translate it
-        def mrkdeltrans(x: Optional[float]) -> Optional[float]:
+        def mrkdeltrans(x: float | None) -> float | None:
             if x is None:
                 return None
             else:
@@ -1010,7 +1003,7 @@ class TektronixAWG5014(VisaInstrument):
                       mrkdeltrans(self.ch3_m2_del.get_latest()),
                       mrkdeltrans(self.ch4_m2_del.get_latest())]
 
-        AWG_channel_cfg: dict[str, Optional[float]] = {}
+        AWG_channel_cfg: dict[str, float | None] = {}
 
         for chan in range(1, self.num_channels+1):
             if dirouts[chan - 1] is not None:
@@ -1071,7 +1064,7 @@ class TektronixAWG5014(VisaInstrument):
         goto_state: Sequence[int],
         jump_to: Sequence[int],
         channel_cfg: dict[str, Any],
-        sequence_cfg: Optional[dict[str, float]] = None,
+        sequence_cfg: dict[str, float] | None = None,
         preservechannelsettings: bool = False,
     ) -> bytes:
         """
@@ -1253,16 +1246,17 @@ class TektronixAWG5014(VisaInstrument):
         self.sequence_length.set(self.sequence_length.get())
 
     def make_awg_file(
-            self,
-            waveforms: Union[Sequence[Sequence[np.ndarray]], Sequence[np.ndarray]],
-            m1s: Union[Sequence[Sequence[np.ndarray]], Sequence[np.ndarray]],
-            m2s: Union[Sequence[Sequence[np.ndarray]], Sequence[np.ndarray]],
-            nreps: Sequence[int],
-            trig_waits: Sequence[int],
-            goto_states: Sequence[int],
-            jump_tos: Sequence[int],
-            channels: Optional[Sequence[int]] = None,
-            preservechannelsettings: bool = True) -> bytes:
+        self,
+        waveforms: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
+        m1s: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
+        m2s: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
+        nreps: Sequence[int],
+        trig_waits: Sequence[int],
+        goto_states: Sequence[int],
+        jump_tos: Sequence[int],
+        channels: Sequence[int] | None = None,
+        preservechannelsettings: bool = True,
+    ) -> bytes:
         """
         Args:
             waveforms: A list of the waveforms to be packed. The list
@@ -1344,17 +1338,17 @@ class TektronixAWG5014(VisaInstrument):
             preservechannelsettings=preservechannelsettings)
 
     def make_send_and_load_awg_file(
-            self,
-            waveforms: Sequence[Sequence[np.ndarray]],
-            m1s: Sequence[Sequence[np.ndarray]],
-            m2s: Sequence[Sequence[np.ndarray]],
-            nreps: Sequence[int],
-            trig_waits: Sequence[int],
-            goto_states: Sequence[int],
-            jump_tos: Sequence[int],
-            channels: Optional[Sequence[int]] = None,
-            filename: str = 'customawgfile.awg',
-            preservechannelsettings: bool = True
+        self,
+        waveforms: Sequence[Sequence[np.ndarray]],
+        m1s: Sequence[Sequence[np.ndarray]],
+        m2s: Sequence[Sequence[np.ndarray]],
+        nreps: Sequence[int],
+        trig_waits: Sequence[int],
+        goto_states: Sequence[int],
+        jump_tos: Sequence[int],
+        channels: Sequence[int] | None = None,
+        filename: str = "customawgfile.awg",
+        preservechannelsettings: bool = True,
     ) -> None:
         """
         Makes an .awg-file, sends it to the AWG and loads it. The .awg-file
@@ -1423,17 +1417,19 @@ class TektronixAWG5014(VisaInstrument):
         loadfrom = f'{currentdir}{filename}'
         self.load_awg_file(loadfrom)
 
-    def make_and_save_awg_file(self,
-                               waveforms: Sequence[Sequence[np.ndarray]],
-                               m1s: Sequence[Sequence[np.ndarray]],
-                               m2s: Sequence[Sequence[np.ndarray]],
-                               nreps: Sequence[int],
-                               trig_waits: Sequence[int],
-                               goto_states: Sequence[int],
-                               jump_tos: Sequence[int],
-                               channels: Optional[Sequence[int]] = None,
-                               filename: str = 'customawgfile.awg',
-                               preservechannelsettings: bool = True) -> None:
+    def make_and_save_awg_file(
+        self,
+        waveforms: Sequence[Sequence[np.ndarray]],
+        m1s: Sequence[Sequence[np.ndarray]],
+        m2s: Sequence[Sequence[np.ndarray]],
+        nreps: Sequence[int],
+        trig_waits: Sequence[int],
+        goto_states: Sequence[int],
+        jump_tos: Sequence[int],
+        channels: Sequence[int] | None = None,
+        filename: str = "customawgfile.awg",
+        preservechannelsettings: bool = True,
+    ) -> None:
         """
         Makes an .awg-file and saves it locally.
 
@@ -1561,8 +1557,8 @@ class TektronixAWG5014(VisaInstrument):
     ###########################
 
     def _file_dict(
-        self, wf: np.ndarray, m1: np.ndarray, m2: np.ndarray, clock: Optional[float]
-    ) -> dict[str, Union[np.ndarray, float, None]]:
+        self, wf: np.ndarray, m1: np.ndarray, m2: np.ndarray, clock: float | None
+    ) -> dict[str, np.ndarray | float | None]:
         """
         Make a file dictionary as used by self.send_waveform_to_list
 

--- a/src/qcodes/instrument_drivers/tektronix/AWGFileParser.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWGFileParser.py
@@ -2,7 +2,7 @@
 # This module parses an awg file using THREE sub-parser. This code could
 # probably be streamlined somewhat.
 import struct
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 
@@ -298,10 +298,10 @@ _parser3_output = tuple[
     list[list[dict[Any, Any]]],
     list[list[dict[Any, Any]]],
     list[list[dict[Any, Any]]],
-    list[Union[str, int]],
-    list[Union[str, int]],
-    list[Union[str, int]],
-    list[Union[str, int]],
+    list[str | int],
+    list[str | int],
+    list[str | int],
+    list[str | int],
     list[int],
 ]
 
@@ -340,7 +340,7 @@ def _unpacker(
     return wf, m1, m2
 
 
-def _unwrap(bites: bytes, fmt: str) -> Union[str, int, tuple[Any, ...]]:
+def _unwrap(bites: bytes, fmt: str) -> str | int | tuple[Any, ...]:
     """
     Helper function for interpreting the bytes from the awg file.
 
@@ -349,7 +349,7 @@ def _unwrap(bites: bytes, fmt: str) -> Union[str, int, tuple[Any, ...]]:
         fmt: the format string (either 's', 'h' or 'd')
 
     """
-    value: Union[str, int, tuple[Any, ...]]
+    value: str | int | tuple[Any, ...]
     if fmt == 's':
         value = bites[:-1].decode('ascii')
     elif fmt == 'ignore':
@@ -394,9 +394,7 @@ awgfilepath2 = (
 
 def _parser1(
     awgfilepath: str,
-) -> tuple[
-    dict[str, Union[str, int, tuple[Any, ...]]], list[list[Any]], list[list[Any]]
-]:
+) -> tuple[dict[str, str | int | tuple[Any, ...]], list[list[Any]], list[list[Any]]]:
     """
     Helper function doing the heavy lifting of reading and understanding the
     binary .awg file format.
@@ -411,7 +409,7 @@ def _parser1(
     instdict = {}
     waveformlist: list[list[Any]] = [[], []]
     sequencelist: list[list[Any]] = [[], []]
-    wfmlen: Optional[int] = None
+    wfmlen: int | None = None
 
     with open(awgfilepath, 'rb') as fid:
 
@@ -489,7 +487,7 @@ def _parser2(waveformlist: list[list[Any]]) -> dict[str, dict[str, np.ndarray]]:
     """
 
     outdict = {}
-    name: Optional[Any] = None
+    name: Any | None = None
 
     for (fieldname, fieldvalue) in zip(waveformlist[0], waveformlist[1]):
         if 'NAME' in fieldname:
@@ -564,7 +562,7 @@ def _parser3(sequencelist: list[list[Any]], wfmdict: dict[Any, Any]) -> _parser3
 
 def parse_awg_file(
         awgfilepath: str
-) -> tuple[_parser3_output, dict[str, Union[str, int, tuple[Any, ...]]]]:
+) -> tuple[_parser3_output, dict[str, str | int | tuple[Any, ...]]]:
     """
     Parser for a binary .awg file. Returns a tuple matching the call signature
     of make_send_and_load_awg_file and a dictionary with instrument settings

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -5,8 +5,9 @@ MSO70000/C/DX Series Digital Oscilloscopes
 """
 import textwrap
 import time
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, ClassVar, Union, cast
+from typing import Any, ClassVar, cast
 
 import numpy as np
 from typing_extensions import Unpack, deprecated
@@ -430,7 +431,7 @@ class TektronixDPOChannel(InstrumentChannel):
     """
     def __init__(
         self,
-        parent: Union[Instrument, InstrumentChannel],
+        parent: Instrument | InstrumentChannel,
         name: str,
         channel_number: int,
         **kwargs: Unpack[InstrumentBaseKWArgs],
@@ -526,7 +527,7 @@ class TektronixDPOHorizontal(InstrumentChannel):
 
     def __init__(
         self,
-        parent: Union[Instrument, InstrumentChannel],
+        parent: Instrument | InstrumentChannel,
         name: str,
         **kwargs: Unpack[InstrumentBaseKWArgs],
     ) -> None:

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -5,9 +5,8 @@ MSO70000/C/DX Series Digital Oscilloscopes
 """
 import textwrap
 import time
-from collections.abc import Callable
 from functools import partial
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 from typing_extensions import Unpack, deprecated
@@ -28,6 +27,9 @@ from qcodes.parameters import (
 )
 from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.validators import Arrays, Enum
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def strip_quotes(string: str) -> str:
@@ -307,7 +309,7 @@ class TektronixDPOWaveform(InstrumentChannel):
             parameter_class=ParameterWithSetpoints
         )
 
-    def _get_cmd(self, cmd_string: str) -> Callable[[], str]:
+    def _get_cmd(self, cmd_string: str) -> "Callable[[], str]":
         """
         Parameters defined in this submodule require the correct
         data source being selected first.

--- a/src/qcodes/instrument_drivers/yokogawa/GS200.py
+++ b/src/qcodes/instrument_drivers/yokogawa/GS200.py
@@ -4,7 +4,7 @@ Will be deprecated and eventually removed.
 """
 
 from functools import partial
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal
 
 from qcodes.instrument import (
     InstrumentBaseKWArgs,
@@ -73,8 +73,8 @@ class GS200_Monitor(InstrumentChannel):
 
         # Set up mode cache. These will be filled in once the parent
         # is fully initialized.
-        self._range: Union[None, float] = None
-        self._unit: Union[None, str] = None
+        self._range: None | float = None
+        self._unit: None | str = None
 
         # Set up monitoring parameters
         if present:
@@ -573,8 +573,8 @@ class GS200(VisaInstrument):
         self.output_level.inter_delay = saved_inter_delay
 
     def _get_set_output(
-        self, mode: ModeType, output_level: Optional[float] = None
-    ) -> Optional[float]:
+        self, mode: ModeType, output_level: float | None = None
+    ) -> float | None:
         """
         Get or set the output level.
 
@@ -638,8 +638,8 @@ class GS200(VisaInstrument):
 
     def _update_measurement_module(
         self,
-        source_mode: Optional[ModeType] = None,
-        source_range: Optional[float] = None,
+        source_mode: ModeType | None = None,
+        source_range: float | None = None,
     ) -> None:
         """
         Update validators/units as source mode/range changes.

--- a/src/qcodes/instrument_drivers/yokogawa/Yokogawa_GS200.py
+++ b/src/qcodes/instrument_drivers/yokogawa/Yokogawa_GS200.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal
 
 from qcodes.instrument import (
     InstrumentBaseKWArgs,
@@ -68,8 +68,8 @@ class YokogawaGS200Monitor(InstrumentChannel):
 
         # Set up mode cache. These will be filled in once the parent
         # is fully initialized.
-        self._range: Union[None, float] = None
-        self._unit: Union[None, str] = None
+        self._range: None | float = None
+        self._unit: None | str = None
 
         # Set up monitoring parameters
         if present:
@@ -568,8 +568,8 @@ class YokogawaGS200(VisaInstrument):
         self.output_level.inter_delay = saved_inter_delay
 
     def _get_set_output(
-        self, mode: ModeType, output_level: Optional[float] = None
-    ) -> Optional[float]:
+        self, mode: ModeType, output_level: float | None = None
+    ) -> float | None:
         """
         Get or set the output level.
 
@@ -633,8 +633,8 @@ class YokogawaGS200(VisaInstrument):
 
     def _update_measurement_module(
         self,
-        source_mode: Optional[ModeType] = None,
-        source_range: Optional[float] = None,
+        source_mode: ModeType | None = None,
+        source_range: float | None = None,
     ) -> None:
         """
         Update validators/units as source mode/range changes.

--- a/src/qcodes/logger/log_analysis.py
+++ b/src/qcodes/logger/log_analysis.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import io
 import logging
-from collections.abc import Callable
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Callable, Iterator, Sequence
 
     import numpy as np
     import numpy.typing as npt

--- a/src/qcodes/logger/log_analysis.py
+++ b/src/qcodes/logger/log_analysis.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import io
 import logging
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence

--- a/src/qcodes/logger/logger.py
+++ b/src/qcodes/logger/logger.py
@@ -37,7 +37,7 @@ Envelope = Any
 
 log: logging.Logger = logging.getLogger(__name__)
 
-LevelType = Union[int, str]
+LevelType = int | str
 
 LOGGING_DIR = "logs"
 LOGGING_SEPARATOR = ' ¦ '

--- a/src/qcodes/logger/logger.py
+++ b/src/qcodes/logger/logger.py
@@ -62,8 +62,8 @@ FORMAT_STRING_DICT = OrderedDict([
 # The handler of the root logger that get set up by `start_logger` are globals
 # for this modules scope, as it is intended to only use a single file and
 # console hander.
-console_handler: Optional[logging.Handler] = None
-file_handler: Optional[logging.Handler] = None
+console_handler: logging.Handler | None = None
+file_handler: logging.Handler | None = None
 telemetry_handler: Optional["AzureLogHandler"] = None
 
 
@@ -109,7 +109,7 @@ def get_formatter_for_telemetry() -> logging.Formatter:
     return logging.Formatter(format_string)
 
 
-def get_console_handler() -> Optional[logging.Handler]:
+def get_console_handler() -> logging.Handler | None:
     """
     Get handle that prints messages from the root logger to the console.
     Returns ``None`` if :func:`start_logger` has not been called.
@@ -118,7 +118,7 @@ def get_console_handler() -> Optional[logging.Handler]:
     return console_handler
 
 
-def get_file_handler() -> Optional[logging.Handler]:
+def get_file_handler() -> logging.Handler | None:
     """
     Get a handle that streams messages from the root logger to the qcodes log
     file. To setup call :func:`start_logger`.
@@ -128,7 +128,7 @@ def get_file_handler() -> Optional[logging.Handler]:
     return file_handler
 
 
-def get_level_name(level: Union[str, int]) -> str:
+def get_level_name(level: str | int) -> str:
     """
     Get a logging level name from either a logging level code or logging level
     name. Will return the output of :func:`logging.getLevelName` if called with
@@ -145,7 +145,7 @@ def get_level_name(level: Union[str, int]) -> str:
                            'string or int.')
 
 
-def get_level_code(level: Union[str, int]) -> int:
+def get_level_code(level: str | int) -> int:
     """
     Get a logging level code from either a logging level string or a logging
     level code. Will return the output of :func:`logging.getLevelName` if
@@ -327,7 +327,7 @@ def start_logger() -> None:
     print(f'Qcodes Logfile : {filename}')
 
 
-def start_command_history_logger(log_dir: Optional[str] = None) -> None:
+def start_command_history_logger(log_dir: str | None = None) -> None:
     """
     Start logging of the history of the interactive command shell.
     Works only with IPython and Jupyter. Call function again to set new path
@@ -492,8 +492,11 @@ class LogCapture:
 
     """
 
-    def __init__(self, logger: logging.Logger = logging.getLogger(),
-                 level: Optional[LevelType] = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger = logging.getLogger(),
+        level: LevelType | None = None,
+    ) -> None:
         self.logger = logger
         self.level = level or logging.NOTSET
 
@@ -510,8 +513,8 @@ class LogCapture:
 
     def __exit__(
         self,
-        exception_type: Optional[type[BaseException]],
-        exception_value: Optional[BaseException],
+        exception_type: type[BaseException] | None,
+        exception_value: BaseException | None,
         traceback: Optional["TracebackType"],
     ) -> None:
         self.logger.removeHandler(self.string_handler)

--- a/src/qcodes/logger/logger.py
+++ b/src/qcodes/logger/logger.py
@@ -509,6 +509,8 @@ class LogCapture:
         self.string_handler = logging.StreamHandler(self.log_capture)
         self.string_handler.setLevel(self.level)
         self.logger.addHandler(self.string_handler)
+        self._stashed_logger_level = self.logger.getEffectiveLevel()
+        self.logger.setLevel(logging.NOTSET)
         return self
 
     def __exit__(
@@ -523,3 +525,4 @@ class LogCapture:
 
         for h in self.stashed_handlers:
             self.logger.addHandler(h)
+        self.logger.setLevel(self._stashed_logger_level)

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -4,7 +4,7 @@ coordinate systems.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 import numpy as np
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 AllCoordsType = tuple[float, float, float, float, float, float, float]
-NormOrder = Union[None, float, Literal["fro"], Literal["nuc"]]
+NormOrder = None | float | Literal["fro"] | Literal["nuc"]
 T = TypeVar("T", bound="FieldVector")
 
 

--- a/src/qcodes/metadatable/metadatable_base.py
+++ b/src/qcodes/metadatable/metadatable_base.py
@@ -33,7 +33,7 @@ class Metadatable:
         deep_update(self.metadata, metadata)
 
     @final
-    def snapshot(self, update: Optional[bool] = False) -> Snapshot:
+    def snapshot(self, update: bool | None = False) -> Snapshot:
         """
         Decorate a snapshot dictionary with metadata.
         DO NOT override this method if you want metadata in the snapshot
@@ -55,7 +55,7 @@ class Metadatable:
 
     def snapshot_base(
         self,
-        update: Optional[bool] = False,
+        update: bool | None = False,
         params_to_skip_update: Optional["Sequence[str]"] = None,
     ) -> Snapshot:
         """

--- a/src/qcodes/monitor/monitor.py
+++ b/src/qcodes/monitor/monitor.py
@@ -28,10 +28,11 @@ import time
 import webbrowser
 from asyncio import CancelledError
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import suppress
 from importlib.resources import as_file, files
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import websockets
 import websockets.exceptions

--- a/src/qcodes/monitor/monitor.py
+++ b/src/qcodes/monitor/monitor.py
@@ -28,7 +28,6 @@ import time
 import webbrowser
 from asyncio import CancelledError
 from collections import defaultdict
-from collections.abc import Callable
 from contextlib import suppress
 from importlib.resources import as_file, files
 from threading import Event, Thread
@@ -41,7 +40,7 @@ import websockets.server
 from qcodes.parameters import Parameter
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Sequence
+    from collections.abc import Awaitable, Callable, Sequence
 
 WEBSOCKET_PORT = 5678
 SERVER_PORT = 3000

--- a/src/qcodes/parameters/parameter.py
+++ b/src/qcodes/parameters/parameter.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from types import MethodType
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from .command import Command
 from .parameter_base import ParamDataType, ParameterBase, ParamRawDataType

--- a/src/qcodes/parameters/parameter.py
+++ b/src/qcodes/parameters/parameter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -14,6 +13,8 @@ from .parameter_base import ParamDataType, ParameterBase, ParamRawDataType
 from .sweep_values import SweepFixedValues
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from qcodes.instrument.base import InstrumentBase
     from qcodes.logger.instrument_logger import InstrumentLoggerAdapter
     from qcodes.validators import Validator

--- a/src/qcodes/plotting/auto_range.py
+++ b/src/qcodes/plotting/auto_range.py
@@ -1,7 +1,6 @@
 """
 This file holds auto ranging logic that is independent of plotting backend
 """
-from typing import Union
 
 import numpy as np
 
@@ -11,7 +10,7 @@ DEFAULT_PERCENTILE = (50, 50)
 
 def auto_range_iqr(
     data_array: np.ndarray,
-    cutoff_percentile: Union[tuple[float, float], float] = DEFAULT_PERCENTILE,
+    cutoff_percentile: tuple[float, float] | float = DEFAULT_PERCENTILE,
 ) -> tuple[float, float]:
     """
     Get the min and max range of the provided array that excludes outliers

--- a/src/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/src/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -7,7 +7,7 @@ attributes on QCoDeS instruments."""
 
 import functools
 import inspect
-from typing import Any, Optional, Union
+from typing import Any
 
 import parso
 import parso.python
@@ -74,7 +74,7 @@ def find_init_func(
 
 def parse_init_function_from_str(
     code: str, classname: str
-) -> Optional[parso.python.tree.Function]:
+) -> parso.python.tree.Function | None:
     module = parso.parse(code)
     classes = find_class(module, classname)
     if len(classes) > 1:
@@ -132,7 +132,7 @@ def eval_params_from_code(code: str, classname: str) -> dict[str, ParameterProxy
 
 def extract_code_as_repr(
     stm: parso.python.tree.ExprStmt,
-) -> Optional[tuple[str, ParameterProxy]]:
+) -> tuple[str, ParameterProxy] | None:
     lhs = stm.children[0]
     rhs = stm.get_rhs()
 
@@ -211,7 +211,7 @@ def qcodes_parameter_attr_getter(
     return attr
 
 
-def setup(app: Any) -> dict[str, Union[str, bool]]:
+def setup(app: Any) -> dict[str, str | bool]:
     """Called by sphinx to setup the extension."""
     app.setup_extension("sphinx.ext.autodoc")  # Require autodoc extension
 

--- a/src/qcodes/station.py
+++ b/src/qcodes/station.py
@@ -24,7 +24,6 @@ from typing import (
     AnyStr,
     ClassVar,
     NoReturn,
-    Union,
     cast,
     overload,
 )
@@ -85,7 +84,7 @@ def get_config_use_monitor() -> str | None:
     return qcodes.config["station"]["use_monitor"]
 
 
-ChannelOrInstrumentBase = Union[InstrumentBase, ChannelTuple]
+ChannelOrInstrumentBase = InstrumentBase | ChannelTuple
 
 
 class ValidationWarning(Warning):

--- a/src/qcodes/tests/common.py
+++ b/src/qcodes/tests/common.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import cProfile
 import os
+from collections.abc import Callable
 from functools import wraps
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import pytest
 from typing_extensions import ParamSpec

--- a/src/qcodes/tests/common.py
+++ b/src/qcodes/tests/common.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import cProfile
 import os
-from collections.abc import Callable
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -13,7 +12,7 @@ from typing_extensions import ParamSpec
 from qcodes.metadatable import MetadatableWithName
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from pathlib import Path
 
     from pytest import ExceptionInfo

--- a/src/qcodes/tests/parameter/conftest.py
+++ b/src/qcodes/tests/parameter/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import pytest
 

--- a/src/qcodes/tests/parameter/conftest.py
+++ b/src/qcodes/tests/parameter/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import pytest
@@ -11,7 +10,7 @@ from qcodes.instrument_drivers.mock_instruments import DummyChannelInstrument
 from qcodes.parameters import ParamDataType, Parameter, ParamRawDataType
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from qcodes.instrument import InstrumentBase
 

--- a/src/qcodes/utils/abstractmethod.py
+++ b/src/qcodes/utils/abstractmethod.py
@@ -1,4 +1,5 @@
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 from typing_extensions import ParamSpec
 

--- a/src/qcodes/utils/abstractmethod.py
+++ b/src/qcodes/utils/abstractmethod.py
@@ -1,13 +1,17 @@
-from collections.abc import Callable
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 input = ParamSpec("input")
 output = TypeVar("output")
 
 
-def qcodes_abstractmethod(funcobj: Callable[input, output]) -> Callable[input, output]:
+def qcodes_abstractmethod(
+    funcobj: "Callable[input, output]",
+) -> "Callable[input, output]":
     """
     A decorator indicating abstract methods.
 

--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -108,7 +108,7 @@ def strip_attrs(obj: object, whitelist: "Sequence[str]" = ()) -> None:
 
 
 def checked_getattr(
-    instance: Any, attribute: str, expected_type: Union[type, tuple[type, ...]]
+    instance: Any, attribute: str, expected_type: type | tuple[type, ...]
 ) -> Any:
     """
     Like ``getattr`` but raises type error if not of expected type.
@@ -150,7 +150,7 @@ def getattr_indexed(instance: Any, attribute: str) -> Any:
 
 
 def checked_getattr_indexed(
-    instance: Any, attribute: str, expected_type: Union[type, tuple[type, ...]]
+    instance: Any, attribute: str, expected_type: type | tuple[type, ...]
 ) -> Any:
     """
     Like ``getattr_indexed`` but raises type error if not of expected type.

--- a/src/qcodes/utils/deep_update_utils.py
+++ b/src/qcodes/utils/deep_update_utils.py
@@ -1,7 +1,7 @@
 from collections import abc
 from collections.abc import Hashable, Mapping, MutableMapping
 from copy import deepcopy
-from typing import Any, TypeVar, Union, cast
+from typing import Any, TypeVar, cast
 
 K = TypeVar("K", bound=Hashable)
 L = TypeVar("L", bound=Hashable)
@@ -9,7 +9,7 @@ L = TypeVar("L", bound=Hashable)
 
 def deep_update(
     dest: MutableMapping[K, Any], update: Mapping[L, Any]
-) -> MutableMapping[Union[K, L], Any]:
+) -> MutableMapping[K | L, Any]:
     """
     Recursively update one JSON structure with another.
 
@@ -17,7 +17,7 @@ def deep_update(
     If the original value is a dictionary and the new value is not, or vice versa,
     we also replace the value completely.
     """
-    dest_int = cast(MutableMapping[Union[K, L], Any], dest)
+    dest_int = cast(MutableMapping[K | L, Any], dest)
     for k, v_update in update.items():
         v_dest = dest_int.get(k)
         if isinstance(v_update, abc.Mapping) and isinstance(v_dest, abc.MutableMapping):

--- a/src/qcodes/utils/delaykeyboardinterrupt.py
+++ b/src/qcodes/utils/delaykeyboardinterrupt.py
@@ -1,9 +1,11 @@
 import logging
 import signal
 import threading
-from collections.abc import Callable
 from types import FrameType, TracebackType
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +23,7 @@ class DelayedKeyboardInterrupt:
     signal_received: tuple[int, FrameType | None] | None = None
     # the handler type is seemingly only defined in typesheeed so copy it here
     # manually https://github.com/python/typeshed/blob/main/stdlib/signal.pyi
-    old_handler: Callable[[int, FrameType | None], Any] | int | None = None
+    old_handler: "Callable[[int, FrameType | None], Any] | int | None" = None
 
     def __enter__(self) -> None:
         is_main_thread = threading.current_thread() is threading.main_thread()

--- a/src/qcodes/utils/deprecate.py
+++ b/src/qcodes/utils/deprecate.py
@@ -1,7 +1,8 @@
 import types
 import warnings
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import wrapt  # type: ignore[import-untyped]
 
@@ -17,9 +18,7 @@ class QCoDeSDeprecationWarning(RuntimeWarning):
 
 
 def deprecation_message(
-    what: str,
-    reason: Optional[str] = None,
-    alternative: Optional[str] = None
+    what: str, reason: str | None = None, alternative: str | None = None
 ) -> str:
     msg = f'The {what} is deprecated'
     if reason is not None:
@@ -32,8 +31,8 @@ def deprecation_message(
 
 def issue_deprecation_warning(
     what: str,
-    reason: Optional[str] = None,
-    alternative: Optional[str] = None,
+    reason: str | None = None,
+    alternative: str | None = None,
     stacklevel: int = 3,
 ) -> None:
     """
@@ -46,8 +45,7 @@ def issue_deprecation_warning(
 
 
 def deprecate(
-        reason: Optional[str] = None,
-        alternative: Optional[str] = None
+    reason: str | None = None, alternative: str | None = None
 ) -> Callable[..., Any]:
     """
     A utility function to decorate deprecated functions and classes.

--- a/src/qcodes/utils/installation_info.py
+++ b/src/qcodes/utils/installation_info.py
@@ -7,7 +7,6 @@ import json
 import logging
 import subprocess
 import sys
-from typing import Optional
 
 if sys.version_info >= (3, 10):
     # distribution.name used below became part of the
@@ -21,14 +20,14 @@ else:
 log = logging.getLogger(__name__)
 
 
-def is_qcodes_installed_editably() -> Optional[bool]:
+def is_qcodes_installed_editably() -> bool | None:
     """
     Try to ask pip whether QCoDeS is installed in editable mode and return
     the answer a boolean. Returns None if pip somehow did not respond as
     expected.
     """
 
-    answer: Optional[bool]
+    answer: bool | None
 
     try:
         pipproc = subprocess.run(['python', '-m', 'pip', 'list', '-e', '--no-index',

--- a/src/qcodes/utils/installation_info.py
+++ b/src/qcodes/utils/installation_info.py
@@ -6,16 +6,7 @@ QCoDeS
 import json
 import logging
 import subprocess
-import sys
-
-if sys.version_info >= (3, 10):
-    # distribution.name used below became part of the
-    # official api in 3.10
-    from importlib.metadata import distributions
-else:
-    # 3.9 and earlier
-    from importlib_metadata import distributions
-
+from importlib.metadata import distributions
 
 log = logging.getLogger(__name__)
 

--- a/src/qcodes/utils/partial_utils.py
+++ b/src/qcodes/utils/partial_utils.py
@@ -1,11 +1,13 @@
-from collections.abc import Callable
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def partial_with_docstring(
-    func: Callable[..., Any], docstring: str, **kwargs: Any
-) -> Callable[..., Any]:
+    func: "Callable[..., Any]", docstring: str, **kwargs: Any
+) -> "Callable[..., Any]":
     """
     We want to have a partial function which will allow us to access the docstring
     through the python built-in help function. This is particularly important

--- a/src/qcodes/utils/partial_utils.py
+++ b/src/qcodes/utils/partial_utils.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable
+from typing import Any
 
 
 def partial_with_docstring(

--- a/src/qcodes/utils/snapshot_helpers.py
+++ b/src/qcodes/utils/snapshot_helpers.py
@@ -1,13 +1,10 @@
-from typing import Any, NamedTuple, TypeVar, Union
+from typing import Any, NamedTuple, TypeVar
 
 T = TypeVar("T")
 
-ParameterKey = Union[
-    # Unbound parameters
-    str,
-    # Instrument parameters
-    tuple[str, str],
-]
+# Unbound parameters or Instrument parameters
+ParameterKey = str | tuple[str, str]
+
 ParameterDict = dict[ParameterKey, T]
 Snapshot = dict[str, Any]
 

--- a/src/qcodes/utils/threading_utils.py
+++ b/src/qcodes/utils/threading_utils.py
@@ -1,10 +1,9 @@
 import logging
 import threading
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 _LOG = logging.getLogger(__name__)
 
@@ -30,7 +29,7 @@ class RespondingThread(threading.Thread, Generic[T]):
 
     def __init__(
         self,
-        target: Callable[..., T],
+        target: "Callable[..., T]",
         args: "Sequence[Any]" = (),
         kwargs: dict[str, Any] | None = None,
         *args2: Any,

--- a/src/qcodes/utils/threading_utils.py
+++ b/src/qcodes/utils/threading_utils.py
@@ -1,6 +1,7 @@
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -31,7 +32,7 @@ class RespondingThread(threading.Thread, Generic[T]):
         self,
         target: Callable[..., T],
         args: "Sequence[Any]" = (),
-        kwargs: Optional[dict[str, Any]] = None,
+        kwargs: dict[str, Any] | None = None,
         *args2: Any,
         **kwargs2: Any,
     ):
@@ -43,8 +44,8 @@ class RespondingThread(threading.Thread, Generic[T]):
         self._target = target
         self._args = args
         self._kwargs = kwargs
-        self._exception: Optional[Exception] = None
-        self._output: Optional[T] = None
+        self._exception: Exception | None = None
+        self._output: T | None = None
 
     def run(self) -> None:
         _LOG.debug(f"Executing {self._target} on thread: {threading.get_ident()}")
@@ -53,7 +54,7 @@ class RespondingThread(threading.Thread, Generic[T]):
         except Exception as e:
             self._exception = e
 
-    def output(self, timeout: Optional[float] = None) -> Optional[T]:
+    def output(self, timeout: float | None = None) -> T | None:
         self.join(timeout=timeout)
 
         if self._exception:
@@ -68,7 +69,7 @@ def thread_map(
     callables: "Sequence[Callable[..., T]]",
     args: Optional["Sequence[Sequence[Any]]"] = None,
     kwargs: Optional["Sequence[dict[str, Any]]"] = None,
-) -> list[Optional[T]]:
+) -> list[T | None]:
     """
     Evaluate a sequence of callables in separate threads, returning
     a list of their return values.

--- a/src/qcodes/utils/types.py
+++ b/src/qcodes/utils/types.py
@@ -3,11 +3,9 @@ Useful collections of types used around QCoDeS
 """
 from __future__ import annotations
 
-from typing import Union
-
 import numpy as np
 
-complex_type_union = Union[np.complex64, np.complex128, np.complexfloating, complex]
+complex_type_union = np.complex64 | np.complex128 | np.complexfloating | complex
 
 
 numpy_concrete_ints = (np.int8, np.int16, np.int32, np.int64,

--- a/src/qcodes/validators/validators.py
+++ b/src/qcodes/validators/validators.py
@@ -8,16 +8,16 @@ import math
 import typing
 from collections import abc
 from collections.abc import Hashable
-from typing import Any, Generic, Literal, Optional, TypeVar, Union, cast
+from typing import Any, Generic, Literal, TypeVar, Union, cast
 
 import numpy as np
 
 BIGSTRING = 1000000000
 BIGINT = int(1e18)
 
-numbertypes = Union[float, int, np.floating, np.integer]
-shape_type = Union[int, typing.Callable[[], int]]
-shape_tuple_type = Optional[tuple[shape_type, ...]]
+numbertypes = float | int | np.floating | np.integer
+shape_type = int | typing.Callable[[], int]
+shape_tuple_type = tuple[shape_type, ...] | None
 
 
 def validate_all(*args: tuple[Validator[Any], Any], context: str = "") -> None:
@@ -152,7 +152,7 @@ class Nothing(Validator[Any]):
         self._reason = reason
 
 
-class Bool(Validator[Union[bool, np.bool_]]):
+class Bool(Validator[bool | np.bool_]):
     """
     Requires a boolean.
     """
@@ -326,7 +326,7 @@ class Ints(Validator[Union[int, "np.integer[Any]", bool]]):
     """
 
     validtypes = (int, np.integer)
-    inttypes = Union[int, np.integer]
+    inttypes = int | np.integer
 
     def __init__(
         self, min_value: inttypes = -BIGINT, max_value: inttypes = BIGINT

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import cProfile
 import os
-from collections.abc import Callable
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -13,6 +12,7 @@ from typing_extensions import ParamSpec
 from qcodes.metadatable import MetadatableWithName
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from pytest import ExceptionInfo

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import cProfile
 import os
+from collections.abc import Callable
 from functools import wraps
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import pytest
 from typing_extensions import ParamSpec

--- a/tests/dataset/test_database_extract_runs.py
+++ b/tests/dataset/test_database_extract_runs.py
@@ -2,10 +2,10 @@ import os
 import random
 import re
 import uuid
-from collections.abc import Callable
 from contextlib import contextmanager
 from os.path import getmtime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -36,6 +36,9 @@ from qcodes.dataset.sqlite.queries import get_experiments
 from qcodes.instrument_drivers.mock_instruments import DummyInstrument
 from qcodes.station import Station
 from tests.common import error_caused_by, skip_if_no_fixtures
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @contextmanager

--- a/tests/dataset/test_database_extract_runs.py
+++ b/tests/dataset/test_database_extract_runs.py
@@ -2,10 +2,10 @@ import os
 import random
 import re
 import uuid
+from collections.abc import Callable
 from contextlib import contextmanager
 from os.path import getmtime
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 import pytest

--- a/tests/dataset/test_datasaver.py
+++ b/tests/dataset/test_datasaver.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -8,6 +8,9 @@ from qcodes.dataset import new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.measurements import DataSaver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 CALLBACK_COUNT = 0
 CALLBACK_RUN_ID = None

--- a/tests/dataset/test_datasaver.py
+++ b/tests/dataset/test_datasaver.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/tests/dataset/test_dataset_basic.py
+++ b/tests/dataset/test_dataset_basic.py
@@ -2,7 +2,7 @@ import io
 import random
 import re
 from copy import copy
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -1308,8 +1308,8 @@ def parameter_test_helper(
     expected_names: dict[str, list[str]],
     expected_shapes: dict[str, list[tuple[int, ...]]],
     expected_values: dict[str, list[np.ndarray]],
-    start: Optional[int] = None,
-    end: Optional[int] = None,
+    start: int | None = None,
+    end: int | None = None,
 ):
     """
     A helper function to compare the data we actually read out of a given

--- a/tests/dataset/test_nested_measurements.py
+++ b/tests/dataset/test_nested_measurements.py
@@ -1,4 +1,3 @@
-from typing import Union
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -12,7 +11,7 @@ from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.sqlite.connection import atomic_transaction
 from tests.common import retry_until_does_not_throw
 
-VALUE = Union[str, float, list, np.ndarray, bool]
+VALUE = str | float | list | np.ndarray | bool
 
 
 @pytest.mark.usefixtures("experiment")

--- a/tests/dataset/test_subscribing.py
+++ b/tests/dataset/test_subscribing.py
@@ -1,7 +1,7 @@
 # Test some subscription scenarios
 import logging
 from numbers import Number
-from typing import Any, Union
+from typing import Any
 
 import pytest
 from numpy import ndarray
@@ -14,7 +14,7 @@ from tests.common import retry_until_does_not_throw
 
 log = logging.getLogger(__name__)
 
-VALUE = Union[str, Number, list[Any], ndarray, bool]
+VALUE = str | Number | list[Any] | ndarray | bool
 
 
 class MockSubscriber:

--- a/tests/drivers/test_lakeshore.py
+++ b/tests/drivers/test_lakeshore.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 import time
 import warnings
-from collections.abc import Callable
 from contextlib import suppress
 from functools import wraps
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import pytest
 from typing_extensions import ParamSpec
@@ -18,6 +17,9 @@ from qcodes.instrument_drivers.Lakeshore.lakeshore_base import (
 from qcodes.instrument_drivers.Lakeshore.Model_372 import Model_372
 from qcodes.logger import get_instrument_logger
 from qcodes.utils import QCoDeSDeprecationWarning
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 log = logging.getLogger(__name__)
 

--- a/tests/drivers/test_lakeshore.py
+++ b/tests/drivers/test_lakeshore.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 import time
 import warnings
+from collections.abc import Callable
 from contextlib import suppress
 from functools import wraps
-from typing import Any, Callable, Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 import pytest
 from typing_extensions import ParamSpec

--- a/tests/parameter/conftest.py
+++ b/tests/parameter/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import pytest
 

--- a/tests/parameter/conftest.py
+++ b/tests/parameter/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import pytest
@@ -11,7 +10,7 @@ from qcodes.instrument_drivers.mock_instruments import DummyChannelInstrument
 from qcodes.parameters import ParamDataType, Parameter, ParamRawDataType
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from qcodes.instrument import InstrumentBase
 

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -3,7 +3,8 @@ Test suite for DelegateParameter
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import hypothesis.strategies as hst
 import pytest

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -3,7 +3,6 @@ Test suite for DelegateParameter
 """
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import hypothesis.strategies as hst
@@ -16,7 +15,7 @@ from qcodes.parameters import DelegateParameter, Parameter, ParamRawDataType
 from .conftest import BetterGettableParam
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
 
 @pytest.fixture(name="numeric_val")

--- a/tests/parameter/test_get_set_wrapping.py
+++ b/tests/parameter/test_get_set_wrapping.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
@@ -13,6 +12,9 @@ from .conftest import (
     OverwriteSetParam,
     ParameterMemory,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_parameter_with_overwritten_get_raises() -> None:

--- a/tests/parameter/test_get_set_wrapping.py
+++ b/tests/parameter/test_get_set_wrapping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Literal
+from collections.abc import Callable
+from typing import Any, Literal
 
 import pytest
 

--- a/tests/parameter/test_group_parameter.py
+++ b/tests/parameter/test_group_parameter.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -17,11 +17,14 @@ def close_all_instruments():
 
 
 class Dummy(Instrument):
-    def __init__(self, name: str,
-                 initial_a: Optional[int] = None,
-                 initial_b: Optional[int] = None,
-                 scale_a: Optional[float] = None,
-                 get_cmd: Optional[str] = "CMD?") -> None:
+    def __init__(
+        self,
+        name: str,
+        initial_a: int | None = None,
+        initial_b: int | None = None,
+        scale_a: float | None = None,
+        get_cmd: str | None = "CMD?",
+    ) -> None:
         super().__init__(name)
 
         self._a = 0

--- a/tests/parameter/test_snapshot.py
+++ b/tests/parameter/test_snapshot.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Callable, Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 from typing_extensions import ParamSpec
 

--- a/tests/parameter/test_snapshot.py
+++ b/tests/parameter/test_snapshot.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from typing_extensions import ParamSpec
 
 from qcodes.parameters import Parameter
 
 from .conftest import NOT_PASSED
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/tests/test_autoloadable_channels.py
+++ b/tests/test_autoloadable_channels.py
@@ -6,8 +6,7 @@ mean a physical instrument channel, but rather an instrument sub-module.
 """
 
 import re
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -16,6 +15,9 @@ from qcodes.instrument.channel import (
     AutoLoadableChannelList,
     AutoLoadableInstrumentChannel,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class MockBackendBase:

--- a/tests/test_autoloadable_channels.py
+++ b/tests/test_autoloadable_channels.py
@@ -6,7 +6,8 @@ mean a physical instrument channel, but rather an instrument sub-module.
 """
 
 import re
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
@@ -126,7 +127,7 @@ class SimpleTestChannel(AutoLoadableInstrumentChannel):
 
     @classmethod
     def _get_new_instance_kwargs(
-            cls, parent: Optional[Instrument] = None, **kwargs
+        cls, parent: Instrument | None = None, **kwargs
     ) -> dict[Any, Any]:
         """
         Find the smallest channel number not yet occupied. An optional keyword
@@ -150,13 +151,13 @@ class SimpleTestChannel(AutoLoadableInstrumentChannel):
         return new_kwargs
 
     def __init__(
-            self,
-            parent: Union[Instrument, InstrumentChannel],
-            name: str,
-            channel: int,
-            greeting: str,
-            existence: bool = False,
-            channel_list: Optional[AutoLoadableChannelList] = None,
+        self,
+        parent: Instrument | InstrumentChannel,
+        name: str,
+        channel: int,
+        greeting: str,
+        existence: bool = False,
+        channel_list: AutoLoadableChannelList | None = None,
     ) -> None:
 
         super().__init__(parent, name, existence, channel_list)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -59,8 +59,9 @@ class EmptyChannel(InstrumentChannel):
     pass
 
 
-def test_instrument_channel_label() -> None:
+def test_instrument_channel_label(request) -> None:
     dci = DummyChannelInstrument(name="dci_with_labels", label="Instrument Label")
+    request.addfinalizer(dci.close)
     channel = DummyChannel(dci, "A_with_label", "A_wl", label="A with f@ncy label")
     dci.add_submodule("A_with_label", channel)
     channel_2 = EmptyChannel(dci, "B_with_label", label="B with f@ncy label")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -142,9 +142,8 @@ def test_start_logger_twice() -> None:
     logger.start_logger()
     logger.start_logger()
     handlers = root_logger.handlers
-    # there is one or two loggers registered from pytest
-    # depending on the version
-    # and the telemetry logger is always off in the tests
+    # we expect there to be two log handlers file+console
+    # plus the existing ones from pytest
     assert len(handlers) == 2 + NUM_PYTEST_LOGGERS
 
 
@@ -156,6 +155,7 @@ def test_set_level_without_starting_raises() -> None:
 
 
 def test_handler_level() -> None:
+    logger.start_logger()
     with logger.LogCapture(level=logging.INFO) as logs:
         logging.debug(TEST_LOG_MESSAGE)
     assert logs.value == ""

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -5,7 +5,6 @@ import warnings
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from ruamel.yaml import YAML
@@ -449,7 +448,7 @@ def test_simple_mock_load_instrument(simple_mock_station) -> None:
 
 
 def test_enable_force_reconnect() -> None:
-    def get_instrument_config(enable_forced_reconnect: Optional[bool]) -> str:
+    def get_instrument_config(enable_forced_reconnect: bool | None) -> str:
         return f"""
 instruments:
   mock:
@@ -462,8 +461,8 @@ instruments:
 
     def assert_on_reconnect(
         *,
-        use_user_cfg: Optional[bool],
-        use_instr_cfg: Optional[bool],
+        use_user_cfg: bool | None,
+        use_instr_cfg: bool | None,
         expect_failure: bool,
     ) -> None:
         qcodes.config["station"]["enable_forced_reconnect"] = use_user_cfg

--- a/tests/test_visa.py
+++ b/tests/test_visa.py
@@ -2,7 +2,7 @@ import gc
 import logging
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 import pyvisa
@@ -24,7 +24,7 @@ class MockVisa(VisaInstrument):
                            vals=Numbers(-20, 20))
 
     def _open_resource(
-        self, address: str, visalib: Optional[str]
+        self, address: str, visalib: str | None
     ) -> tuple[pyvisa.resources.MessageBasedResource, str, pyvisa.ResourceManager]:
         if visalib is None:
             visalib = "MockVisaLib"
@@ -57,8 +57,8 @@ class MockVisaHandle(pyvisa.resources.MessageBasedResource):
     def write(
         self,
         message: str,
-        termination: Optional[str] = None,
-        encoding: Optional[str] = None,
+        termination: str | None = None,
+        encoding: str | None = None,
     ) -> int:
         if self.closed:
             raise RuntimeError("Trying to write to a closed instrument")
@@ -80,7 +80,7 @@ class MockVisaHandle(pyvisa.resources.MessageBasedResource):
             raise ValueError("I'm out of fingers")
         return self.state
 
-    def query(self, message: str, delay: Optional[float] = None) -> str:
+    def query(self, message: str, delay: float | None = None) -> str:
         if self.state > 10:
             raise ValueError("I'm out of fingers")
         return str(self.state)

--- a/tests/validators/test_ints.py
+++ b/tests/validators/test_ints.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -10,6 +9,9 @@ import pytest
 from qcodes.validators import Ints
 
 from .conftest import AClass, a_func
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 ints: tuple[int | bool | np.int64, ...] = (
     0,

--- a/tests/validators/test_ints.py
+++ b/tests/validators/test_ints.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import pytest

--- a/tests/validators/test_lists.py
+++ b/tests/validators/test_lists.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -20,7 +20,7 @@ def test_type() -> None:
 
 def test_elt_vals() -> None:
     list_validator = Lists(Ints(max_value=10))
-    v1: list[Union[int, np.integer, bool]] = [0, 1, 5]
+    v1: list[int | np.integer | bool] = [0, 1, 5]
     list_validator.validate(v1)
 
     v2 = [0, 1, 11]

--- a/tests/validators/test_multiples.py
+++ b/tests/validators/test_multiples.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 import numpy as np
 import pytest

--- a/tests/validators/test_multiples.py
+++ b/tests/validators/test_multiples.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pytest
@@ -10,6 +9,9 @@ import pytest
 from qcodes.validators import Multiples
 
 from .conftest import AClass, a_func
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 divisors = (3, 7, 11, 13)
 not_divisors: tuple[


### PR DESCRIPTION
Most of the scientific python stack has adopted [SPEC 0](https://scientific-python.org/specs/spec-0000/) which means that python 3.9 support should be dropped from late 2023. As an example we can see in https://github.com/QCoDeS/Qcodes/pull/5602 that Ipython has dropped support for 3.9.

This is to propose that QCoDeS also drops support for 3.9 

- [x] This should also update the readme
- [x] Remove 3.9 ci jobs