### PR TITLE
Only warn on parameter overriding attribute if this is not a parameter

### DIFF
--- a/docs/changes/0.46.0.rst
+++ b/docs/changes/0.46.0.rst
@@ -21,8 +21,11 @@ Breaking Changes:
 - It is now considered unsupported to modify the `parameters` attribute of an instrument or instrument module after it has been created.
   To remove a parameter from an instrument use the `remove_parameter` method. (:pr:`6174`)
 
-- InstrumentBase.add_parameter will now error if an attribute of the same name as the parameter added already exists. This
-  is similar to how it would error if a parameter of the same name existed. (:pr:`6174`)
+- InstrumentBase.add_parameter will now error if an attribute of the same name as the parameter added already exists and
+  this attribute is an instance of `ParameterBase`. This is to prevent issues where a parameter is partially
+  overwritten by a new parameter. To remove the existing Parameter use the new `instrument.remove_parameter`` method.
+  If the attribute is not a ParameterBase this will instead warn. It is the intention that this becomes an error in the future.
+  (:pr:`6174`) (:pr:`6211`)
 
 
 Improved:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -334,9 +334,14 @@ class ParameterBase(MetadatableWithName):
                     )
                 if existing_parameter is None:
                     existing_attribute = getattr(instrument, name, None)
-                    if existing_attribute is not None:
+                    if isinstance(existing_attribute, ParameterBase):
                         raise KeyError(
-                            f"Parameter {name} overrides an attribute of the same name on instrument {instrument}"
+                            f"Duplicate parameter name {name} on instrument {instrument}"
+                        )
+                    elif existing_attribute is not None:
+                        warnings.warn(
+                            f"Parameter {name} overrides an attribute of the same name on instrument {instrument} "
+                            "This will be an error in the future.",
                         )
 
             instrument.parameters[name] = self

--- a/tests/parameter/test_parameter_override.py
+++ b/tests/parameter/test_parameter_override.py
@@ -59,14 +59,13 @@ class DummyInstr(Instrument):
 def test_overriding_parameter_attribute_with_parameter_raises():
     with pytest.raises(
         KeyError,
-        match="Parameter voltage overrides an attribute of the same name on instrument",
+        match="Duplicate parameter name voltage on instrument",
     ):
         DummyOverrideInstr("my_instr")
 
 
 def test_overriding_attribute_with_parameter_raises():
-    with pytest.raises(
-        KeyError,
+    with pytest.warns(
         match="Parameter voltage overrides an attribute of the same name on instrument",
     ):
         DummyParameterIsAttrInstr("my_instr")


### PR DESCRIPTION
This makes the error from #6174 a warning if the overridden attribute is not itself a parameter. 