### PR TITLE
LakeShore335: add power output parameters

### DIFF
--- a/docs/changes/newsfragments/6248.improved_driver
+++ b/docs/changes/newsfragments/6248.improved_driver
@@ -1,2 +1,2 @@
-- Add power output parameters to LakeShore335 driver, 
+- Add power output parameters to LakeShore335 driver,
   this allows to configure the maximum heater current.

--- a/docs/changes/newsfragments/6248.improved_driver
+++ b/docs/changes/newsfragments/6248.improved_driver
@@ -1,0 +1,2 @@
+- Add power output parameters to LakeShore335 driver, 
+  this allows to configure the maximum heater current.

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -130,9 +130,9 @@ class LakeshoreBaseOutput(InstrumentChannel):
         self.output_type: GroupParameter = self.add_parameter(
             name="output_type",
             docstring="Output type (Output 2 only): 0=Current, 1=Voltage",
-            val_mapping={"current": 0, "voltage": 1}
-            if output_index == 1
-            else {"current": 0},
+            val_mapping=(
+                {"current": 0, "voltage": 1} if output_index == 1 else {"current": 0}
+            ),
             parameter_class=GroupParameter,
         )
         """Output type (Output 2 only): 0=Current, 1=Voltage"""

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -121,10 +121,67 @@ class LakeshoreBaseOutput(InstrumentChannel):
                 parameter_class=GroupParameter,
             )
             """The value for closed control loop Derivative (rate)"""
-            self.pid_group = Group([self.P, self.I, self.D],
-                                   set_cmd=f'PID {output_index}, '
-                                           f'{{P}}, {{I}}, {{D}}',
-                                   get_cmd=f'PID? {output_index}')
+            self.pid_group = Group(
+                [self.P, self.I, self.D],
+                set_cmd=f"PID {output_index},{{P}},{{I}},{{D}}",
+                get_cmd=f"PID? {output_index}",
+            )
+
+        self.output_type: GroupParameter = self.add_parameter(
+            name="output_type",
+            docstring="Output type (Output 2 only): 0=Current, 1=Voltage",
+            val_mapping={"current": 0, "voltage": 1}
+            if output_index == 1
+            else {"current": 0},
+            parameter_class=GroupParameter,
+        )
+        """Output type (Output 2 only): 0=Current, 1=Voltage"""
+
+        self.output_heater_resistance: GroupParameter = self.add_parameter(
+            name="output_heater_resistance",
+            docstring="Heater Resistance Setting: 25/50ohm",
+            val_mapping={"25ohm": 1, "50ohm": 2},
+            parameter_class=GroupParameter,
+        )
+        """Heater Resistance Setting: 25/50ohm"""
+
+        self.output_max_current: GroupParameter = self.add_parameter(
+            name="output_max_current",
+            docstring="Specifies the maximum heater output current: User Specified, 0.707 A, 1 A, 1.141 A, 1.732",
+            val_mapping={"user": 0, "0.707A": 1, "1A": 2, "1.141A": 3, "1.732A": 4},
+            parameter_class=GroupParameter,
+        )
+        """Specifies the maximum heater output current: User Specified, 0.707 A, 1 A, 1.141 A, 1.732"""
+
+        self.output_max_user_current: GroupParameter = self.add_parameter(
+            name="output_max_user_current",
+            docstring="Specifies the maximum heater output current if max current is set to User Specified.",
+            vals=vals.Numbers(0, 1.732),
+            unit="A",
+            get_parser=float,
+            parameter_class=GroupParameter,
+        )
+        """Specifies the maximum heater output current if max current is set to User Specified."""
+
+        self.output_display: GroupParameter = self.add_parameter(
+            name="output_display",
+            docstring="Specifies whether the heater output displays in current or power (current mode only)",
+            val_mapping={"current": 1, "power": 2},
+            parameter_class=GroupParameter,
+        )
+        """Specifies whether the heater output displays in current or power (current mode only)"""
+
+        self.heater_group = Group(
+            [
+                self.output_type,
+                self.output_heater_resistance,
+                self.output_max_current,
+                self.output_max_user_current,
+                self.output_display,
+            ],
+            set_cmd=f"HTRSET {output_index},{{output_type}},{{output_heater_resistance}},{{output_max_current}},{{output_max_user_current}},{{output_display}}",
+            get_cmd=f"HTRSET? {output_index}",
+        )
 
         self.output_range: Parameter = self.add_parameter(
             "output_range",


### PR DESCRIPTION
Add power output parameters to LakeShore335 driver, this allows to configure the maximum heater current.