### PR TITLE
Avoid triggering warnings + nan in fieldvector conversion

### DIFF
--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -101,7 +101,14 @@ class FieldVector:
         r = np.sqrt(x ** 2 + y ** 2 + z ** 2)
         if r != 0:
             z_r_frac = z / r
-            assert abs(z_r_frac) <= 1
+            # it it possible that z_r_frac is slightly larger than 1 or
+            # slightly smaller than -1 due to floating point errors.
+            # an example that triggers this is:
+            # x=0, y=0, z=3.729170476738041e-155
+            if z_r_frac > 1:
+                z_r_frac = 1
+            elif z_r_frac < -1:
+                z_r_frac = -1
             theta = np.arccos(z_r_frac)
         else:
             theta = 0
@@ -133,7 +140,16 @@ class FieldVector:
         y = rho * np.sin(phi)
         r = np.sqrt(rho ** 2 + z ** 2)
         if r != 0:
-            theta = np.arccos(z / r)
+            z_r_frac = z / r
+            # it it possible that z_r_frac is slightly larger than 1 or
+            # slightly smaller than -1 due to floating point errors.
+            # an example that triggers this is:
+            # phi=0, rho=0, z=3.729170476738041e-155
+            if z_r_frac > 1:
+                z_r_frac = 1
+            elif z_r_frac < -1:
+                z_r_frac = -1
+            theta = np.arccos(z_r_frac)
         else:
             theta = 0
 

--- a/tests/drivers/test_ami430_visa.py
+++ b/tests/drivers/test_ami430_visa.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict
 
 import numpy as np
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, example, given, settings
 from hypothesis.strategies import floats, tuples
 from pytest import FixtureRequest, LogCaptureFixture
 
@@ -374,6 +374,10 @@ def test_cylindrical_sanity(current_driver, set_target) -> None:
     assert np.allclose(set_target, [rho, phi, z])
 
 
+# add some examples where floating point math results
+# in z > r due to round off errors and ensure
+# we handle them correctly
+@example((0, 0, 3.729170476738041e-155))
 @given(set_target=random_coordinates["cartesian"])
 @settings(
     max_examples=10,
@@ -424,7 +428,10 @@ def test_spherical_setpoints(current_driver, set_target) -> None:
     get_vector = FieldVector(**get_target)
     assert set_vector.is_equal(get_vector)
 
-
+# add some examples where floating point math results
+# in z > r due to round off errors and ensure
+# we handle them correctly
+@example((0, 0, 3.729170476738041e-155))
 @given(set_target=random_coordinates["cylindrical"])
 @settings(
     max_examples=10,


### PR DESCRIPTION
These are triggered due to floating point round off errors.
Since we do not accept warnings in the test suite these cause tests to fail


