### PR TITLE
More robust converting to pandas / xarray

### DIFF
--- a/docs/changes/newsfragments/5641.improved
+++ b/docs/changes/newsfragments/5641.improved
@@ -1,0 +1,1 @@
+Fixed an issue where datasets with categorical setpoints could fail to correctly export to Pandas dataframes or Xarray dataset.


### PR DESCRIPTION
Handle that we could see coordinates of dtype object for other reasons than ragged arrays.

Specifically this can happen if we load a dataset from a netcdf file with xarray <2023.11.0 convert it to a qcodes dataset and try to convert it back to xarray


- [x] Needs a test
- [x] changelog
