### PR TITLE
Pass parameter kwargs as kwargs

### DIFF
--- a/src/qcodes/instrument_drivers/Keithley/Keithley_s46.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_s46.py
@@ -76,7 +76,7 @@ class S46Parameter(Parameter):
         lock: KeithleyS46RelayLock,
         **kwargs: Any,
     ):
-        super().__init__(name, instrument, **kwargs)
+        super().__init__(name, instrument=instrument, **kwargs)
 
         self._lock = lock
         self._channel_number = channel_number

--- a/src/qcodes/parameters/array_parameter.py
+++ b/src/qcodes/parameters/array_parameter.py
@@ -146,9 +146,9 @@ class ArrayParameter(ParameterBase):
     ) -> None:
         super().__init__(
             name,
-            instrument,
-            snapshot_get,
-            metadata,
+            instrument=instrument,
+            snapshot_get=snapshot_get,
+            metadata=metadata,
             snapshot_value=snapshot_value,
             snapshot_exclude=snapshot_exclude,
             **kwargs,

--- a/src/qcodes/parameters/multi_parameter.py
+++ b/src/qcodes/parameters/multi_parameter.py
@@ -156,9 +156,9 @@ class MultiParameter(ParameterBase):
     ) -> None:
         super().__init__(
             name,
-            instrument,
-            snapshot_get,
-            metadata,
+            instrument=instrument,
+            snapshot_get=snapshot_get,
+            metadata=metadata,
             snapshot_value=snapshot_value,
             snapshot_exclude=snapshot_exclude,
             **kwargs,

--- a/src/qcodes/parameters/specialized_parameters.py
+++ b/src/qcodes/parameters/specialized_parameters.py
@@ -93,15 +93,15 @@ class InstrumentRefParameter(Parameter):
             raise RuntimeError("InstrumentRefParameter does not support set_cmd.")
         super().__init__(
             name,
-            instrument,
-            label,
-            unit,
-            get_cmd,
-            set_cmd,
-            initial_value,
-            max_val_age,
-            vals,
-            docstring,
+            instrument=instrument,
+            label=label,
+            unit=unit,
+            get_cmd=get_cmd,
+            set_cmd=set_cmd,
+            initial_value=initial_value,
+            max_val_age=max_val_age,
+            vals=vals,
+            docstring=docstring,
             **kwargs,
         )
 

--- a/tests/parameter/test_get_set_wrapping.py
+++ b/tests/parameter/test_get_set_wrapping.py
@@ -81,7 +81,7 @@ def test_gettable_settable_attributes_with_get_set_raw(
     assert a.gettable is True
     assert a.settable is True
 
-    b = ParameterBase("foo", None)
+    b = ParameterBase("foo", instrument=None)
 
     assert b.gettable is False
     assert b.settable is False


### PR DESCRIPTION
This makes it less likely to mix up args in the rather long lists of args that these classes takes and to prepare for doing
something similar to #6012 for parameters.

