### PR TITLE
Add 'offset' parameter to Tektronix AWG Channels

### DIFF
--- a/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -331,6 +331,17 @@ class Tektronix70000AWGChannel(InstrumentChannel):
             vals=vals.Numbers(0.250, _chan_amps[self.model]))
         """Parameter awg_amplitude"""
 
+        self.offset: Parameter = self.add_parameter(
+            "offset",
+            label=f"Channel {channel} Offset for DC Output paths",
+            set_cmd=f"SOURce{channel}:VOLTage:LEVel:IMMediate:OFFSet {{}}",
+            get_cmd=f"SOURce{channel}:VOLTage:LEVel:IMMediate:OFFSet?",
+            unit="V",
+            get_parser=float,
+            vals=vals.Numbers(-2.0, 2.0),
+        )
+        """Parameter offset"""
+
         self.assigned_asset: Parameter = self.add_parameter(
             "assigned_asset",
             label=(f"Waveform/sequence assigned to channel {self.channel}"),


### PR DESCRIPTION
This change adds support for the `offset` parameter on Tektronix AWG channels.

See page 2-261 of the [AWG5200 Programmer Manual](https://download.tek.com/manual/AWG5200-Programmer-Manual-077133700-RevA.pdf) for full details on this command.  A summary of the syntax from that page is as follows:

```
SOURce[n]:]VOLTage[:LEVel][:IMMediate]:OFFSet

This command sets or returns the Offset (for DC output paths) for the waveform
associated with the specified channel.

Conditions This is a blocking command. (See page 2-9, Sequential, blocking, and overlapping
commands.)

 Group: Source

 Syntax
- [SOURce[n]:]VOLTage[:LEVel][:IMMediate]:OFFSet <NRf>
- [SOURce[n]:]VOLTage[:LEVel][:IMMediate]:OFFSet?
```