### PR TITLE
mark non visa AMI driver as deprecated.

### DIFF
--- a/docs/changes/newsfragments/5712.breaking
+++ b/docs/changes/newsfragments/5712.breaking
@@ -1,0 +1,2 @@
+The AMI drivers in ``qcodes.instrument_drivers.american_magnetics.AMI430`` and their submodules has been deprecated. Use the ``AMIModel430`` and
+``AMIModel4303D`` drivers from ``qcodes.instrument_drivers.american_magnetics`` instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ ignore = [
     "src/qcodes/instrument_drivers/Harvard/Decadac.py",
     ]
 reportMissingTypeStubs = true
+reportDeprecated = true
 stubPath = "typings/stubs"
 # we would like to move this to at least standard
 # eventually. From 1.1.339 onwards standard is the default

--- a/src/qcodes/instrument/ip_to_visa.py
+++ b/src/qcodes/instrument/ip_to_visa.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from importlib.resources import as_file, files
 from typing import Any
 
+from typing_extensions import deprecated
+
 import qcodes.validators as vals
 from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430
 from qcodes.logger import get_instrument_logger
-from qcodes.utils import strip_attrs
+from qcodes.utils import QCoDeSDeprecationWarning, strip_attrs
 
 from .instrument import Instrument
 from .ip import IPInstrument
@@ -115,5 +117,9 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
         self.remove_instance(self)
 
 
+@deprecated(
+    "The IP version of AMI430 is deprecated and this helper is therefor also deprecated",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430_VISA(AMI430, IPToVisa):  # type: ignore[misc]
     pass

--- a/src/qcodes/instrument/ip_to_visa.py
+++ b/src/qcodes/instrument/ip_to_visa.py
@@ -6,7 +6,9 @@ from typing import Any
 from typing_extensions import deprecated
 
 import qcodes.validators as vals
-from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430
+from qcodes.instrument_drivers.american_magnetics.AMI430 import (
+    AMI430,  # pyright: ignore[reportDeprecated]
+)
 from qcodes.logger import get_instrument_logger
 from qcodes.utils import QCoDeSDeprecationWarning, strip_attrs
 

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -1,3 +1,5 @@
+# type: ignore # this triggers deprecation warnings from pyright
+# lets just disable these
 from __future__ import annotations
 
 import collections.abc

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -1,5 +1,5 @@
-# type: ignore # this triggers deprecation warnings from pyright
-# lets just disable these
+# pyright: reportDeprecated=none
+# This deprecated code calls it self triggering deprecation warnings
 from __future__ import annotations
 
 import collections.abc

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -12,6 +12,7 @@ from functools import partial
 from typing import Any, Callable, ClassVar, TypeVar, cast
 
 import numpy as np
+from typing_extensions import deprecated
 
 from qcodes.instrument import Instrument, InstrumentChannel, IPInstrument
 from qcodes.math_utils import FieldVector
@@ -26,14 +27,26 @@ CartesianFieldLimitFunction = Callable[[float, float, float], bool]
 T = TypeVar('T')
 
 
+@deprecated(
+    "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430Exception from qcodes.instrument_drivers.american_magnetics",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430Exception(Exception):
     pass
 
 
+@deprecated(
+    "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430Warning from qcodes.instrument_drivers.american_magnetics",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430Warning(UserWarning):
     pass
 
 
+@deprecated(
+    "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430SwitchHeater from qcodes.instrument_drivers.american_magnetics",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430SwitchHeater(InstrumentChannel):
     class _Decorators:
         @classmethod
@@ -120,6 +133,10 @@ class AMI430SwitchHeater(InstrumentChannel):
         return bool(int(self.ask("PS?").strip()))
 
 
+@deprecated(
+    "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMIModel430 from qcodes.instrument_drivers.american_magnetics",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430(IPInstrument):
     """
     Driver for the American Magnetics Model 430 magnet power supply programmer.
@@ -475,6 +492,10 @@ class AMI430(IPInstrument):
         self.coil_constant()
 
 
+@deprecated(
+    "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMIModel4303D from qcodes.instrument_drivers.american_magnetics",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430_3D(Instrument):
     def __init__(
         self,

--- a/tests/drivers/test_ami430.py
+++ b/tests/drivers/test_ami430.py
@@ -1,3 +1,5 @@
+# pyright: reportDeprecated=none
+# This deprecated code calls it self triggering deprecation warnings
 import io
 import logging
 import re
@@ -14,9 +16,9 @@ from pytest import FixtureRequest, LogCaptureFixture
 
 from qcodes.instrument import Instrument
 from qcodes.instrument_drivers.american_magnetics.AMI430 import (
-    AMI430,  # pyright: ignore[reportDeprecated]
-    AMI430_3D,  # pyright: ignore[reportDeprecated]
-    AMI430Warning,  # pyright: ignore[reportDeprecated]
+    AMI430,
+    AMI430_3D,
+    AMI430Warning,
 )
 from qcodes.math_utils import FieldVector
 from qcodes.utils import QCoDeSDeprecationWarning
@@ -30,7 +32,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
 
     from qcodes.instrument.ip_to_visa import (
-        AMI430_VISA,  # pyright: ignore[reportDeprecated]
+        AMI430_VISA,
     )
 
 
@@ -53,21 +55,21 @@ def magnet_axes_instances():
     and z directions.
     """
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
-        mag_x = AMI430_VISA(  # pyright: ignore[reportDeprecated]
+        mag_x = AMI430_VISA(
             "x",
             address="GPIB::1::INSTR",
             pyvisa_sim_file="AMI430.yaml",
             terminator="\n",
             port=1,
         )
-        mag_y = AMI430_VISA(  # pyright: ignore[reportDeprecated]
+        mag_y = AMI430_VISA(
             "y",
             address="GPIB::2::INSTR",
             pyvisa_sim_file="AMI430.yaml",
             terminator="\n",
             port=1,
         )
-        mag_z = AMI430_VISA(  # pyright: ignore[reportDeprecated]
+        mag_z = AMI430_VISA(
             "z",
             address="GPIB::3::INSTR",
             pyvisa_sim_file="AMI430.yaml",
@@ -90,9 +92,7 @@ def _make_current_driver(magnet_axes_instances):
     """
     mag_x, mag_y, mag_z = magnet_axes_instances
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
-        driver = AMI430_3D(  # pyright: ignore[reportDeprecated]
-            "AMI430_3D", mag_x, mag_y, mag_z, field_limit
-        )
+        driver = AMI430_3D("AMI430_3D", mag_x, mag_y, mag_z, field_limit)
 
     yield driver
 
@@ -102,7 +102,7 @@ def _make_current_driver(magnet_axes_instances):
 @pytest.fixture(scope="function", name="ami430")
 def _make_ami430():
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
-        mag = AMI430_VISA(  # pyright: ignore[reportDeprecated]
+        mag = AMI430_VISA(
             "ami430",
             address="GPIB::1::INSTR",
             pyvisa_sim_file="AMI430.yaml",
@@ -154,12 +154,10 @@ def test_instantiation_from_names(
     names as opposed from their instances.
     """
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
+    request.addfinalizer(AMI430_3D.close_all)
 
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
-        driver = AMI430_3D(  # pyright: ignore[reportDeprecated]
-            "AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit
-        )
+        driver = AMI430_3D("AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit)
 
     assert driver._instrument_x is mag_x
     assert driver._instrument_y is mag_y
@@ -171,7 +169,7 @@ def test_instantiation_from_name_of_nonexistent_ami_instrument(
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
 
-    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
+    request.addfinalizer(AMI430_3D.close_all)
 
     non_existent_instrument = mag_y.name + "foo"
 
@@ -179,7 +177,7 @@ def test_instantiation_from_name_of_nonexistent_ami_instrument(
         with pytest.raises(
             KeyError, match=f"with name {non_existent_instrument} does not exist"
         ):
-            AMI430_3D(  # pyright: ignore[reportDeprecated]
+            AMI430_3D(
                 "AMI430_3D",
                 mag_x.name,
                 non_existent_instrument,
@@ -192,7 +190,7 @@ def test_instantiation_from_name_of_existing_non_ami_instrument(
     magnet_axes_instances, request: FixtureRequest
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
+    request.addfinalizer(AMI430_3D.close_all)
 
     non_ami_existing_instrument = Instrument("foo")
 
@@ -201,11 +199,11 @@ def test_instantiation_from_name_of_existing_non_ami_instrument(
             TypeError,
             match=re.escape(
                 f"Instrument {non_ami_existing_instrument.name} is "
-                f"{type(non_ami_existing_instrument)} but {AMI430} "  # pyright: ignore[reportDeprecated]
+                f"{type(non_ami_existing_instrument)} but {AMI430} "
                 f"was requested"
             ),
         ):
-            AMI430_3D(  # pyright: ignore[reportDeprecated]
+            AMI430_3D(
                 "AMI430_3D",
                 mag_x.name,
                 non_ami_existing_instrument.name,
@@ -218,7 +216,7 @@ def test_instantiation_from_badly_typed_argument(
     magnet_axes_instances, request: FixtureRequest
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
+    request.addfinalizer(AMI430_3D.close_all)
 
     badly_typed_instrument_z_argument = 123
 
@@ -226,7 +224,7 @@ def test_instantiation_from_badly_typed_argument(
         with pytest.raises(
             ValueError, match="instrument_z argument is neither of those"
         ):
-            AMI430_3D(  # pyright: ignore[reportDeprecated]
+            AMI430_3D(
                 "AMI430_3D",
                 mag_x.name,
                 mag_y,
@@ -1024,9 +1022,7 @@ def test_current_and_field_params_interlink__permutations_of_tests(ami430) -> No
     with warnings.catch_warnings():
         # this is to avoid AMI430Warning about "maximum ramp rate", which
         # may show up but is not relevant to this test
-        warnings.simplefilter(
-            "ignore", category=AMI430Warning  # pyright: ignore[reportDeprecated]
-        )
+        warnings.simplefilter("ignore", category=AMI430Warning)
 
         test_current_and_field_params_interlink_at_init(ami430)
 
@@ -1107,9 +1103,7 @@ def test_numeric_field_limit(
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
-        ami = AMI430_3D(  # pyright: ignore[reportDeprecated]
-            "AMI430_3D", mag_x, mag_y, mag_z, field_limit
-        )
+        ami = AMI430_3D("AMI430_3D", mag_x, mag_y, mag_z, field_limit)
     request.addfinalizer(ami.close)
 
     assert isinstance(ami._field_limit, float)


### PR DESCRIPTION
The visa one is better supported and has fewer issues.

- [x] Add a deprecation notice
- [x] Silence warnings in tests
