### PR TITLE
Silence warnings during test suite.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,10 +224,12 @@ addopts = "-n auto --dist=loadfile"
 
 markers = "serial"
 
+# we ignore warnings
 # triggered by third party packages
 filterwarnings = [
     'ignore:Deprecated call to `pkg_resources\.declare_namespace:DeprecationWarning',  # google, sphinxcontrib
     'ignore:pkg_resources is deprecated as an API:DeprecationWarning', # pyvisa-sim
+    'ignore:open_binary is deprecated:DeprecationWarning', # pyvisa-sim
     'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version:DeprecationWarning', # tqdm dateutil
     'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning' # jupyter
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "opencensus-ext-azure>=1.0.4, <2.0.0",
     "packaging>=20.0",
     "pandas>=1.2.0",
+    "pyarrow>=11.0.0", # will become a requirement of pandas. Installing explicitly silences a warning
     "pyvisa>=1.11.0, <1.15.0",
     "ruamel.yaml>=0.16.0,!=0.16.6",
     "tabulate>=0.8.0",

--- a/tests/test_deprecate.py
+++ b/tests/test_deprecate.py
@@ -63,6 +63,7 @@ def test_similar_output() -> None:
         assert add_one(1) == _add_one(1)
 
 
+@pytest.mark.filterwarnings("ignore:Some other warning")
 def test_deprecated_context_manager() -> None:
     with _catch_deprecation_warnings() as ws:
         issue_deprecation_warning('something')

--- a/tests/validators/test_complex.py
+++ b/tests/validators/test_complex.py
@@ -9,8 +9,11 @@ from qcodes.validators import ComplexNumbers
 
 
 @given(complex_val=hst.complex_numbers())
+@pytest.mark.filterwarnings("ignore:overflow encountered in cast:RuntimeWarning")
 def test_complex(complex_val: complex) -> None:
-
+    # we are generating 128 b complex numbers with hypothesis
+    # so we are likely to generate overflow warnings when converting
+    # these to np complex 64. In this case that is harmless.
     n = ComplexNumbers()
     assert str(n) == '<Complex Number>'
     n.validate(complex_val)


### PR DESCRIPTION
* Filter warnings from pyvisa-sim 
* Silence warnings explicitly raised in a test
* Silence overflows produced by hypothesis
* Install pyarrow to avoid warning from pandas about pyarrow becoming a dependency