### PR TITLE
Enable additional Ruff pydocstyle lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ extend-exclude = ["typings"]
 # TID253 banned-module-level-imports
 # W pydocstyle
 # PLx pylint
-select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411", "D412"]
+select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411", "D412", "D405"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # G004 We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ extend-exclude = ["typings"]
 # TID253 banned-module-level-imports
 # W pydocstyle
 # PLx pylint
-select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417"]
+select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # G004 We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ extend-exclude = ["typings"]
 # TID253 banned-module-level-imports
 # W pydocstyle
 # PLx pylint
-select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411", "D412", "D405"]
+select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411", "D412", "D405", "D214"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # G004 We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ extend-exclude = ["typings"]
 # TID253 banned-module-level-imports
 # W pydocstyle
 # PLx pylint
-select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411"]
+select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411", "D412"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # G004 We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ extend-exclude = ["typings"]
 # TID253 banned-module-level-imports
 # W pydocstyle
 # PLx pylint
-select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416"]
+select = ["E", "F", "PT025", "UP", "RUF010", "RUF012", "RUF200", "I", "G", "ISC", "TID253", "NPY", "PLE", "PLR", "PLC", "PLW", "W", "D417", "D416", "D410", "D411"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # G004 We have a lot of use of f strings in log messages

--- a/src/qcodes/configuration/config.py
+++ b/src/qcodes/configuration/config.py
@@ -240,7 +240,6 @@ class Config:
             default: default value, stored only in the schema
 
         Examples:
-
             >>> defaults.add("trace_color", "blue", "string", "description")
 
         will update the config:

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1028,6 +1028,7 @@ class DataSet(BaseDataSet):
                 If set to "auto" multi index will be used if projecting the data onto
                 a grid requires filling non measured values with NaN  and the shapes
                 of the data has not been set in the run description.
+
         Returns:
             :py:class:`xr.Dataset` with the requested parameter(s) data as
             :py:class:`xr.DataArray` s and coordinates formed by the dependencies.

--- a/src/qcodes/dataset/sqlite/queries.py
+++ b/src/qcodes/dataset/sqlite/queries.py
@@ -949,12 +949,14 @@ def get_run_counter(conn: ConnectionPlus, exp_id: int) -> int:
 
 
 def get_experiments(conn: ConnectionPlus) -> list[int]:
-    """Get a list of experiments
+    """
+    Get a list of experiments
+
     Args:
         conn: database connection
 
-     Returns:
-         list of rows
+    Returns:
+        list of rows
     """
     sql = "SELECT exp_id FROM experiments"
     c = atomic_transaction(conn, sql)

--- a/src/qcodes/instrument/visa.py
+++ b/src/qcodes/instrument/visa.py
@@ -341,6 +341,7 @@ class VisaInstrument(Instrument):
                 different way (as in the qdac). If you want to skip the
                 update of certain parameters in all snapshots, use the
                 ``snapshot_get``  attribute of those parameters instead.
+
         Returns:
             dict: base snapshot
         """

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -91,7 +91,6 @@ class AlazarTech_ATS(Instrument):
             board_id: id of the board within the alazar system
 
         Return:
-
             Dictionary containing
 
                 - system_id

--- a/src/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/src/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -433,7 +433,6 @@ class HarvardDecadac(VisaInstrument, DacReader):
 
 
     Attributes:
-
         _ramp_state (bool): If True, ramp state is ON. Default False.
 
         _ramp_time (int): The ramp time in ms. Default 100 ms.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
@@ -91,7 +91,7 @@ class KeysightB2962A(VisaInstrument):
 
     Status: alpha-version.
 
-    TODO:
+    Todo:
         - Implement any remaining parameters supported by the device
         - Similar drivers have special handlers to map return values of
           9.9e+37 to inf, is this needed?

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
@@ -90,6 +90,7 @@ class KeysightB2962A(VisaInstrument):
     Power Source
 
     Status: alpha-version.
+
     TODO:
         - Implement any remaining parameters supported by the device
         - Similar drivers have special handlers to map return values of

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -11,6 +11,7 @@ from .keysight_34980a_submodules import KeysightSwitchMatrixSubModule
 class Keysight34934A(KeysightSwitchMatrixSubModule):
     """
     Create an instance for module 34933A.
+
     Args:
         parent: the system which the module is installed on
         name: user defined name for the module

--- a/src/qcodes/instrument_drivers/mock_instruments/__init__.py
+++ b/src/qcodes/instrument_drivers/mock_instruments/__init__.py
@@ -1101,6 +1101,7 @@ class MockCustomChannel(InstrumentChannel):
 
         It adds a parameter not found in the original channel, the
         current_valid_range.
+
         Args:
             parent: Instrument to which the original channel belongs to,
                 usually a dac.

--- a/src/qcodes/instrument_drivers/oxford/triton.py
+++ b/src/qcodes/instrument_drivers/oxford/triton.py
@@ -28,7 +28,7 @@ class OxfordTriton(IPInstrument):
 
     Status: beta-version.
 
-        TODO:
+    Todo:
         fetch registry directly from fridge-computer
     """
 

--- a/src/qcodes/instrument_drivers/oxford/triton.py
+++ b/src/qcodes/instrument_drivers/oxford/triton.py
@@ -27,6 +27,7 @@ class OxfordTriton(IPInstrument):
         timeout: Defaults to 20.
 
     Status: beta-version.
+
         TODO:
         fetch registry directly from fridge-computer
     """

--- a/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -949,8 +949,8 @@ class ZNB(VisaInstrument):
             of initialization are reset and removed.
         **kwargs: passed to base class
 
-    TODO:
-    - check initialisation settings and test functions
+    Todo:
+        - check initialisation settings and test functions
     """
 
     CHANNEL_CLASS = ZNBChannel

--- a/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -641,7 +641,7 @@ class SignalHoundUSBSA124B(Instrument):
     def QuerySweep(self) -> tuple[int, float, float]:
         """
         Queries the sweep for information on the parameters that defines the
-            x axis of the sweep
+        x axis of the sweep
 
         Returns:
             number of points in sweep, start frequency and step size
@@ -664,7 +664,7 @@ class SignalHoundUSBSA124B(Instrument):
         This function performs a sweep over the configured ranges.
         The result of the sweep is returned along with the sweep points
 
-        returns:
+        Returns:
             datamin numpy array
         """
         if not self._parameters_synced:

--- a/src/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -67,7 +67,6 @@ class SR560(Instrument):
     This is a virtual driver only and will not talk to your instrument.
 
     Note:
-
     - The ``cutoff_lo`` and ``cutoff_hi`` parameters will interact with
       each other on the instrument (hi cannot be <= lo) but this is not
       managed here, you must ensure yourself that both are correct whenever

--- a/src/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -67,13 +67,12 @@ class SR560(Instrument):
     This is a virtual driver only and will not talk to your instrument.
 
     Note:
-    - The ``cutoff_lo`` and ``cutoff_hi`` parameters will interact with
-      each other on the instrument (hi cannot be <= lo) but this is not
-      managed here, you must ensure yourself that both are correct whenever
-      you change one of them.
-
-    - ``gain`` has a vernier setting, which does not yield a well-defined
-      output. We restrict this driver to only the predefined gain values.
+        - The ``cutoff_lo`` and ``cutoff_hi`` parameters will interact with
+          each other on the instrument (hi cannot be <= lo) but this is not
+          managed here, you must ensure yourself that both are correct whenever
+          you change one of them.
+        - ``gain`` has a vernier setting, which does not yield a well-defined
+          output. We restrict this driver to only the predefined gain values.
 
     """
     def __init__(self, name: str, **kwargs: Any):

--- a/src/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -36,7 +36,7 @@ class TektronixAWG5014(VisaInstrument):
         - The output channels are always in Amplitude/Offset mode
         - The output markers are always in High/Low mode
 
-    TODO:
+    Todo:
         - Implement support for cable transfer function compensation
         - Implement more instrument functionality in the driver
         - Remove double functionality

--- a/src/qcodes/interactive_widget.py
+++ b/src/qcodes/interactive_widget.py
@@ -224,7 +224,7 @@ def _do_in_tab(
 ) -> Callable[[Button], None]:
     """Performs an operation inside of a subtab of a `ipywidgets.Tab`.
 
-    Args
+    Args:
         tab: Instance of `ipywidgets.Tab`.
         ds: A qcodes.DataSet instance.
         which: Either "plot" or "snapshot".

--- a/src/qcodes/parameters/group_parameter.py
+++ b/src/qcodes/parameters/group_parameter.py
@@ -111,7 +111,6 @@ class Group:
     group belong to the same instrument.
 
     Example:
-
         ::
 
             class InstrumentWithGroupParameters(VisaInstrument):

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -968,7 +968,6 @@ class ParameterBase(MetadatableWithName):
         This may be overridden with ``allow_changes=True``.
 
         Examples:
-
             >>> from qcodes.parameters import Parameter
             >>> p = Parameter("p", set_cmd=None, get_cmd=None)
             >>> p.set(2)
@@ -994,7 +993,6 @@ class ParameterBase(MetadatableWithName):
         unintentionally modifies a parameter.
 
         Example:
-
             >>> p = Parameter("p", set_cmd=None, get_cmd=None)
             >>> p.set(2)
             >>> with p.restore_at_exit():

--- a/src/qcodes/station.py
+++ b/src/qcodes/station.py
@@ -836,6 +836,7 @@ def _merge_yamls(*yamls: str | Path) -> str:
 
     Args:
         yamls: string or Path to yaml files separated by comma.
+
     Returns:
         Full yaml file stored in the memory. Returns an empty string
         if no files are given.

--- a/src/qcodes/tests/common.py
+++ b/src/qcodes/tests/common.py
@@ -190,6 +190,7 @@ def compare_dictionaries(
                      differences string.
         dict_2_name: Optional name of the second dictionary used in the
                      differences string.
+
     Returns:
         Tuple: Are the dicts equal and the difference rendered as
                a string.


### PR DESCRIPTION
These will help the user write docstrings with fewer issues without having to do the sphinx compile round trip

