### PR TITLE
Add trace manipulation commands to Keysight PNA driver

### DIFF
--- a/docs/changes/newsfragments/6035.improved_driver
+++ b/docs/changes/newsfragments/6035.improved_driver
@@ -1,0 +1,1 @@
+Adds trace manipulation commands to the Keysight PNA driver.

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -277,7 +277,7 @@ class KeysightPNATrace(InstrumentChannel):
 
     def disable(self) -> None:
         """
-        Disable a trace on the PNA
+        Disable this trace on the PNA
         """
         self.write(f"DISP:TRAC{self.trace_num}:STAT 0")
 

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -275,7 +275,7 @@ class KeysightPNATrace(InstrumentChannel):
             vals=Arrays(shape=(self.parent.points,), valid_types=(complex,)),
         )
 
-    def disable(self):
+    def disable(self) -> None:
         """
         Disable a trace on the PNA
         """

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -662,7 +662,8 @@ class PNABase(VisaInstrument):
 
     def enable_trace(self, trace_num: int) -> KeysightPNATrace:
         """
-        Enable a trace given by trace_num and return it
+        Enable a trace given by trace_num and return it. Note, if the trace is
+        already enabled, we simply return it.
         """
         self.write(f"DISP:TRAC{trace_num}:STAT 1")
         time.sleep(0.5)


### PR DESCRIPTION
This PR adds trace manipulation commands to the Keysight PNA driver.

Specifically, we now allow the following interactions:
 - `trace = pna.add_trace()`: Create a new trace (of any number) on the PNA
 - `trace = pna.enable_trace(trace_num)`: Enable and return the given trace number
 - `trace.disable()`: Disable a trace on the PNA