### PR TITLE
revert changes to _get / _set_wrapper in ParameterBase

### DIFF
--- a/src/qcodes/parameters/parameter.py
+++ b/src/qcodes/parameters/parameter.py
@@ -287,7 +287,9 @@ class Parameter(ParameterBase):
                     exec_str=exec_str_ask,
                 )
             self._gettable = True
-            self.get = self._wrap_get()
+            # mypy resolves the type of self.get_raw to object here.
+            # this may be resolvable if Command above is correctly wrapped in MethodType
+            self.get = self._wrap_get(self.get_raw)  # type: ignore[arg-type]
 
         if self.settable and set_cmd not in (None, False):
             raise TypeError(
@@ -317,7 +319,9 @@ class Parameter(ParameterBase):
                     arg_count=1, cmd=set_cmd, exec_str=exec_str_write
                 )
             self._settable = True
-            self.set = self._wrap_set()
+            # mypy resolves the type of self.get_raw to object here.
+            # this may be resolvable if Command above is correctly wrapped in MethodType
+            self.set = self._wrap_set(self.set_raw)  # type: ignore[arg-type]
 
         self._meta_attrs.extend(["label", "unit", "vals"])
 

--- a/tests/parameter/test_get_latest.py
+++ b/tests/parameter/test_get_latest.py
@@ -170,7 +170,7 @@ def test_no_get_max_val_age() -> None:
         def __init__(self, *args: Any, **kwargs: Any):
             super().__init__(*args, **kwargs)
             self.set_raw = lambda x: x  # type: ignore[method-assign]
-            self.set = self._wrap_set()
+            self.set = self._wrap_set(self.set_raw)
 
     localparameter = LocalParameter('test_param',
                                     None,

--- a/tests/parameter/test_parameter_cache.py
+++ b/tests/parameter/test_parameter_cache.py
@@ -232,7 +232,7 @@ def test_no_get_max_val_age_runtime_error(
         def __init__(self, *args: Any, **kwargs: Any):
             super().__init__(*args, **kwargs)
             self.set_raw = lambda x: x  # type: ignore[method-assign]
-            self.set = self._wrap_set()
+            self.set = self._wrap_set(self.set_raw)
 
     local_parameter = LocalParameter('test_param',
                                      None,


### PR DESCRIPTION
This private api is used in zhinst qcodes https://github.com/zhinst/zhinst-qcodes/blob/main/src/zhinst/qcodes/qcodes_adaptions.py#L202

This reverts an insignificant part of #5721 
