### PR TITLE
Keep Pyright up to date as a npm package.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
   directory: /.binder
   schedule:
     interval: daily
+
+- package-ecosystem: npm
+  directory: /.github
+  schedule:
+    interval: daily

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,0 +1,5 @@
+{
+"dependencies": {
+	"pyright": "1.1.356"
+}
+}

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,5 +1,5 @@
 {
-"dependencies": {
+"devDependencies": {
 	"pyright": "1.1.356"
 }
 }

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -81,9 +81,19 @@ jobs:
       run: |
         pip install .[test] -c requirements.txt
       if: ${{ !matrix.min-version }}
+    - name: Install node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+    - name: install pyright
+      run: |
+        npm install
+        echo "$PWD/node_modules/.bin" >> $GITHUB_PATH
+      shell: bash
+      working-directory: .github
     - uses: jakebailey/pyright-action@3bdde3b31d26f0f1f5de051b1fbd7a536a9a4e7f # v2.3.1
       with:
-        version: 1.1.356
+        version: PATH
       if: ${{ !matrix.min-version }}
     - name: Run Mypy
       run: mypy -p qcodes

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -81,19 +81,17 @@ jobs:
       run: |
         pip install .[test] -c requirements.txt
       if: ${{ !matrix.min-version }}
-    - name: Install node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-    - name: install pyright
+    - name: Get Pyright Version
+      id: pyright-version
       run: |
-        npm install
-        echo "$PWD/node_modules/.bin" >> $GITHUB_PATH
-      shell: bash
+        PYRIGHT_VERSION=$(jq -r '.devDependencies.pyright' < package.json)
+        echo $PYRIGHT_VERSION
+        echo "version=$PYRIGHT_VERSION" >> $GITHUB_OUTPUT
       working-directory: .github
+      shell: bash
     - uses: jakebailey/pyright-action@3bdde3b31d26f0f1f5de051b1fbd7a536a9a4e7f # v2.3.1
       with:
-        version: PATH
+        version: ${{ steps.pyright-version.outputs.version }}
       if: ${{ !matrix.min-version }}
     - name: Run Mypy
       run: mypy -p qcodes

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ benchmarking/results/
 qcodes/tests/dataset/fixtures/db_files/*
 qcodes/tests/output
 qcodes/tests/*.db
+
+# Do not ignore pyright npm version file
+!.github/package.json


### PR DESCRIPTION
Rather than installing the package this parses the version out of a packages.json file making the setup simpler