### PR TITLE
Accept sequences of values for setting MultiChannelInstrumentParameter

### DIFF
--- a/docs/changes/newsfragments/6073.improved
+++ b/docs/changes/newsfragments/6073.improved
@@ -1,0 +1,1 @@
+Accept sequences of values for setting `MultiChannelInstrumentParameter` s. Previously, the behavior was inconsistent since `param.set(param.get())` would error.

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -61,7 +61,11 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
                 getattr(chan, self._param_name).set(value)
         except Exception as err:
             try:
-                for chan, val in zip(self._channels, value, strict=True):
+                # Catch wrong length of value before any setting is done
+                value_list = list(value)
+                if len(value_list) != len(self._channels):
+                    raise ValueError
+                for chan, val in zip(self._channels, value_list):
                     getattr(chan, self._param_name).set(val)
             except (TypeError, ValueError):
                 note = (
@@ -72,7 +76,7 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
                     err.add_note(note)
                 else:
                     _LOG.error(note)
-                raise
+                raise err from None
 
     @property
     def full_names(self) -> tuple[str, ...]:

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -49,10 +49,10 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
 
     def set_raw(self, value: ParamRawDataType | Sequence[ParamRawDataType]) -> None:
         """
-        Set all parameters to this value.
+        Set all parameters to this/these value(s).
 
         Args:
-            value: The value to set to. The type is given by the
+            value: The value(s) to set to. The type is given by the
                 underlying parameter.
         """
         try:

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from .multi_parameter import MultiParameter
@@ -67,13 +68,11 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
                     "Value should either be valid for a single parameter of the channel list "
                     "or a sequence of valid values of the same length as the list."
                 )
-                try:
+                if sys.version_info >= (3, 11):
                     err.add_note(note)
-                except AttributeError:
-                    # <3.11
+                else:
                     _LOG.error(note)
-                finally:
-                    raise
+                raise
 
     @property
     def full_names(self) -> tuple[str, ...]:

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .parameter_base import ParamRawDataType
 
 InstrumentModuleType = TypeVar("InstrumentModuleType", bound="InstrumentModule")
-LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger(__name__)
 
 
 class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleType]):
@@ -69,7 +69,7 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
                     err.add_note(note)
                 except AttributeError:
                     # <3.11
-                    LOG.error(note)
+                    _LOG.error(note)
                 finally:
                     raise
 

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -63,8 +63,10 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
                 for chan, val in zip(self._channels, value, strict=True):
                     getattr(chan, self._param_name).set(val)
             except (TypeError, ValueError):
-                note = ('Value should either be valid for a single parameter of the channel list '
-                        'or a sequence of valid values of the same length as the list.')
+                note = (
+                    "Value should either be valid for a single parameter of the channel list "
+                    "or a sequence of valid values of the same length as the list."
+                )
                 try:
                     err.add_note(note)
                 except AttributeError:

--- a/tests/parameter/test_multi_channel_instrument_parameter.py
+++ b/tests/parameter/test_multi_channel_instrument_parameter.py
@@ -1,0 +1,53 @@
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from qcodes.instrument_drivers.mock_instruments import DummyChannelInstrument
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def dummy_channel_instrument() -> "Generator[DummyChannelInstrument, None, None]":
+    instrument = DummyChannelInstrument(name="testdummy")
+    try:
+        yield instrument
+    finally:
+        instrument.close()
+
+
+@pytest.fixture
+def assert_raises_match() -> str:
+    if sys.version_info >= (3, 11):
+        return "Value should either be valid"
+    else:
+        return ""
+
+
+def test_set_multi_channel_instrument_parameter(
+    dummy_channel_instrument: DummyChannelInstrument, assert_raises_match: str
+):
+    """Tests :class:`MultiChannelInstrumentParameter` set method."""
+    for name, param in dummy_channel_instrument.channels[0].parameters.items():
+        if not param.settable:
+            continue
+
+        channel_parameter = getattr(dummy_channel_instrument.channels, name)
+
+        getval = channel_parameter.get()
+
+        channel_parameter.set(getval[0])
+
+        # Assert channel parameter setters accept what the getter returns (PR #6073)
+        channel_parameter.set(getval)
+
+        with pytest.raises(TypeError, match=assert_raises_match):
+            channel_parameter.set(getval[:-1])
+
+        with pytest.raises(TypeError, match=assert_raises_match):
+            channel_parameter.set(getval + (getval[-1],))
+
+        with pytest.raises(TypeError):
+            channel_parameter.set(object())


### PR DESCRIPTION
As of now, the `MultiChannelInstrumentParameter` is inconsistent; its setter does not accept the values returned by its getter as the first accepts a scalar `ParamRawDataType`, but the last returns a tuple thereof. This is particularly problematic as it breaks the `set_to` context manager.

This proposed change modifies the setter to allow both the current scalar behavior as well as a sequence, in which case it is zipped together with `self._channels`.