### PR TITLE
make qcodes.__version__ lazy

### DIFF
--- a/src/qcodes/__init__.py
+++ b/src/qcodes/__init__.py
@@ -4,13 +4,9 @@ import importlib
 import warnings
 from typing import TYPE_CHECKING, Any
 
-import qcodes._version
 import qcodes.configuration as qcconfig
 from qcodes.logger.logger import conditionally_start_all_logging
 from qcodes.utils import QCoDeSDeprecationWarning
-
-__version__ = qcodes._version.__version__
-
 
 config: qcconfig.Config = qcconfig.Config()
 
@@ -114,9 +110,18 @@ _LAZY_SUBMODULES = frozenset(
 # ``if not TYPE_CHECKING`` so that these discouraged short hands are reported as
 # unknown attributes (rather than typed as ``Any``); import the names from their
 # respective submodules to get proper type information.
+#
+# ``__version__`` is also resolved lazily: computing it is slow in an editable
+# install since we have to shell out to run ``git describe``, so we only do it if
+# it is actually requested. Under ``TYPE_CHECKING`` it is defined below with a
+# placeholder value so static type checkers still know it exists.
 if not TYPE_CHECKING:
 
     def __getattr__(name: str) -> Any:
+        if name == "__version__":
+            import qcodes._version  # noqa: PLC0415  # lazy import since getting version is slow in editable install.
+
+            return qcodes._version.__version__
         if name in _LAZY_SUBMODULES:
             return importlib.import_module(f"{__name__}.{name}")
         module_name = _LAZY_NAME_TO_MODULE.get(name)
@@ -129,3 +134,10 @@ if not TYPE_CHECKING:
             )
             return getattr(importlib.import_module(module_name), name)
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+else:
+    __version__ = "not_set"
+
+__all__ = [
+    "__version__",
+    "config",
+]


### PR DESCRIPTION
This speeds up importing qcodes from an editable install with ~ 0.6-0.7 s assuming that you do not actually make use of the `__version__` attribute. By only doing this in a `if not TYPE_CHECKING:` block we avoid losing static type information about top level attributes