### PR TITLE
Allow parameter contexts for uninitialized parameters

### DIFF
--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -81,13 +81,12 @@ class _SetParamContext:
                 self._parameter.set(self._original_value)
             except Exception:
                 # Likely an uninitialized Parameter
-                vals = self._parameter._vals
-                set_parser = self._parameter.set_parser
-                self._parameter._vals = []
-                self._parameter.set_parser = None
-                self._parameter.cache.set(self._original_value)
-                self._parameter.set_parser = set_parser
-                self._parameter._vals = vals
+                LOG.info(
+                    "Encountered an exception setting the original value "
+                    "when exiting set_to context of "
+                    f"{self._parameter.full_name}",
+                    exc_info=True,
+                )
 
 
 def invert_val_mapping(val_mapping: Mapping[Any, Any]) -> dict[Any, Any]:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -77,7 +77,16 @@ class _SetParamContext:
             self._parameter._settable = self._original_settable
 
         if self._parameter.cache() != self._original_value:
-            self._parameter.set(self._original_value)
+            try:
+                self._parameter.validate(self._original_value)
+            except Exception:
+                # Likely an uninitialized Parameter
+                vals = self._parameter._vals
+                self._parameter._vals = []
+                self._parameter.cache.set(self._original_value)
+                self._parameter._vals = vals
+            else:
+                self._parameter.set(self._original_value)
 
 
 def invert_val_mapping(val_mapping: Mapping[Any, Any]) -> dict[Any, Any]:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -82,8 +82,11 @@ class _SetParamContext:
             except Exception:
                 # Likely an uninitialized Parameter
                 vals = self._parameter._vals
+                set_parser = self._parameter.set_parser
                 self._parameter._vals = []
+                self._parameter.set_parser = None
                 self._parameter.cache.set(self._original_value)
+                self._parameter.set_parser = set_parser
                 self._parameter._vals = vals
 
 

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -78,15 +78,13 @@ class _SetParamContext:
 
         if self._parameter.cache() != self._original_value:
             try:
-                self._parameter.validate(self._original_value)
+                self._parameter.set(self._original_value)
             except Exception:
                 # Likely an uninitialized Parameter
                 vals = self._parameter._vals
                 self._parameter._vals = []
                 self._parameter.cache.set(self._original_value)
                 self._parameter._vals = vals
-            else:
-                self._parameter.set(self._original_value)
 
 
 def invert_val_mapping(val_mapping: Mapping[Any, Any]) -> dict[Any, Any]:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -249,8 +249,8 @@ class ParameterBase(MetadatableWithName):
         else:
             self.inverse_val_mapping = invert_val_mapping(val_mapping)
 
-        self.get_parser = get_parser
-        self.set_parser = set_parser
+        self.get_parser: Callable[..., Any] | None = get_parser
+        self.set_parser: Callable[..., Any] | None = set_parser
 
         # ``_Cache`` stores "latest" value (and raw value) and timestamp
         # when it was set or measured

--- a/tests/parameter/test_parameter_context_manager.py
+++ b/tests/parameter/test_parameter_context_manager.py
@@ -171,7 +171,6 @@ def test_context(instrument: DummyTrackingInstrument) -> None:
     # context
     with instrument.uninitialized_param.set_to(2):
         assert instrument.uninitialized_param.get() == 2
-    assert instrument.uninitialized_param.cache.get() is None
 
 
 def test_validated_param(instrument: DummyTrackingInstrument) -> None:

--- a/tests/parameter/test_parameter_context_manager.py
+++ b/tests/parameter/test_parameter_context_manager.py
@@ -34,6 +34,13 @@ class DummyTrackingInstrument(DummyInstrument):
                            get_cmd=self._pp_getter,
                            set_parser=int)
 
+        # A parameter that is not initialized and whose cache value does not
+        # pass the validator
+        self.add_parameter("uninitialized_param",
+                           initial_cache_value=None,
+                           set_cmd=None,
+                           vals=vals.Enum("foo"))
+
         # A parameter that counts the number of times it has been set
         self.add_parameter("counting_parameter",
                            set_cmd=self._cp_setter,
@@ -157,6 +164,13 @@ def test_context(instrument: DummyTrackingInstrument) -> None:
     with instrument.a.set_to(3):
         assert instrument.a.get() == 3
     assert instrument.a.get() == 2
+
+    # The cached value does not pass the validator (since it was not
+    # initialized). Make sure no exception is raised when __exit__ing the
+    # context
+    with instrument.uninitialized_param.set_to('foo'):
+        assert instrument.uninitialized_param.get() == 'foo'
+    assert instrument.uninitialized_param.cache.get() is None
 
 
 def test_validated_param(instrument: DummyTrackingInstrument) -> None:

--- a/tests/parameter/test_parameter_context_manager.py
+++ b/tests/parameter/test_parameter_context_manager.py
@@ -35,11 +35,12 @@ class DummyTrackingInstrument(DummyInstrument):
                            set_parser=int)
 
         # A parameter that is not initialized and whose cache value does not
-        # pass the validator
+        # pass the validator or the set parser
         self.add_parameter("uninitialized_param",
                            initial_cache_value=None,
                            set_cmd=None,
-                           vals=vals.Enum("foo"))
+                           set_parser=int,
+                           vals=vals.Enum(2))
 
         # A parameter that counts the number of times it has been set
         self.add_parameter("counting_parameter",
@@ -168,8 +169,8 @@ def test_context(instrument: DummyTrackingInstrument) -> None:
     # The cached value does not pass the validator (since it was not
     # initialized). Make sure no exception is raised when __exit__ing the
     # context
-    with instrument.uninitialized_param.set_to('foo'):
-        assert instrument.uninitialized_param.get() == 'foo'
+    with instrument.uninitialized_param.set_to(2):
+        assert instrument.uninitialized_param.get() == 2
     assert instrument.uninitialized_param.cache.get() is None
 
 


### PR DESCRIPTION
Currently, using the `set_to` context fails on exit for parameters whose value does not pass the set parser or validator. The only -- but common -- case where this happens are uninitialized parameters, in which case the value is `None`.

This change catches exceptions when setting the original value and then sets the cache value instead. The exception catch is very broad, but as far as I can tell, validators can raise any kind of exception they like. Only doing this if `original_value` is `None` might be a bit safer -- are there other cases?