### PR TITLE
Avoid roundtrip to qcodes format when loading as xarray from netcdf

### DIFF
--- a/docs/changes/newsfragments/5627.improved
+++ b/docs/changes/newsfragments/5627.improved
@@ -1,3 +1,3 @@
 When loading a QCoDeS dataset from a netcdf file using load_from_netcdf and converted to a Xarray dataset using
 ``to_xarray_dataset`` or ``cache.to_xarray_dataset`` we avoid converting the data to QCoDeS format and back to Xarray format.
-This should safe time and avoid any potential corner cases when roundtripping the data.
+This should save time and avoid any potential corner cases when roundtripping the data.

--- a/docs/changes/newsfragments/5627.improved
+++ b/docs/changes/newsfragments/5627.improved
@@ -1,0 +1,3 @@
+When loading a QCoDeS dataset from a netcdf file using load_from_netcdf and converted to a Xarray dataset using
+``to_xarray_dataset`` or ``cache.to_xarray_dataset`` we avoid converting the data to QCoDeS format and back to Xarray format.
+This should safe time and avoid any potential corner cases when roundtripping the data.

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -465,6 +465,18 @@ class DataSetCacheDeferred(DataSetCacheInMem):
             )
 
 
+    def to_xarray_dataset(
+        self, *, use_multi_index: Literal["auto", "always", "never"] = "auto"
+    ) -> xr.Dataset:
+        if use_multi_index == "always":
+            ds = self._xr_dataset.stack()
+        elif use_multi_index == "never":
+            ds = self._xr_dataset.unstack()
+        else:
+            ds = self._xr_dataset
+        return ds
+
+
 class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
     def load_data_from_db(self) -> None:
         """

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -456,9 +456,9 @@ class DataSetCacheInMem(DataSetCache["DataSetInMem"]):
 
 
 class DataSetCacheDeferred(DataSetCacheInMem):
-    def __init__(self, dataset: DataSetInMem, loaded_data: Path):
+    def __init__(self, dataset: DataSetInMem, loaded_data: Path | str):
         super().__init__(dataset)
-        self._xr_dataset_path = loaded_data
+        self._xr_dataset_path = Path(loaded_data)
 
     def load_data_from_db(self) -> None:
         if self._data == {}:

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     # used in forward refs that cannot be detected
     from .data_set import DataSet  # noqa F401
-    from .data_set_in_memory import DataSetInMem  # noqa F401
+    from .data_set_in_memory import DataSetInMem
     from .data_set_protocol import DataSetProtocol, ParameterData
 
 DatasetType = TypeVar("DatasetType", bound="DataSetProtocol", covariant=True)
@@ -451,6 +451,18 @@ def _expand_single_param_dict(
 
 class DataSetCacheInMem(DataSetCache["DataSetInMem"]):
     pass
+
+
+class DataSetCacheDeferred(DataSetCacheInMem):
+    def __init__(self, dataset: DataSetInMem, loaded_data: xr.Dataset):
+        super().__init__(dataset)
+        self._xr_dataset = loaded_data
+
+    def load_data_from_db(self) -> None:
+        if self._data == {}:
+            self._data = self._dataset._from_xarray_dataset_to_qcodes_raw_data(
+                self._xr_dataset
+            )
 
 
 class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 import numpy as np
 
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
+from qcodes.dataset.exporters.export_info import ExportInfo
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.dataset.sqlite.queries import completed, load_new_data_for_rundescriber
 
@@ -454,26 +456,38 @@ class DataSetCacheInMem(DataSetCache["DataSetInMem"]):
 
 
 class DataSetCacheDeferred(DataSetCacheInMem):
-    def __init__(self, dataset: DataSetInMem, loaded_data: xr.Dataset):
+    def __init__(self, dataset: DataSetInMem, loaded_data: Path):
         super().__init__(dataset)
-        self._xr_dataset = loaded_data
+        self._xr_dataset_path = loaded_data
 
     def load_data_from_db(self) -> None:
         if self._data == {}:
+            loaded_data = self._load_xr_dataset()
             self._data = self._dataset._from_xarray_dataset_to_qcodes_raw_data(
-                self._xr_dataset
+                loaded_data
             )
 
+    def _load_xr_dataset(self) -> xr.Dataset:
+        import cf_xarray as cfxr
+        import xarray as xr
+
+        loaded_data = xr.load_dataset(self._xr_dataset_path, engine="h5netcdf")
+        loaded_data = cfxr.coding.decode_compress_to_multi_index(loaded_data)
+        export_info = ExportInfo.from_str(loaded_data.attrs.get("export_info", ""))
+        export_info.export_paths["nc"] = str(self._xr_dataset_path)
+        loaded_data.attrs["export_info"] = export_info.to_str()
+        return loaded_data
 
     def to_xarray_dataset(
         self, *, use_multi_index: Literal["auto", "always", "never"] = "auto"
     ) -> xr.Dataset:
+        loaded_data = self._load_xr_dataset()
         if use_multi_index == "always":
-            ds = self._xr_dataset.stack()
+            ds = loaded_data.stack()
         elif use_multi_index == "never":
-            ds = self._xr_dataset.unstack()
+            ds = loaded_data.unstack()
         else:
-            ds = self._xr_dataset
+            ds = loaded_data
         return ds
 
 

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -44,7 +44,7 @@ from qcodes.dataset.sqlite.queries import (
 )
 from qcodes.utils import NumpyJSONEncoder
 
-from .data_set_cache import DataSetCacheInMem
+from .data_set_cache import DataSetCacheDeferred, DataSetCacheInMem
 from .dataset_helpers import _add_run_to_runs_table
 from .descriptions.versioning import serialization as serial
 from .experiment_settings import get_default_experiment_id
@@ -298,8 +298,7 @@ class DataSetInMem(BaseDataSet):
             export_info=export_info,
             snapshot=loaded_data.snapshot,
         )
-        ds._cache = DataSetCacheInMem(ds)
-        ds._cache._data = cls._from_xarray_dataset_to_qcodes_raw_data(loaded_data)
+        ds._cache = DataSetCacheDeferred(ds, loaded_data)
 
         return ds
 

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -228,77 +228,74 @@ class DataSetInMem(BaseDataSet):
         # in the code below floats and ints loaded from attributes are explicitly casted
         # this is due to some older versions of qcodes writing them with a different backend
         # reading them back results in a numpy array of one element
-        import cf_xarray as cfxr
         import xarray as xr
 
-        loaded_data = xr.load_dataset(path, engine="h5netcdf")
+        with xr.open_dataset(path, engine="h5netcdf") as loaded_data:
 
-        loaded_data = cfxr.coding.decode_compress_to_multi_index(loaded_data)
+            parent_dataset_links = str_to_links(
+                loaded_data.attrs.get("parent_dataset_links", "[]")
+            )
+            if path_to_db is not None:
+                path_to_db = str(path_to_db)
 
-        parent_dataset_links = str_to_links(
-            loaded_data.attrs.get("parent_dataset_links", "[]")
-        )
-        if path_to_db is not None:
-            path_to_db = str(path_to_db)
+            with contextlib.closing(
+                conn_from_dbpath_or_conn(conn=None, path_to_db=path_to_db)
+            ) as conn:
+                run_data = get_raw_run_attributes(conn, guid=loaded_data.guid)
+                path_to_db = conn.path_to_dbfile
 
-        with contextlib.closing(
-            conn_from_dbpath_or_conn(conn=None, path_to_db=path_to_db)
-        ) as conn:
-            run_data = get_raw_run_attributes(conn, guid=loaded_data.guid)
-            path_to_db = conn.path_to_dbfile
+            if run_data is not None:
+                run_id = run_data["run_id"]
+                counter = run_data["counter"]
+            else:
+                run_id = int(loaded_data.captured_run_id)
+                counter = int(loaded_data.captured_counter)
 
-        if run_data is not None:
-            run_id = run_data["run_id"]
-            counter = run_data["counter"]
-        else:
-            run_id = int(loaded_data.captured_run_id)
-            counter = int(loaded_data.captured_counter)
+            path = str(path)
+            path = os.path.abspath(path)
 
-        path = str(path)
-        path = os.path.abspath(path)
+            export_info = ExportInfo.from_str(loaded_data.attrs.get("export_info", ""))
+            export_info.export_paths["nc"] = path
+            non_metadata = {
+                "run_timestamp_raw",
+                "completed_timestamp_raw",
+                "ds_name",
+                "exp_name",
+                "sample_name",
+                "export_info",
+                "parent_dataset_links",
+            }
 
-        export_info = ExportInfo.from_str(loaded_data.attrs.get("export_info", ""))
-        export_info.export_paths["nc"] = path
-        non_metadata = {
-            "run_timestamp_raw",
-            "completed_timestamp_raw",
-            "ds_name",
-            "exp_name",
-            "sample_name",
-            "export_info",
-            "parent_dataset_links",
-        }
+            metadata_keys = (
+                set(loaded_data.attrs.keys()) - set(RUNS_TABLE_COLUMNS) - non_metadata
+            )
+            metadata = {}
+            for key in metadata_keys:
+                data = loaded_data.attrs[key]
+                if isinstance(data, np.ndarray) and data.size == 1:
+                    data = data[0]
+                metadata[str(key)] = data
 
-        metadata_keys = (
-            set(loaded_data.attrs.keys()) - set(RUNS_TABLE_COLUMNS) - non_metadata
-        )
-        metadata = {}
-        for key in metadata_keys:
-            data = loaded_data.attrs[key]
-            if isinstance(data, np.ndarray) and data.size == 1:
-                data = data[0]
-            metadata[str(key)] = data
-
-        ds = cls(
-            run_id=run_id,
-            captured_run_id=int(loaded_data.captured_run_id),
-            counter=counter,
-            captured_counter=int(loaded_data.captured_counter),
-            name=loaded_data.ds_name,
-            exp_id=0,
-            exp_name=loaded_data.exp_name,
-            sample_name=loaded_data.sample_name,
-            guid=loaded_data.guid,
-            path_to_db=path_to_db,
-            run_timestamp_raw=float(loaded_data.run_timestamp_raw),
-            completed_timestamp_raw=float(loaded_data.completed_timestamp_raw),
-            metadata=metadata,
-            rundescriber=serial.from_json_to_current(loaded_data.run_description),
-            parent_dataset_links=parent_dataset_links,
-            export_info=export_info,
-            snapshot=loaded_data.snapshot,
-        )
-        ds._cache = DataSetCacheDeferred(ds, loaded_data)
+            ds = cls(
+                run_id=run_id,
+                captured_run_id=int(loaded_data.captured_run_id),
+                counter=counter,
+                captured_counter=int(loaded_data.captured_counter),
+                name=loaded_data.ds_name,
+                exp_id=0,
+                exp_name=loaded_data.exp_name,
+                sample_name=loaded_data.sample_name,
+                guid=loaded_data.guid,
+                path_to_db=path_to_db,
+                run_timestamp_raw=float(loaded_data.run_timestamp_raw),
+                completed_timestamp_raw=float(loaded_data.completed_timestamp_raw),
+                metadata=metadata,
+                rundescriber=serial.from_json_to_current(loaded_data.run_description),
+                parent_dataset_links=parent_dataset_links,
+                export_info=export_info,
+                snapshot=loaded_data.snapshot,
+            )
+            ds._cache = DataSetCacheDeferred(ds, path)
 
         return ds
 

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -1187,8 +1187,7 @@ def test_inverted_coords_perserved_on_netcdf_roundtrip(
     file_path = os.path.join(path, expected_path)
     ds = load_from_netcdf(file_path)
 
-    with pytest.warns(UserWarning):
-        xr_ds_reimported = ds.to_xarray_dataset()
+    xr_ds_reimported = ds.to_xarray_dataset()
 
     assert xr_ds_reimported["z1"].dims == ("x", "y")
     assert xr_ds_reimported["z2"].dims == ("y", "x")


### PR DESCRIPTION
Todo

- [x] add tests that calling to_xarray_dataset does not trigger the conversion code 
- [x] Newsfragment