### PR TITLE
Deprecate opencensus integration

### DIFF
--- a/docs/changes/newsfragments/5991.breaking
+++ b/docs/changes/newsfragments/5991.breaking
@@ -1,0 +1,5 @@
+QCoDeS no longer installs opencensus and opencensus-ext-azure are no longer installed by default and opencensus integration is deprecated.
+This means that the option ``qcodes.config.telemetry.enabled`` to ``True`` is deprecated. For the time being opencensus and opencensus-ext-azure
+can be installed by installing QCoDeS with the opencensus option e.g. ``pip install qcodes[opencensus]``. We however, recommend that any use
+of this telemetry integration is replaced by the use of OpenTelemetry. QCoDeS will not include any telemetry integration but the codebase
+has been instrumented using OpenTelemetry spans and python log messages enabling any user to collect telemetry if they should so wish.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ dependencies = [
     "jsonschema>=4.9.0",
     "matplotlib>=3.3.3",
     "numpy>=1.21.0",
-    "opencensus>=0.7.10",
-    "opencensus-ext-azure>=1.0.4, <2.0.0",
     "packaging>=20.0",
     "pandas>=1.2.0",
     "pyarrow>=11.0.0", # will become a requirement of pandas. Installing explicitly silences a warning
@@ -58,7 +56,6 @@ dependencies = [
     "tornado>=6.3.3",
     "ipython>=8.10.0",
     "pillow>=9.0.0",
-    "rsa>=4.7",
 ]
 
 dynamic = ["version"]
@@ -117,6 +114,10 @@ docs = [
     "scipy>=1.7.0", # examples using scipy
     "qcodes_loop>=0.1.1", # legacy dataset import examples
     "jinja2>=3.1.3", # transitive dependency pin due to cve in earlier version
+]
+opencensus = [
+    "opencensus>=0.7.10",
+    "opencensus-ext-azure>=1.0.4, <2.0.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,9 +117,7 @@ idna==3.7
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.11.0
-    # via
-    #   dask
-    #   opentelemetry-api
+    # via opentelemetry-api
 incremental==22.10.0
     # via towncrier
 iniconfig==2.0.0
@@ -249,6 +247,7 @@ packaging==24.0
     #   dask
     #   h5netcdf
     #   ipykernel
+    #   lazy-loader
     #   matplotlib
     #   msal-extensions
     #   nbconvert
@@ -282,10 +281,13 @@ portalocker==2.8.2
     # via msal-extensions
 prompt-toolkit==3.0.43
     # via ipython
+proto-plus==1.23.0
+    # via google-api-core
 protobuf==4.25.3
     # via
     #   google-api-core
     #   googleapis-common-protos
+    #   proto-plus
 psutil==5.9.8
     # via
     #   ipykernel

--- a/src/qcodes/logger/logger.py
+++ b/src/qcodes/logger/logger.py
@@ -33,6 +33,7 @@ from qcodes.utils import (
 )
 
 AzureLogHandler = Any
+Envelope = Any
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -205,11 +206,9 @@ def _create_telemetry_handler() -> "AzureLogHandler":
     """
     Configure, create, and return the telemetry handler
     """
-    if TYPE_CHECKING:
-        from opencensus.ext.azure.common.protocol import (  # type: ignore[import-untyped]
-            Envelope,
-        )
-    from opencensus.ext.azure.log_exporter import AzureLogHandler
+    from opencensus.ext.azure.log_exporter import (  # type: ignore[import-not-found]
+        AzureLogHandler,
+    )
     global telemetry_handler
 
     # The default_custom_dimensions will appear in the "customDimensions"

--- a/src/qcodes/logger/logger.py
+++ b/src/qcodes/logger/logger.py
@@ -199,7 +199,7 @@ def flush_telemetry_traces() -> None:
 
 
 @deprecated(
-    "OpenCensus integration is deprecated. Please use your own telemetry integration as needed",
+    "OpenCensus integration is deprecated. Please use your own telemetry integration as needed, we recommend OpenTelemetry",
     category=QCoDeSDeprecationWarning,
 )
 def _create_telemetry_handler() -> "AzureLogHandler":


### PR DESCRIPTION
And remove default install of opencensus and opencensus azure integration.

Note that this does not yet remove opencensus from requirements.txt. This will happen once a release of qcodes with these changes is out. This is due to the "circular" dependencies between qcodes[test], qcodes-loop, and qcodes. 

TODO

- [ ] Breaking change notice