### PR TITLE
Import speedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ known-first-party = ["qcodes"]
 # There modules are relatively slow to import
 # and only required in specific places so
 # don't import them at module level
-banned-module-level-imports = ["xarray", "pandas", "opencensus", "tqdm.dask", "dask"]
+banned-module-level-imports = ["xarray", "pandas", "opencensus", "tqdm.dask", "dask", "matplotlib"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ known-first-party = ["qcodes"]
 # There modules are relatively slow to import
 # and only required in specific places so
 # don't import them at module level
-banned-module-level-imports = ["xarray", "pandas", "opencensus"]
+banned-module-level-imports = ["xarray", "pandas", "opencensus", "tqdm.dask", "dask"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ known-first-party = ["qcodes"]
 # There modules are relatively slow to import
 # and only required in specific places so
 # don't import them at module level
-banned-module-level-imports = ["xarray", "pandas", "opencensus", "tqdm.dask", "dask", "matplotlib"]
+banned-module-level-imports = ["xarray", "pandas", "opencensus", "tqdm.dask", "dask", "matplotlib", "IPython"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -5,8 +5,6 @@ import warnings
 from math import prod
 from typing import TYPE_CHECKING, Literal, cast
 
-from tqdm.dask import TqdmCallback
-
 from qcodes.dataset.linked_datasets.links import links_to_str
 
 from ..descriptions.versioning import serialization as serial
@@ -283,6 +281,10 @@ def xarray_to_h5netcdf_with_complex_numbers(
         )
         # https://github.com/microsoft/pyright/issues/6069
         if not compute and maybe_write_job is not None:
+            # Dask and therefor tqdm.dask is slow to
+            # import and only used here so defer the import
+            # to when required.
+            from tqdm.dask import TqdmCallback
             with TqdmCallback(desc="Combining files"):
                 _LOG.info(
                     "Writing netcdf file using Dask delayed writer.",

--- a/src/qcodes/dataset/plotting.py
+++ b/src/qcodes/dataset/plotting.py
@@ -13,7 +13,6 @@ from textwrap import wrap
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import numpy as np
-from matplotlib.figure import Figure
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -341,6 +340,8 @@ def plot_and_save_image(
         save_pdf: Save figure in pdf format.
         save_png: Save figure in png format.
     """
+    from matplotlib.figure import Figure
+
     from qcodes import config
 
     dataid = data.captured_run_id

--- a/src/qcodes/interactive_widget.py
+++ b/src/qcodes/interactive_widget.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from functools import partial, reduce
 from typing import TYPE_CHECKING, Any, Literal
 
-from IPython.display import clear_output, display
 from ipywidgets import (  # type: ignore[import-untyped]
     HTML,
     Box,
@@ -230,6 +229,7 @@ def _do_in_tab(
         ds: A qcodes.DataSet instance.
         which: Either "plot" or "snapshot".
     """
+    from IPython.display import clear_output, display
     assert which in ("plot", "snapshot")
 
     def delete_tab(output: Output, tab: Tab) -> Callable[[Button], None]:
@@ -282,6 +282,7 @@ def _do_in_tab(
 
 def create_tab(do_display: bool = True) -> Tab:
     """Creates a `ipywidgets.Tab` which can display outputs in its tabs."""
+    from IPython.display import display
     output = Output()
     tab = Tab(children=(output,))
 


### PR DESCRIPTION
This improves import time by ensuring that dask and matplotlib are only imported lazily. With these improvements import time is ~1.1 sec for me. Out of these the main contributions are numpy contributes 0.172 s and jsonschema 0.229 s. These are not easily removed since numpy is used everywhere and jsonschema is required to validate the default config.