### PR TITLE
Fix: Check exp_id in experiment list

### DIFF
--- a/src/qcodes/dataset/experiment_container.py
+++ b/src/qcodes/dataset/experiment_container.py
@@ -67,10 +67,10 @@ class Experiment(Sized):
 
         self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
 
-        max_id = len(get_experiments(self.conn))
+        experiments_list = get_experiments(self.conn)
 
         if exp_id is not None:
-            if exp_id not in range(1, max_id+1):
+            if exp_id not in experiments_list:
                 raise ValueError('No such experiment in the database')
             self._exp_id = exp_id
         else:
@@ -86,7 +86,7 @@ class Experiment(Sized):
                                  "(name, exp_id, run_counter)") from e
 
             log.info(f"creating new experiment in {self.path_to_db}")
-
+            max_id = max(experiments_list, default=0)
             name = name or f"experiment_{max_id+1}"
             sample_name = sample_name or "some_sample"
             self._exp_id = ne(self.conn, name, sample_name, format_string)


### PR DESCRIPTION
Instead of checking with just the length of the experiment list.
Check that the exp_id is in the experiment list.
Useful when working with an offset or missing entries in the database.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [X] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
