### PR TITLE
Type check tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-include = ["src"]
+include = ["src","tests"]
 ignore = [
     "src/qcodes/instrument_drivers/Harvard/Decadac.py",
     ]

--- a/tests/dataset/test_measurement_extensions.py
+++ b/tests/dataset/test_measurement_extensions.py
@@ -294,9 +294,7 @@ def test_dond_into_fails_with_together_sweeps(
 
             dond_into(
                 datasaver,
-                TogetherSweep(
-                    sweep1, sweep2
-                ),  # pyright: ignore [reportGeneralTypeIssues]
+                TogetherSweep(sweep1, sweep2),  # pyright: ignore [reportArgumentType]
                 meas1,
             )
             _ = datasaver.dataset
@@ -317,8 +315,8 @@ def test_dond_into_fails_with_groups(default_params, default_database_and_experi
             dond_into(
                 datasaver,
                 sweep1,
-                [meas1],  # pyright: ignore [reportGeneralTypeIssues]
-                [meas2],  # pyright: ignore [reportGeneralTypeIssues]
+                [meas1],  # pyright: ignore [reportArgumentType]
+                [meas2],  # pyright: ignore [reportArgumentType]
             )
             _ = datasaver.dataset
 

--- a/tests/dataset/test_string_data.py
+++ b/tests/dataset/test_string_data.py
@@ -196,7 +196,7 @@ def test_list_of_strings(experiment) -> None:
                 hypnumpy.timedelta64_dtypes(),
                 hypnumpy.datetime64_dtypes(),
             )
-        ),  # pyright: ignore[reportGeneralTypeIssues]
+        ),  # pyright: ignore[reportCallIssue,reportArgumentType]
         shape=hypnumpy.array_shapes(),
     )
 )

--- a/tests/drivers/test_lakeshore.py
+++ b/tests/drivers/test_lakeshore.py
@@ -64,18 +64,19 @@ class MockVisaInstrument:
         else:
             super().write_raw(cmd)  # type: ignore[misc]
 
-    def ask_raw(self, query) -> Any:
-        query_parts = query.split(' ')
+    def ask_raw(self, cmd) -> Any:
+        query_parts = cmd.split(" ")
         query_str = query_parts[0].upper()
         if query_str in self.queries:
-            args = ''.join(query_parts[1:])
-            self.visa_log.debug(f'Query: '
-                      f'{query} for command {query_str} with args {args}')
+            args = "".join(query_parts[1:])
+            self.visa_log.debug(
+                f"Query: {cmd} for command {query_str} with args {args}"
+            )
             response = self.queries[query_str](args)
             self.visa_log.debug(f"Response: {response}")
             return response
         else:
-            super().ask_raw(query)  # type: ignore[misc]
+            super().ask_raw(cmd)  # type: ignore[misc]
 
 
 def query(name: str) -> Callable[[Callable[P, T]], Callable[P, T]]:


### PR DESCRIPTION
Over in https://github.com/microsoft/Qcodes/pull/4412 I would like to use [assert_type](https://docs.python.org/3/library/typing.html#typing.assert_type) to check that the right type is deducted for a parameter attribute. For that to make sense we should type check the tests. 

To enable this:

* Enable pyright on tests
* Update mock interfaces to match upstream interface
* Update some pyright ignores to match the current version of pyright