### PR TITLE
Fix #5551

### DIFF
--- a/src/qcodes/instrument/visa.py
+++ b/src/qcodes/instrument/visa.py
@@ -28,12 +28,16 @@ log = logging.getLogger(__name__)
 def _close_visa_handle(
     handle: pyvisa.resources.MessageBasedResource, name: str
 ) -> None:
-    log.info(
-        "Closing VISA handle to %s as there are no non weak "
-        "references to the instrument.",
-        name,
-    )
-    handle.close()
+    if (
+        handle.session is not None
+    ):  # pyvisa sets the session of a handle to None when it is closed
+        log.info(
+            "Closing VISA handle to %s as there are no non weak "
+            "references to the instrument.",
+            name,
+        )
+
+        handle.close()
 
 class VisaInstrument(Instrument):
 


### PR DESCRIPTION
Avoid logging info about closing instrument when the instrument is already closed
This causes random log messages at gc time even if the instrument had already been closed
Fixes #5551

