### PR TITLE
Fix typos in two Tektronix channel classes

### DIFF
--- a/docs/changes/newsfragments/5932.breaking
+++ b/docs/changes/newsfragments/5932.breaking
@@ -1,0 +1,16 @@
+Fix spelling of the 2 incorrectly spelled classes
+```qcodes.instrument_drivers.tektronix.TekronixDPOTrigger``` and
+ ```qcodes.instrument_drivers.tektronix.TekronixDPOWaveform``` to
+ ```qcodes.instrument_drivers.tektronix.TektronixDPOTrigger```
+and ```qcodes.instrument_drivers.tektronix.TektronixDPOWaveform``` .
+
+If you need to import these classes and support multiple qcodes versions we suggest wrapping an import with:
+
+.. code-block:: python
+
+   try:
+         from qcodes.instrument_drivers.tektronix import TektronixDPOTrigger
+         from qcodes.instrument_drivers.tektronix import TektronixDPOWaveform
+    except ImportError:
+         from qcodes.instrument_drivers.tektronix import TekronixDPOTrigger
+         from qcodes.instrument_drivers.tektronix import TekronixDPOWaveform

--- a/docs/changes/newsfragments/5932.breaking
+++ b/docs/changes/newsfragments/5932.breaking
@@ -1,6 +1,6 @@
 Fix spelling of the 2 incorrectly spelled classes
 ```qcodes.instrument_drivers.tektronix.TekronixDPOTrigger``` and
- ```qcodes.instrument_drivers.tektronix.TekronixDPOWaveform``` to
- ```qcodes.instrument_drivers.tektronix.TektronixDPOTrigger```
+```qcodes.instrument_drivers.tektronix.TekronixDPOWaveform``` to
+```qcodes.instrument_drivers.tektronix.TektronixDPOTrigger```
 and ```qcodes.instrument_drivers.tektronix.TektronixDPOWaveform``` .
 The old names have been deprecated and will be removed in a future release.

--- a/docs/changes/newsfragments/5932.breaking
+++ b/docs/changes/newsfragments/5932.breaking
@@ -3,14 +3,4 @@ Fix spelling of the 2 incorrectly spelled classes
  ```qcodes.instrument_drivers.tektronix.TekronixDPOWaveform``` to
  ```qcodes.instrument_drivers.tektronix.TektronixDPOTrigger```
 and ```qcodes.instrument_drivers.tektronix.TektronixDPOWaveform``` .
-
-If you need to import these classes and support multiple qcodes versions we suggest wrapping an import with:
-
-.. code-block:: python
-
-   try:
-         from qcodes.instrument_drivers.tektronix import TektronixDPOTrigger
-         from qcodes.instrument_drivers.tektronix import TektronixDPOWaveform
-    except ImportError:
-         from qcodes.instrument_drivers.tektronix import TekronixDPOTrigger
-         from qcodes.instrument_drivers.tektronix import TekronixDPOWaveform
+The old names have been deprecated and will be removed in a future release.

--- a/docs/examples/Station.ipynb
+++ b/docs/examples/Station.ipynb
@@ -740,7 +740,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.1"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -115,14 +115,11 @@ class TektronixDPO7000xx(VisaInstrument):
 
         self.add_submodule("channel", channel_list)
 
-        self.add_submodule(
-            "trigger",
-            TekronixDPOTrigger(self, "trigger")
-        )
+        self.add_submodule("trigger", TektronixDPOTrigger(self, "trigger"))
 
         self.add_submodule(
             "delayed_trigger",
-            TekronixDPOTrigger(self, "delayed_trigger", delayed_trigger=True)
+            TektronixDPOTrigger(self, "delayed_trigger", delayed_trigger=True),
         )
 
         self.connect_message()
@@ -173,7 +170,7 @@ class TektronixDPOData(InstrumentChannel):
             "source",
             get_cmd="DATa:SOU?",
             set_cmd="DATa:SOU {}",
-            vals=Enum(*TekronixDPOWaveform.valid_identifiers)
+            vals=Enum(*TektronixDPOWaveform.valid_identifiers),
         )
 
         self.add_parameter(
@@ -201,7 +198,7 @@ class TektronixDPOData(InstrumentChannel):
         )
 
 
-class TekronixDPOWaveform(InstrumentChannel):
+class TektronixDPOWaveform(InstrumentChannel):
     """
     This submodule retrieves data from waveform sources, e.g.
     channels.
@@ -431,10 +428,7 @@ class TektronixDPOChannel(InstrumentChannel):
         self._identifier = f"CH{channel_number}"
 
         self.add_submodule(
-            "waveform",
-            TekronixDPOWaveform(
-                self, "waveform", self._identifier
-            )
+            "waveform", TektronixDPOWaveform(self, "waveform", self._identifier)
         )
 
         self.add_parameter(
@@ -618,7 +612,7 @@ class TektronixDPOHorizontal(InstrumentChannel):
         self.write(f"HORizontal:MODE:SCAle {value}")
 
 
-class TekronixDPOTrigger(InstrumentChannel):
+class TektronixDPOTrigger(InstrumentChannel):
     """
     Submodule for trigger setup.
 
@@ -861,9 +855,7 @@ class TektronixDPOMeasurement(InstrumentChannel):
                 get_cmd=f"MEASUrement:MEAS{self._measurement_number}:SOUrce"
                         f"{src}?",
                 set_cmd=partial(self._set_source, src),
-                vals=Enum(
-                    *(TekronixDPOWaveform.valid_identifiers + ["HISTogram"])
-                )
+                vals=Enum(*(TektronixDPOWaveform.valid_identifiers + ["HISTogram"])),
             )
 
     @property

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -9,6 +9,7 @@ from functools import partial
 from typing import Any, Callable, ClassVar, Union, cast
 
 import numpy as np
+from typing_extensions import deprecated
 
 from qcodes.instrument import ChannelList, Instrument, InstrumentChannel, VisaInstrument
 from qcodes.parameters import (
@@ -16,6 +17,7 @@ from qcodes.parameters import (
     ParameterWithSetpoints,
     create_on_off_val_mapping,
 )
+from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.validators import Arrays, Enum
 
 
@@ -351,6 +353,16 @@ class TektronixDPOWaveform(InstrumentChannel):
         sample_count = self.length()
         x_increment = self.x_increment()
         return np.linspace(0, x_increment * sample_count, sample_count)
+
+
+@deprecated(
+    "TekronixDPOWaveform is deprecated use TektronixDPOWaveform",
+    category=QCoDeSDeprecationWarning,
+)
+class TekronixDPOWaveform(TektronixDPOWaveform):
+    """
+    Deprecated alias for backwards compatibility
+    """
 
 
 class TektronixDPOWaveformFormat(InstrumentChannel):
@@ -697,6 +709,16 @@ class TektronixDPOTrigger(InstrumentChannel):
                 "We currently only support the 'edge' trigger type"
             )
         self.write(f"TRIGger:{self._identifier}:TYPE {value}")
+
+
+@deprecated(
+    "TekronixDPOTrigger is deprecated use TektronixDPOTrigger",
+    category=QCoDeSDeprecationWarning,
+)
+class TekronixDPOTrigger(TektronixDPOTrigger):
+    """
+    Deprecated alias for backwards compatibility
+    """
 
 
 class TektronixDPOMeasurementParameter(Parameter):

--- a/src/qcodes/instrument_drivers/tektronix/__init__.py
+++ b/src/qcodes/instrument_drivers/tektronix/__init__.py
@@ -3,6 +3,8 @@ from .AWG5208 import TektronixAWG5208
 from .AWG70000A import Tektronix70000AWGChannel
 from .AWG70002A import TektronixAWG70002A
 from .DPO7200xx import (
+    TekronixDPOTrigger,  # pyright: ignore[reportDeprecated]
+    TekronixDPOWaveform,  # pyright: ignore[reportDeprecated]
     TektronixDPOChannel,
     TektronixDPOData,
     TektronixDPOHorizontal,
@@ -26,6 +28,8 @@ from .Tektronix_MSO70000 import TektronixMSO70000
 from .TPS2012 import TektronixTPS2012, TektronixTPS2012Channel
 
 __all__ = [
+    "TekronixDPOWaveform",
+    "TekronixDPOTrigger",
     "TektronixDPOTrigger",
     "TektronixDPOWaveform",
     "Tektronix70000AWGChannel",

--- a/src/qcodes/instrument_drivers/tektronix/__init__.py
+++ b/src/qcodes/instrument_drivers/tektronix/__init__.py
@@ -3,8 +3,6 @@ from .AWG5208 import TektronixAWG5208
 from .AWG70000A import Tektronix70000AWGChannel
 from .AWG70002A import TektronixAWG70002A
 from .DPO7200xx import (
-    TekronixDPOTrigger,
-    TekronixDPOWaveform,
     TektronixDPOChannel,
     TektronixDPOData,
     TektronixDPOHorizontal,
@@ -12,6 +10,8 @@ from .DPO7200xx import (
     TektronixDPOMeasurementParameter,
     TektronixDPOMeasurementStatistics,
     TektronixDPOModeError,
+    TektronixDPOTrigger,
+    TektronixDPOWaveform,
     TektronixDPOWaveformFormat,
 )
 from .Tektronix_70001A import TektronixAWG70001A
@@ -26,8 +26,8 @@ from .Tektronix_MSO70000 import TektronixMSO70000
 from .TPS2012 import TektronixTPS2012, TektronixTPS2012Channel
 
 __all__ = [
-    "TekronixDPOTrigger",
-    "TekronixDPOWaveform",
+    "TektronixDPOTrigger",
+    "TektronixDPOWaveform",
     "Tektronix70000AWGChannel",
     "TektronixAWG5014",
     "TektronixAWG5208",


### PR DESCRIPTION
These two DPO channels had a missing t in their names. 

I could be convinced that we should retain the old names as deprecated aliases but since these are not the top level instruments names I don't think that is required. 