### PR TITLE
set default github token permission to read only.

### DIFF
--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -7,6 +7,9 @@ on:
       - 'release/*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint-with-darker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,6 +14,9 @@ on:
   merge_group:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   builddocs:
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,6 +14,9 @@ on:
   merge_group:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   pytestmypy:
 


### PR DESCRIPTION
This limits the damage a rouge job can do