### PR TITLE
Refactor AimTTI drivers 

### DIFF
--- a/docs/changes/newsfragments/6105.improved_driver
+++ b/docs/changes/newsfragments/6105.improved_driver
@@ -1,0 +1,5 @@
+The Aim TTi drivers shipping with QCoDeS have been updated to ensure all Parameters are set as static
+attributes that are documented and can be type checked. The docs for the Aim TTi drivers have been
+updated to not document inherited members. This makes the documentation significantly more readable
+as it focuses on specific members for a given instrument. The documentation now also links superclasses.
+Please consult these for inherited members.

--- a/docs/drivers_api/AimTTi.rst
+++ b/docs/drivers_api/AimTTi.rst
@@ -5,3 +5,4 @@ AimTTi Drivers
 
 .. automodule:: qcodes.instrument_drivers.AimTTi
     :autosummary:
+    :no-inherited-members:

--- a/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -8,7 +8,7 @@ from qcodes.instrument import (
     VisaInstrument,
     VisaInstrumentKWArgs,
 )
-from qcodes.parameters import create_on_off_val_mapping
+from qcodes.parameters import Parameter, create_on_off_val_mapping
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack
@@ -46,7 +46,7 @@ class AimTTiChannel(InstrumentChannel):
         # internally.
         self.set_up_store_slots = [i for i in range(0, 10)]
 
-        self.add_parameter(
+        self.volt: Parameter = self.add_parameter(
             "volt",
             get_cmd=self._get_voltage_value,
             get_parser=float,
@@ -54,8 +54,9 @@ class AimTTiChannel(InstrumentChannel):
             label="Voltage",
             unit="V",
         )
+        """Parameter volt"""
 
-        self.add_parameter(
+        self.volt_step_size: Parameter = self.add_parameter(
             "volt_step_size",
             get_cmd=self._get_voltage_step_size,
             get_parser=float,
@@ -63,8 +64,9 @@ class AimTTiChannel(InstrumentChannel):
             label="Voltage Step Size",
             unit="V",
         )
+        """Parameter volt_step_size"""
 
-        self.add_parameter(
+        self.curr: Parameter = self.add_parameter(
             "curr",
             get_cmd=self._get_current_value,
             get_parser=float,
@@ -72,8 +74,9 @@ class AimTTiChannel(InstrumentChannel):
             label="Current",
             unit="A",
         )
+        """Parameter curr"""
 
-        self.add_parameter(
+        self.curr_range: Parameter = self.add_parameter(
             "curr_range",
             get_cmd=f"IRANGE{channel}?",
             get_parser=int,
@@ -85,8 +88,9 @@ class AimTTiChannel(InstrumentChannel):
             "Here, the integer 1 is for the Low range, "
             "and integer 2 is for the High range.",
         )
+        """Set the current range of the output.Here, the integer 1 is for the Low range, and integer 2 is for the High range."""
 
-        self.add_parameter(
+        self.curr_step_size: Parameter = self.add_parameter(
             "curr_step_size",
             get_cmd=self._get_current_step_size,
             get_parser=float,
@@ -94,14 +98,16 @@ class AimTTiChannel(InstrumentChannel):
             label="Current Step Size",
             unit="A",
         )
+        """Parameter curr_step_size"""
 
-        self.add_parameter(
+        self.output: Parameter = self.add_parameter(
             "output",
             get_cmd=f"OP{channel}?",
             get_parser=float,
             set_cmd=f"OP{channel} {{}}",
             val_mapping=create_on_off_val_mapping(on_val=1, off_val=0),
         )
+        """Parameter output"""
 
     def _get_voltage_value(self) -> float:
         channel_id = self.channel

--- a/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -1,9 +1,10 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 from qcodes import validators as vals
 from qcodes.instrument import (
     ChannelList,
     Instrument,
+    InstrumentBaseKWArgs,
     InstrumentChannel,
     VisaInstrument,
     VisaInstrumentKWArgs,
@@ -29,7 +30,11 @@ class AimTTiChannel(InstrumentChannel):
     """
 
     def __init__(
-        self, parent: Instrument, name: str, channel: int, **kwargs: Any
+        self,
+        parent: Instrument,
+        name: str,
+        channel: int,
+        **kwargs: "Unpack[InstrumentBaseKWArgs]",
     ) -> None:
         """
         Args:

--- a/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -89,11 +89,11 @@ class AimTTiChannel(InstrumentChannel):
             label="Current Range",
             unit="A",
             vals=vals.Numbers(1, 2),
-            docstring="Set the current range of the output."
+            docstring="Set the current range of the output. "
             "Here, the integer 1 is for the Low range, "
             "and integer 2 is for the High range.",
         )
-        """Set the current range of the output.Here, the integer 1 is for the Low range, and integer 2 is for the High range."""
+        """Set the current range of the output. Here, the integer 1 is for the Low range, and integer 2 is for the High range."""
 
         self.curr_step_size: Parameter = self.add_parameter(
             "curr_step_size",

--- a/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/src/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -226,8 +226,10 @@ class AimTTiChannel(InstrumentChannel):
 
 class AimTTi(VisaInstrument):
     """
-    This is the QCoDeS driver for the Aim TTi PL-P series power supply.
-    Tested with Aim TTi PL601-P equipped with a single output channel.
+    Base class for Aim TTi PL-P series power supply.
+    This class should not be instantiated directly, but rather one of the
+    subclasses corresponding to the specific model of the power supply should
+    be used.
     """
 
     _numOutputChannels: ClassVar[dict[str, int]] = {

--- a/src/qcodes/instrument_drivers/AimTTi/__init__.py
+++ b/src/qcodes/instrument_drivers/AimTTi/__init__.py
@@ -1,4 +1,4 @@
-from ._AimTTi_PL_P import AimTTiChannel, NotKnownModel
+from ._AimTTi_PL_P import AimTTi, AimTTiChannel, NotKnownModel
 from .Aim_TTi_PL068_P import AimTTiPL068P
 from .Aim_TTi_PL155_P import AimTTiPL155P
 from .Aim_TTi_PL303_P import AimTTiPL303P
@@ -8,6 +8,7 @@ from .Aim_TTi_PL601_P import AimTTiPL601
 from .Aim_TTi_QL355_TP import AimTTiQL355TP
 
 __all__ = [
+    "AimTTi",
     "AimTTiChannel",
     "AimTTiPL068P",
     "AimTTiPL155P",


### PR DESCRIPTION
* Convert attributes to be assigned using automatic tool
* Document baseclass and disable documentation of inherited attributes. This is such that the duplication is reduced, and the docs becomes more readable.