### PR TITLE
Move versioningit config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 68.1.0",
-    "versioningit >= 2.0.1",
+    "versioningit >= 2.2.1",
 ]
 build-backend = 'setuptools.build_meta'
 
@@ -44,7 +44,7 @@ dependencies = [
     "typing_extensions>=4.5.0",
     "tqdm>=4.59.0",
     "uncertainties>=3.1.4",
-    "versioningit>=2.0.1",
+    "versioningit>=2.2.1",
     "websockets>=9.1",
     "wrapt>=1.13.2; python_version < '3.12'",
     "wrapt>=1.16.0; python_version >= '3.12'",
@@ -314,6 +314,10 @@ banned-module-level-imports = ["xarray", "pandas", "opencensus"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.setuptools.cmdclass]
+sdist = "versioningit.cmdclass.sdist"
+build_py = "versioningit.cmdclass.build_py"
 
 [tool.towncrier]
 package = "qcodes"

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,8 @@
-import setuptools
+"""
+This file only exists as a fallback for older versions of pip/setuptools
+All configuration is done in pyproject.toml
+"""
 from setuptools import setup
-from versioningit import get_cmdclasses
-
-# this file does not contain configuration
-# all configuration should be in pyproject.toml
-
-if int(setuptools.__version__.split(".")[0]) < 61:
-    raise RuntimeError(
-        "At least setuptools 61 is required to install qcodes from source"
-    )
-
-try:
-    import pip
-
-    if int(pip.__version__.split(".")[0]) < 19:
-        raise RuntimeError("At least pip 19 is required to install qcodes from source")
-except ImportError:
-    # we are not being executed from pip so pip version is not important
-    pass
 
 if __name__ == "__main__":
-    setup(
-        cmdclass=get_cmdclasses(),
-    )
+    setup()


### PR DESCRIPTION
This has been possible since version 2.2 so bump
min version accordingly.

Remove warnings for older pip versions since the relevant versions are now 6 years old
