### PR TITLE
Simple indexed attribute access in station files

### DIFF
--- a/docs/changes/newsfragments/5887.improved
+++ b/docs/changes/newsfragments/5887.improved
@@ -1,0 +1,2 @@
+Add support for integer indexing in parameter paths in Station Files,
+e.g ``channel[0].voltage`` or ``sigouts[0].enables[1].value``.

--- a/src/qcodes/dist/schemas/station-template.schema.json
+++ b/src/qcodes/dist/schemas/station-template.schema.json
@@ -59,7 +59,7 @@
                                     "properties": {
                                         "source": {
                                             "type": "string",
-                                            "pattern": "^(\\w+)(\\.\\w+)*$"
+                                            "pattern": "^(\\w+(\\[\\d+\\])*)(\\.\\w+(\\[\\d+\\])*)*$"
                                         },
                                         "label": {
                                             "type": "string"
@@ -112,7 +112,7 @@
                         "parameters": {
                             "type": "object",
                             "patternProperties": {
-                                "^(\\w+)(\\.\\w+)*$": {
+                                "^(\\w+(\\[\\d+\\])*)(\\.\\w+(\\[\\d+\\])*)*$": {
                                     "type": "object",
                                     "properties": {
                                         "alias": {

--- a/src/qcodes/station.py
+++ b/src/qcodes/station.py
@@ -48,6 +48,8 @@ from qcodes.parameters import (
 from qcodes.utils import (
     DelegateAttributes,
     checked_getattr,
+    checked_getattr_indexed,
+    getattr_indexed,
     get_qcodes_path,
     get_qcodes_user_path,
 )
@@ -595,7 +597,7 @@ class Station(Metadatable, DelegateAttributes):
             level = levels[0]
             try:
                 for level in levels:
-                    instrument = checked_getattr(
+                    instrument = checked_getattr_indexed(
                         instrument, level, (InstrumentBase, ChannelTuple)
                     )
             except TypeError:
@@ -615,7 +617,7 @@ class Station(Metadatable, DelegateAttributes):
                     instrument,
                     '.'.join(parts[:-1]))
             try:
-                return checked_getattr(instrument, parts[-1], ParameterBase)
+                return checked_getattr_indexed(instrument, parts[-1], ParameterBase)
             except TypeError:
                 raise RuntimeError(
                     f'Cannot resolve parameter identifier `{identifier}` to '

--- a/src/qcodes/station.py
+++ b/src/qcodes/station.py
@@ -47,9 +47,7 @@ from qcodes.parameters import (
 )
 from qcodes.utils import (
     DelegateAttributes,
-    checked_getattr,
     checked_getattr_indexed,
-    getattr_indexed,
     get_qcodes_path,
     get_qcodes_user_path,
 )
@@ -591,7 +589,8 @@ class Station(Metadatable, DelegateAttributes):
             Get the instrument, channel or channel_list described by a nested
             string.
 
-            E.g: 'dac.ch1' will return the instance of ch1.
+            E.g: 'dac.ch1' will return the instance of ch1, 'dac.channels[0]'
+            returns the first item of the channels property.
             """
             levels = identifier.split(".")
             level = levels[0]

--- a/src/qcodes/utils/__init__.py
+++ b/src/qcodes/utils/__init__.py
@@ -4,6 +4,8 @@ from .attribute_helpers import (
     DelegateAttributes,
     attribute_set_to,
     checked_getattr,
+    getattr_indexed,
+    checked_getattr_indexed,
     strip_attrs,
 )
 from .deep_update_utils import deep_update
@@ -32,6 +34,8 @@ __all__ = [
     "RespondingThread",
     "attribute_set_to",
     "checked_getattr",
+    "getattr_indexed",
+    "checked_getattr_indexed",
     "convert_legacy_version_to_supported_version",
     "deep_update",
     "deprecate",

--- a/src/qcodes/utils/__init__.py
+++ b/src/qcodes/utils/__init__.py
@@ -4,8 +4,8 @@ from .attribute_helpers import (
     DelegateAttributes,
     attribute_set_to,
     checked_getattr,
-    getattr_indexed,
     checked_getattr_indexed,
+    getattr_indexed,
     strip_attrs,
 )
 from .deep_update_utils import deep_update

--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -119,6 +119,48 @@ def checked_getattr(
     return attr
 
 
+def getattr_indexed(instance: Any, attribute: str) -> Any:
+    """
+    Similar to ``getattr`` but allows indexing the returned attribute.
+    Returning a default value is _not_ supported.
+
+    The indices are decimal digits surrounded by square brackets.
+    Chained indexing is supported, but the string should not contain
+    any whitespace between consecutive indices.
+
+    Example: `getattr_indexed(some_object, "list_of_lists_field[1][2]")`
+    """
+    if not attribute.endswith("]"):
+        return getattr(instance, attribute)
+
+    end: int = len(attribute) - 1
+
+    start: int = attribute.find("[", 0, end)
+    attr: Any = getattr(instance, attribute[0:start])
+    start += 1
+
+    while (pos := attribute.find("][", start, end)) != -1:
+        index = int(attribute[start:pos])
+        attr = attr[index]
+        start = pos + 2
+
+    index = int(attribute[start:end])
+    attr = attr[index]
+    return attr
+
+
+def checked_getattr_indexed(
+    instance: Any, attribute: str, expected_type: Union[type, tuple[type, ...]]
+) -> Any:
+    """
+    Like ``getattr_indexed`` but raises type error if not of expected type.
+    """
+    attr: Any = getattr_indexed(instance, attribute)
+    if not isinstance(attr, expected_type):
+        raise TypeError()
+    return attr
+
+
 @contextmanager
 def attribute_set_to(
     object_: object, attribute_name: str, new_value: Any

--- a/tests/utils/test_getattr_indexed.py
+++ b/tests/utils/test_getattr_indexed.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+
+import pytest
+
+from qcodes.utils import checked_getattr_indexed, getattr_indexed
+
+
+@dataclass
+class A:
+    x: object
+    y: object
+
+
+@dataclass
+class B:
+    a_list: list
+    b_dict: dict
+
+
+def test_regular_unindexed() -> None:
+    a = A(x=1, y=2)
+
+    assert getattr_indexed(a, "x") == 1
+    assert getattr_indexed(a, "y") == 2
+
+
+def test_checked_regular_unindexed() -> None:
+    a = A(x=1, y=2)
+
+    assert checked_getattr_indexed(a, "x", int) == 1
+    assert checked_getattr_indexed(a, "y", int) == 2
+
+
+def test_checked_notype_unindexed() -> None:
+    # just make sure this never errors, since it's meant to be used
+    # during deletion
+    a = A(x=1, y=2)
+
+    with pytest.raises(TypeError):
+        checked_getattr_indexed(a, "x", str)
+
+
+def test_checked_notfound_unindexed() -> None:
+    # just make sure this never errors, since it's meant to be used
+    # during deletion
+    a = A(x=1, y=2)
+
+    with pytest.raises(AttributeError):
+        getattr_indexed(a, "z")
+
+    with pytest.raises(AttributeError):
+        checked_getattr_indexed(a, "z", int)
+
+    with pytest.raises(AttributeError):
+        checked_getattr_indexed(a, "z", str)
+
+
+def test_regular_indexed() -> None:
+    a1 = A(x=1, y=2)
+    a2 = A(x=3, y=4)
+    b1 = B(a_list=[a1, a2], b_dict={2: [a1, a2]})
+
+    assert getattr_indexed(b1, "a_list[0]") is a1
+    assert getattr_indexed(b1, "a_list[1]") is a2
+    assert getattr_indexed(b1, "b_dict[2][0]") is a1
+
+
+def test_checked_indexed() -> None:
+    a1 = A(x=1, y=2)
+    a2 = A(x=3, y=4)
+    b1 = B(a_list=[a1, a2], b_dict={2: [a1, a2]})
+
+    assert checked_getattr_indexed(b1, "a_list[0]", A) is a1
+    assert checked_getattr_indexed(b1, "a_list[1]", A) is a2
+    assert checked_getattr_indexed(b1, "b_dict[2][0]", (A, B)) is a1
+
+
+def test_notype_indexed() -> None:
+    a1 = A(x=1, y=2)
+    a2 = A(x=3, y=4)
+    b1 = B(a_list=[a1, a2], b_dict={2: [a1, a2]})
+
+    with pytest.raises(TypeError):
+        checked_getattr_indexed(b1, "a_list[0]", B)
+    with pytest.raises(TypeError):
+        assert checked_getattr_indexed(b1, "a_list[1]", B) is a2
+    with pytest.raises(TypeError):
+        assert checked_getattr_indexed(b1, "b_dict[2][0]", B) is a1


### PR DESCRIPTION
Some drivers (see zurich-instruments) only expose parameters through an interface which needs indexing in addition to attribute access. This patch enables access to those parameters in the station yaml file.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [x] Make sure that the pull request contains a short description of the changes made.
- [x] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
