### PR TITLE
Make loading from netcdf lazy using load_by_guid etc.

### DIFF
--- a/docs/changes/newsfragments/5711.improved
+++ b/docs/changes/newsfragments/5711.improved
@@ -1,0 +1,1 @@
+As an extension to the feature added in #5627 datasets are also no longer converted into QCoDeS format when loaded from netcdf using ``load_by_guid``, ``load_by_id``, ``load_by_run_spec``, ``load_by_counter``

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -345,6 +345,7 @@ class DataSetInMem(BaseDataSet):
         if xr_path is not None and xr_path.is_file():
             ds._cache = DataSetCacheDeferred(ds, xr_path)
         elif xr_path is not None and not xr_path.is_file():
+            success = False
             warnings.warn(
                 "Could not load raw data for dataset with guid : {ds.guid} from location {xr_path}"
             )

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -332,8 +332,8 @@ class DataSetInMem(BaseDataSet):
             export_info=export_info,
             snapshot=run_attributes["snapshot"],
         )
-        xr_path = export_info.export_paths.get("nc")
-        xr_path = Path(xr_path) if xr_path is not None else None
+        xr_path_temp = export_info.export_paths.get("nc")
+        xr_path = Path(xr_path_temp) if xr_path_temp is not None else None
 
         cls._set_cache_from_netcdf(ds, xr_path)
         return ds


### PR DESCRIPTION
This is an extension to #5627 which also avoids loading the data from a netcdf file into qcodes format when loading the file using load_by_guid etc.

