### PR TITLE
Fix typing of Instrument

### DIFF
--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -35,9 +35,19 @@ class InstrumentProtocol(Protocol):
 
 T = TypeVar("T", bound="Instrument")
 
+# a metaclass that overrides __call__ means that we lose
+# both the args and return type hints.
+# Since our metaclass does not modify the signature
+# is is safe simply not to use that metaclass in typechecking context.
+# See https://github.com/microsoft/pyright/discussions/5561 and
+# https://github.com/microsoft/pyright/issues/5488
+if TYPE_CHECKING:
+    instrument_meta_class = type
+else:
+    instrument_meta_class = InstrumentMeta
 
-class Instrument(InstrumentBase, metaclass=InstrumentMeta):
 
+class Instrument(InstrumentBase, metaclass=instrument_meta_class):
     """
     Base class for all QCodes instruments.
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -13,6 +13,7 @@ from weakref import WeakValueDictionary
 
 import pytest
 from pytest import FixtureRequest
+from typing_extensions import assert_type
 
 from qcodes.instrument import (
     Instrument,
@@ -78,6 +79,15 @@ def _close_before_and_after():
         yield
     finally:
         Instrument.close_all()
+
+
+def test_instrument_type(request: pytest.FixtureRequest) -> None:
+    # make sure that the type of the instrument is correct.
+    # Due to our use of a metaclass for instrument this could be
+    # incorrect. See comment in instrument.py
+    testldummy = DummyInstrument("dummy")
+    request.addfinalizer(testldummy.close)
+    assert_type(testldummy, DummyInstrument)
 
 
 def test_validate_function(testdummy: DummyInstrument) -> None:


### PR DESCRIPTION
It turns out that overriding `__call__` for the metaclass will limit pyrights ability to check the type of the constructor. See https://github.com/microsoft/pyright/discussions/5561 

To work around this, we avoid using the metaclass when type checking. This is safe since the only taks of the metaclass is to register instruments which is a runtime only task. 

