### PR TITLE
Refactor Agilent drivers

### DIFF
--- a/docs/changes/newsfragments/6089.improved_driver
+++ b/docs/changes/newsfragments/6089.improved_driver
@@ -1,0 +1,6 @@
+The Agilent drivers shipping with QCoDeS have been updated to ensure all Parameters are set as static
+attributes that are documented and can be type checked. The docs for the Agilent drivers have been
+updated to not document inherited members. This makes the documentation significantly more readable
+as it focuses on specific members for a given instrument. The documentation now also links superclasses.
+Please consult these for inherited members. It is the plan to make the same change to all drivers shipping
+with QCoDeS in the near future.

--- a/docs/drivers_api/Agilent.rst
+++ b/docs/drivers_api/Agilent.rst
@@ -5,3 +5,4 @@ Agilent Drivers
 
 .. automodule:: qcodes.instrument_drivers.agilent
    :autosummary:
+   :no-inherited-members:

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34401A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34401A.py
@@ -1,4 +1,15 @@
+from typing import TYPE_CHECKING
+
+from qcodes.instrument import VisaInstrumentKWArgs
+from qcodes.validators import Strings
+
 from ._Agilent_344xxA import Agilent344xxA
+
+if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
+    from qcodes.instrument import VisaInstrumentKWArgs
+    from qcodes.parameters import Parameter
 
 
 class Agilent34401A(Agilent344xxA):
@@ -6,4 +17,18 @@ class Agilent34401A(Agilent344xxA):
     This is the QCoDeS driver for the Agilent 34401A DMM.
     """
 
-    pass
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        **kwargs: "Unpack[VisaInstrumentKWArgs]",
+    ) -> None:
+        super().__init__(name, address, **kwargs)
+
+        self.display_text: Parameter = self.add_parameter(
+            "display_text",
+            get_cmd="DISP:TEXT?",
+            set_cmd='DISP:TEXT "{}"',
+            vals=Strings(),
+        )
+        """Parameter display_text"""

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34401A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34401A.py
@@ -1,7 +1,7 @@
-from ._Agilent_344xxA import _Agilent344xxA
+from ._Agilent_344xxA import Agilent344xxA
 
 
-class Agilent34401A(_Agilent344xxA):
+class Agilent34401A(Agilent344xxA):
     """
     This is the QCoDeS driver for the Agilent 34401A DMM.
     """

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34410A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34410A.py
@@ -1,4 +1,15 @@
+from typing import TYPE_CHECKING
+
+from qcodes.instrument import VisaInstrumentKWArgs
+from qcodes.validators import Strings
+
 from ._Agilent_344xxA import Agilent344xxA
+
+if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
+    from qcodes.instrument import VisaInstrumentKWArgs
+    from qcodes.parameters import Parameter
 
 
 class Agilent34410A(Agilent344xxA):
@@ -6,4 +17,26 @@ class Agilent34410A(Agilent344xxA):
     This is the QCoDeS driver for the Agilent 34410A DMM.
     """
 
-    pass
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        **kwargs: "Unpack[VisaInstrumentKWArgs]",
+    ) -> None:
+        super().__init__(name, address, **kwargs)
+
+        self.display_text: Parameter = self.add_parameter(
+            "display_text",
+            get_cmd="DISP:WIND1:TEXT?",
+            set_cmd='DISP:WIND1:TEXT "{}"',
+            vals=Strings(),
+        )
+        """Parameter display_text"""
+
+        self.display_text_2: Parameter = self.add_parameter(
+            "display_text_2",
+            get_cmd="DISP:WIND2:TEXT?",
+            set_cmd='DISP:WIND2:TEXT "{}"',
+            vals=Strings(),
+        )
+        """Parameter display_text_2"""

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34410A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34410A.py
@@ -1,7 +1,7 @@
-from ._Agilent_344xxA import _Agilent344xxA
+from ._Agilent_344xxA import Agilent344xxA
 
 
-class Agilent34410A(_Agilent344xxA):
+class Agilent34410A(Agilent344xxA):
     """
     This is the QCoDeS driver for the Agilent 34410A DMM.
     """

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34411A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34411A.py
@@ -1,7 +1,7 @@
-from ._Agilent_344xxA import _Agilent344xxA
+from ._Agilent_344xxA import Agilent344xxA
 
 
-class Agilent34411A(_Agilent344xxA):
+class Agilent34411A(Agilent344xxA):
     """
     This is the QCoDeS driver for the Agilent 34411A DMM.
     """

--- a/src/qcodes/instrument_drivers/agilent/Agilent_34411A.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_34411A.py
@@ -1,4 +1,15 @@
+from typing import TYPE_CHECKING
+
+from qcodes.instrument import VisaInstrumentKWArgs
+from qcodes.validators import Strings
+
 from ._Agilent_344xxA import Agilent344xxA
+
+if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
+    from qcodes.instrument import VisaInstrumentKWArgs
+    from qcodes.parameters import Parameter
 
 
 class Agilent34411A(Agilent344xxA):
@@ -6,4 +17,26 @@ class Agilent34411A(Agilent344xxA):
     This is the QCoDeS driver for the Agilent 34411A DMM.
     """
 
-    pass
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        **kwargs: "Unpack[VisaInstrumentKWArgs]",
+    ) -> None:
+        super().__init__(name, address, **kwargs)
+
+        self.display_text: Parameter = self.add_parameter(
+            "display_text",
+            get_cmd="DISP:WIND1:TEXT?",
+            set_cmd='DISP:WIND1:TEXT "{}"',
+            vals=Strings(),
+        )
+        """Parameter display_text"""
+
+        self.display_text_2: Parameter = self.add_parameter(
+            "display_text_2",
+            get_cmd="DISP:WIND2:TEXT?",
+            set_cmd='DISP:WIND2:TEXT "{}"',
+            vals=Strings(),
+        )
+        """Parameter display_text_2"""

--- a/src/qcodes/instrument_drivers/agilent/Agilent_E8257D.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_E8257D.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import qcodes.validators as vals
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
-from qcodes.parameters import create_on_off_val_mapping
+from qcodes.parameters import Parameter, create_on_off_val_mapping
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack
@@ -91,7 +91,7 @@ class AgilentE8257D(VisaInstrument):
             self._min_power = -20
             self._max_power = 5
 
-        self.add_parameter(
+        self.frequency: Parameter = self.add_parameter(
             name="frequency",
             label="Frequency",
             unit="Hz",
@@ -101,8 +101,9 @@ class AgilentE8257D(VisaInstrument):
             set_parser=float,
             vals=vals.Numbers(self._min_freq, self._max_freq),
         )
+        """Parameter frequency"""
 
-        self.add_parameter(
+        self.phase: Parameter = self.add_parameter(
             name="phase",
             label="Phase",
             unit="deg",
@@ -112,8 +113,9 @@ class AgilentE8257D(VisaInstrument):
             set_parser=self.deg_to_rad,
             vals=vals.Numbers(-180, 180),
         )
+        """Parameter phase"""
 
-        self.add_parameter(
+        self.power: Parameter = self.add_parameter(
             name="power",
             label="Power",
             unit="dBm",
@@ -123,13 +125,15 @@ class AgilentE8257D(VisaInstrument):
             set_parser=float,
             vals=vals.Numbers(self._min_power, self._max_power),
         )
+        """Parameter power"""
 
-        self.add_parameter(
+        self.output_enabled: Parameter = self.add_parameter(
             "output_enabled",
             get_cmd=":OUTP?",
             set_cmd="OUTP {}",
             val_mapping=create_on_off_val_mapping(on_val="1", off_val="0"),
         )
+        """Parameter output_enabled"""
 
         self.connect_message()
 

--- a/src/qcodes/instrument_drivers/agilent/Agilent_E8267C.py
+++ b/src/qcodes/instrument_drivers/agilent/Agilent_E8267C.py
@@ -8,6 +8,9 @@ from qcodes.validators import Enum, Numbers
 if TYPE_CHECKING:
     from typing_extensions import Unpack
 
+    from qcodes.parameters import Parameter
+
+
 class AgilentE8267C(VisaInstrument):
     """
     This is the QCoDeS driver for the Agilent E8267C signal generator.
@@ -23,7 +26,7 @@ class AgilentE8267C(VisaInstrument):
     ) -> None:
         super().__init__(name, address, **kwargs)
         # general commands
-        self.add_parameter(
+        self.frequency: Parameter = self.add_parameter(
             name="frequency",
             label="Frequency",
             unit="Hz",
@@ -32,7 +35,8 @@ class AgilentE8267C(VisaInstrument):
             get_parser=float,
             vals=Numbers(min_value=100e3, max_value=40e9),
         )
-        self.add_parameter(
+        """Parameter frequency"""
+        self.freq_offset: Parameter = self.add_parameter(
             name="freq_offset",
             label="Frequency offset",
             unit="Hz",
@@ -41,14 +45,16 @@ class AgilentE8267C(VisaInstrument):
             get_parser=float,
             vals=Numbers(min_value=-200e9, max_value=200e9),
         )
-        self.add_parameter(
+        """Parameter freq_offset"""
+        self.freq_mode: Parameter = self.add_parameter(
             "freq_mode",
             label="Frequency mode",
             set_cmd="FREQ:MODE {}",
             get_cmd="FREQ:MODE?",
             vals=Enum("FIX", "CW", "SWE", "LIST"),
         )
-        self.add_parameter(
+        """Parameter freq_mode"""
+        self.pulse_width: Parameter = self.add_parameter(
             "pulse_width",
             label="Pulse width",
             unit="ns",
@@ -56,7 +62,8 @@ class AgilentE8267C(VisaInstrument):
             get_cmd="PULM:INT:PWID?",
             vals=Numbers(min_value=10e-9, max_value=20e-9),
         )
-        self.add_parameter(
+        """Parameter pulse_width"""
+        self.phase: Parameter = self.add_parameter(
             name="phase",
             label="Phase",
             unit="deg",
@@ -66,7 +73,8 @@ class AgilentE8267C(VisaInstrument):
             set_parser=self.deg_to_rad,
             vals=Numbers(min_value=-180, max_value=179),
         )
-        self.add_parameter(
+        """Parameter phase"""
+        self.power: Parameter = self.add_parameter(
             name="power",
             label="Power",
             unit="dBm",
@@ -75,7 +83,8 @@ class AgilentE8267C(VisaInstrument):
             get_parser=float,
             vals=Numbers(min_value=-135, max_value=25),
         )
-        self.add_parameter(
+        """Parameter power"""
+        self.power_offset: Parameter = self.add_parameter(
             name="power_offset",
             label="Power offset",
             unit="dBm",
@@ -84,18 +93,21 @@ class AgilentE8267C(VisaInstrument):
             get_parser=float,
             vals=Numbers(min_value=-200, max_value=200),
         )
-        self.add_parameter(
+        """Parameter power_offset"""
+        self.output_rf: Parameter = self.add_parameter(
             name="output_rf",
             get_cmd="OUTP?",
             set_cmd="OUTP {}",
             val_mapping={"OFF": 0, "ON": 1},
         )
-        self.add_parameter(
+        """Parameter output_rf"""
+        self.modulation_rf: Parameter = self.add_parameter(
             name="modulation_rf",
             get_cmd="OUTP:MOD?",
             set_cmd="OUTP:MOD {}",
             val_mapping={"OFF": 0, "ON": 1},
         )
+        """Parameter modulation_rf"""
         # reset values after each reconnect
         self.power(0)
         self.power_offset(0)

--- a/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
+++ b/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
 
 class Agilent344xxA(VisaInstrument):
     """
-    This is the QCoDeS driver for the Agilent_34400A DMM Series,
-    tested with Agilent_34401A, Agilent_34410A, and Agilent_34411A.
+    This is the base class for QCoDeS driver for the Agilent 34400A DMM Series.
+    This class should not be instantiated directly but a specific sub model should
+    be used.
 
     Note that most models are better supported by the Keysight 33xxA drivers.
     """

--- a/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
+++ b/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.parameters import Parameter
-from qcodes.validators import Enum, Strings
+from qcodes.validators import Enum
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack
@@ -118,32 +118,6 @@ class Agilent344xxA(VisaInstrument):
             vals=Enum(0.1, 1.0, 10.0, 100.0, 1000.0),
         )
         """Parameter range"""
-
-        if self.model in ["34401A"]:
-            self.display_text: Parameter = self.add_parameter(
-                "display_text",
-                get_cmd="DISP:TEXT?",
-                set_cmd='DISP:TEXT "{}"',
-                vals=Strings(),
-            )
-            """Parameter display_text"""
-
-        elif self.model in ["34410A", "34411A"]:
-            self.display_text: Parameter = self.add_parameter(
-                "display_text",
-                get_cmd="DISP:WIND1:TEXT?",
-                set_cmd='DISP:WIND1:TEXT "{}"',
-                vals=Strings(),
-            )
-            """Parameter display_text"""
-
-            self.display_text_2: Parameter = self.add_parameter(
-                "display_text_2",
-                get_cmd="DISP:WIND2:TEXT?",
-                set_cmd='DISP:WIND2:TEXT "{}"',
-                vals=Strings(),
-            )
-            """Parameter display_text_2"""
 
         self.connect_message()
 

--- a/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
+++ b/src/qcodes/instrument_drivers/agilent/_Agilent_344xxA.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from typing_extensions import Unpack
 
 
-class _Agilent344xxA(VisaInstrument):
+class Agilent344xxA(VisaInstrument):
     """
     This is the QCoDeS driver for the Agilent_34400A DMM Series,
     tested with Agilent_34401A, Agilent_34410A, and Agilent_34411A.
@@ -64,11 +64,12 @@ class _Agilent344xxA(VisaInstrument):
         )
         """Resolution """
 
-        self.add_parameter(
+        self.volt: Parameter = self.add_parameter(
             "volt", get_cmd="READ?", label="Voltage", get_parser=float, unit="V"
         )
+        """Parameter volt"""
 
-        self.add_parameter(
+        self.fetch: Parameter = self.add_parameter(
             "fetch",
             get_cmd="FETCH?",
             label="Voltage",
@@ -83,8 +84,9 @@ class _Agilent344xxA(VisaInstrument):
                 "for data in the first place!"
             ),
         )
+        """Parameter fetch"""
 
-        self.add_parameter(
+        self.NPLC: Parameter = self.add_parameter(
             "NPLC",
             get_cmd="VOLT:NPLC?",
             get_parser=float,
@@ -93,46 +95,55 @@ class _Agilent344xxA(VisaInstrument):
             label="Integration time",
             unit="NPLC",
         )
+        """Parameter NPLC"""
 
-        self.add_parameter("terminals", get_cmd="ROUT:TERM?")
+        self.terminals: Parameter = self.add_parameter(
+            "terminals", get_cmd="ROUT:TERM?"
+        )
+        """Parameter terminals"""
 
-        self.add_parameter(
+        self.range_auto: Parameter = self.add_parameter(
             "range_auto",
             get_cmd="VOLT:RANG:AUTO?",
             set_cmd="VOLT:RANG:AUTO {:d}",
             val_mapping={"on": 1, "off": 0},
         )
+        """Parameter range_auto"""
 
-        self.add_parameter(
+        self.range: Parameter = self.add_parameter(
             "range",
             get_cmd="SENS:VOLT:DC:RANG?",
             get_parser=float,
             set_cmd="SENS:VOLT:DC:RANG {:f}",
             vals=Enum(0.1, 1.0, 10.0, 100.0, 1000.0),
         )
+        """Parameter range"""
 
         if self.model in ["34401A"]:
-            self.add_parameter(
+            self.display_text: Parameter = self.add_parameter(
                 "display_text",
                 get_cmd="DISP:TEXT?",
                 set_cmd='DISP:TEXT "{}"',
                 vals=Strings(),
             )
+            """Parameter display_text"""
 
         elif self.model in ["34410A", "34411A"]:
-            self.add_parameter(
+            self.display_text: Parameter = self.add_parameter(
                 "display_text",
                 get_cmd="DISP:WIND1:TEXT?",
                 set_cmd='DISP:WIND1:TEXT "{}"',
                 vals=Strings(),
             )
+            """Parameter display_text"""
 
-            self.add_parameter(
+            self.display_text_2: Parameter = self.add_parameter(
                 "display_text_2",
                 get_cmd="DISP:WIND2:TEXT?",
                 set_cmd='DISP:WIND2:TEXT "{}"',
                 vals=Strings(),
             )
+            """Parameter display_text_2"""
 
         self.connect_message()
 

--- a/src/qcodes/instrument_drivers/agilent/__init__.py
+++ b/src/qcodes/instrument_drivers/agilent/__init__.py
@@ -1,3 +1,4 @@
+from ._Agilent_344xxA import Agilent344xxA
 from .Agilent_34401A import Agilent34401A
 from .Agilent_34410A import Agilent34410A
 from .Agilent_34411A import Agilent34411A
@@ -5,6 +6,7 @@ from .Agilent_E8257D import AgilentE8257D
 from .Agilent_E8267C import AgilentE8267C
 
 __all__ = [
+    "Agilent344xxA",
     "Agilent34401A",
     "Agilent34410A",
     "Agilent34411A",


### PR DESCRIPTION
This is an example of applying #4412 to Agilent drivers

* Convert attributes to be assigned using automatic tool
* Move model specific parameters into submodels so they can be declared statically
* Document baseclass and disable documentation of inherited attributes. This is such that the duplication is reduced and the docs becomes more readable.

- [x] newsfragment
