### PR TITLE
add header to licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2015-2023 by Microsoft Corporation and Københavns
 Universitet.
 


### PR DESCRIPTION
attempt to fix that https://github.com/microsoft/Qcodes/security/code-scanning/45 does not recognize the licence
