### PR TITLE
Add precommit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit hooks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'release/*'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
After moving to the Microsoft org we no longer can use the precommit-ci bot so we will do precommit hooks manually in github actions