### PR TITLE
AMI430 cleanup

### DIFF
--- a/docs/changes/newsfragments/6306.improved_driver
+++ b/docs/changes/newsfragments/6306.improved_driver
@@ -1,0 +1,5 @@
+The ``qcodes.instrument_drivers.american_magnetics.AMIModel430`` driver can now be snapshotted with the heater missing or not enabled
+without triggering warnings. Furthermore confusing aliases for parameters on the switch module have been deprecated since use of these would
+lead to incorrect state of the parameters.
+The aliases ``qcodes.instrument_drivers.american_magnetics.AMI_430_visa.AMI430_3D`` and ``qcodes.instrument_drivers.american_magnetics.AMI_430_visa.AMI430``
+have been deprecated.

--- a/src/qcodes/instrument/sims/AMI430.yaml
+++ b/src/qcodes/instrument/sims/AMI430.yaml
@@ -113,6 +113,31 @@ devices:
         setter:
           q: "PS {}"
 
+      persistent heater current:
+        default: 0
+        getter:
+          q: "PS:CURR?"
+          r: "{}"
+        setter:
+          q: "CONF:PS:CURR {}"
+
+      persistent heater heat_time:
+        default: 5
+        getter:
+          q: "PS:HTIME?"
+          r: "{}"
+        setter:
+          q: "CONF:PS:HTIME {}"
+
+      persistent heater cool_time:
+        default: 3600
+        getter:
+          q: "PS:CTIME?"
+          r: "{}"
+        setter:
+          q: "CONF:PS:CTIME {}"
+
+
       pause:
         setter:
           q: "PAUSE"

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -134,18 +134,27 @@ class AMI430SwitchHeater(InstrumentChannel):
         self.write(cmd="CONF:PS 1")
         self._enabled = True
 
-    @deprecated("Use enabled parameter to enable/disable the switch heater.")
+    @deprecated(
+        "Use enabled parameter to enable/disable the switch heater.",
+        category=QCoDeSDeprecationWarning,
+    )
     def disable(self) -> None:
         self._disable()
 
-    @deprecated("Use enabled parameter to enable/disable the switch heater.")
+    @deprecated(
+        "Use enabled parameter to enable/disable the switch heater.",
+        category=QCoDeSDeprecationWarning,
+    )
     def enable(self) -> None:
         self._enable()
 
     def _check_enabled(self) -> bool:
         return bool(int(self.ask("PS:INST?").strip()))
 
-    @deprecated("Use enabled parameter to inspect switch heater status.")
+    @deprecated(
+        "Use enabled parameter to inspect switch heater status.",
+        category=QCoDeSDeprecationWarning,
+    )
     def check_enabled(self) -> bool:
         return self._check_enabled()
 
@@ -155,7 +164,10 @@ class AMI430SwitchHeater(InstrumentChannel):
         while self._parent.ramping_state() == "heating switch":
             self._parent._sleep(0.5)
 
-    @deprecated("Use state parameter to turn on the switch heater.")
+    @deprecated(
+        "Use state parameter to turn on the switch heater.",
+        category=QCoDeSDeprecationWarning,
+    )
     def on(self) -> None:
         self._on()
 
@@ -165,7 +177,10 @@ class AMI430SwitchHeater(InstrumentChannel):
         while self._parent.ramping_state() == "cooling switch":
             self._parent._sleep(0.5)
 
-    @deprecated("Use state parameter to turn off the switch heater.")
+    @deprecated(
+        "Use state parameter to turn off the switch heater.",
+        category=QCoDeSDeprecationWarning,
+    )
     def off(self) -> None:
         self._off()
 
@@ -174,7 +189,10 @@ class AMI430SwitchHeater(InstrumentChannel):
             return False
         return bool(int(self.ask("PS?").strip()))
 
-    @deprecated("Use state parameter to inspect if switch heater is on.")
+    @deprecated(
+        "Use state parameter to inspect if switch heater is on.",
+        category=QCoDeSDeprecationWarning,
+    )
     def check_state(self) -> bool:
         return self._check_state()
 
@@ -626,6 +644,10 @@ class AMIModel430(VisaInstrument):
         return result
 
 
+@deprecated(
+    "Use qcodes.instrument_drivers.american_magnetics.AMIModel430 instead.",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430(AMIModel430):
     pass
 
@@ -1296,5 +1318,9 @@ class AMIModel4303D(Instrument):
         self._set_point = set_point
 
 
+@deprecated(
+    "Use qcodes.instrument_drivers.american_magnetics.AMIModel4303D instead.",
+    category=QCoDeSDeprecationWarning,
+)
 class AMI430_3D(AMIModel4303D):
     pass

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -83,7 +83,7 @@ class AMI430SwitchHeater(InstrumentChannel):
             set_cmd=lambda x: (self.on() if x else self.off()),
             vals=Bool(),
         )
-        """Parameter state"""
+        """Parameter state. Always False is the switch heater is not enabled"""
         self.in_persistent_mode: Parameter = self.add_parameter(
             "in_persistent_mode",
             label="Persistent Mode",
@@ -149,8 +149,9 @@ class AMI430SwitchHeater(InstrumentChannel):
         while self._parent.ramping_state() == "cooling switch":
             self._parent._sleep(0.5)
 
-    @_Decorators.check_enabled
     def check_state(self) -> bool:
+        if self.enabled() is False:
+            return False
         return bool(int(self.ask("PS?").strip()))
 
 

--- a/tests/drivers/test_ami430_visa.py
+++ b/tests/drivers/test_ami430_visa.py
@@ -1287,8 +1287,13 @@ def test_change_field_units_parameter(ami430, new_value, unit_string) -> None:
     ami430.field_units("tesla")
 
 
-def test_switch_heater_enabled(ami430) -> None:
+def test_switch_heater_enabled(ami430, caplog) -> None:
     assert ami430.switch_heater.enabled() is False
+    # make sure that getting snapshot with heater disabled works without warning
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=ami430.log.name):
+        ami430.snapshot(update=True)
+    assert len(caplog.records) == 0
     ami430.switch_heater.enabled(True)
     assert ami430.switch_heater.enabled() is True
     ami430.switch_heater.enabled(False)

--- a/tests/drivers/test_ami430_visa.py
+++ b/tests/drivers/test_ami430_visa.py
@@ -18,7 +18,10 @@ from qcodes.instrument_drivers.american_magnetics import (
     AMIModel430,
     AMIModel4303D,
 )
-from qcodes.instrument_drivers.american_magnetics.AMI430_visa import AMI430, AMI430_3D
+from qcodes.instrument_drivers.american_magnetics.AMI430_visa import (
+    AMI430,  # pyright: ignore[reportDeprecated]
+    AMI430_3D,  # pyright: ignore[reportDeprecated]
+)
 from qcodes.math_utils import FieldVector
 from qcodes.utils.types import (
     numpy_concrete_floats,
@@ -143,18 +146,20 @@ def test_instantiation_compat_classes(request: FixtureRequest) -> None:
     Test that we can instantiate drivers using the old names
     """
     request.addfinalizer(AMIModel4303D.close_all)
-    request.addfinalizer(AMI430_3D.close_all)
-    mag_x = AMI430(
+    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
+    mag_x = AMI430(  # pyright: ignore[reportDeprecated]
         "x", address="GPIB::1::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
     )
-    mag_y = AMI430(
+    mag_y = AMI430(  # pyright: ignore[reportDeprecated]
         "y", address="GPIB::2::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
     )
-    mag_z = AMI430(
+    mag_z = AMI430(  # pyright: ignore[reportDeprecated]
         "z", address="GPIB::3::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
     )
 
-    driver = AMI430_3D("AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit)
+    driver = AMI430_3D(  # pyright: ignore[reportDeprecated]
+        "AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit
+    )
 
     assert driver._instrument_x is mag_x
     assert driver._instrument_y is mag_y

--- a/tests/drivers/test_ami430_visa.py
+++ b/tests/drivers/test_ami430_visa.py
@@ -23,6 +23,7 @@ from qcodes.instrument_drivers.american_magnetics.AMI430_visa import (
     AMI430_3D,  # pyright: ignore[reportDeprecated]
 )
 from qcodes.math_utils import FieldVector
+from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.utils.types import (
     numpy_concrete_floats,
     numpy_concrete_ints,
@@ -132,7 +133,7 @@ def test_instantiation_from_names(
     names as opposed from their instances.
     """
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
 
     driver = AMIModel4303D("AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit)
 
@@ -145,21 +146,31 @@ def test_instantiation_compat_classes(request: FixtureRequest) -> None:
     """
     Test that we can instantiate drivers using the old names
     """
-    request.addfinalizer(AMIModel4303D.close_all)
-    request.addfinalizer(AMI430_3D.close_all)  # pyright: ignore[reportDeprecated]
-    mag_x = AMI430(  # pyright: ignore[reportDeprecated]
-        "x", address="GPIB::1::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
-    )
-    mag_y = AMI430(  # pyright: ignore[reportDeprecated]
-        "y", address="GPIB::2::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
-    )
-    mag_z = AMI430(  # pyright: ignore[reportDeprecated]
-        "z", address="GPIB::3::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
-    )
+    request.addfinalizer(Instrument.close_all)
 
-    driver = AMI430_3D(  # pyright: ignore[reportDeprecated]
-        "AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit
-    )
+    with pytest.warns(QCoDeSDeprecationWarning):
+        mag_x = AMI430(  # pyright: ignore[reportDeprecated]
+            "x",
+            address="GPIB::1::INSTR",
+            pyvisa_sim_file="AMI430.yaml",
+            terminator="\n",
+        )
+        mag_y = AMI430(  # pyright: ignore[reportDeprecated]
+            "y",
+            address="GPIB::2::INSTR",
+            pyvisa_sim_file="AMI430.yaml",
+            terminator="\n",
+        )
+        mag_z = AMI430(  # pyright: ignore[reportDeprecated]
+            "z",
+            address="GPIB::3::INSTR",
+            pyvisa_sim_file="AMI430.yaml",
+            terminator="\n",
+        )
+
+        driver = AMI430_3D(  # pyright: ignore[reportDeprecated]
+            "AMI430_3D", mag_x.name, mag_y.name, mag_z.name, field_limit
+        )
 
     assert driver._instrument_x is mag_x
     assert driver._instrument_y is mag_y
@@ -170,7 +181,7 @@ def test_visa_interaction(request: FixtureRequest) -> None:
     """
     Test that closing one instrument we can still use the other simulated instruments.
     """
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
     mag_x = AMIModel430(
         "x", address="GPIB::1::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
     )
@@ -206,7 +217,7 @@ def test_sim_visa_reset_on_fully_closed(request: FixtureRequest) -> None:
     Test that closing all instruments defined in a yaml file will reset the
     state of all the instruments.
     """
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
     mag_x = AMIModel430(
         "x", address="GPIB::1::INSTR", pyvisa_sim_file="AMI430.yaml", terminator="\n"
     )
@@ -255,7 +266,7 @@ def test_instantiation_from_name_of_nonexistent_ami_instrument(
     magnet_axes_instances, request: FixtureRequest
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
 
     non_existent_instrument = mag_y.name + "foo"
 
@@ -271,7 +282,7 @@ def test_instantiation_from_name_of_existing_non_ami_instrument(
     magnet_axes_instances, request: FixtureRequest
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
 
     non_ami_existing_instrument = Instrument("foo")
 
@@ -296,7 +307,7 @@ def test_instantiation_from_badly_typed_argument(
     magnet_axes_instances, request: FixtureRequest
 ) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
-    request.addfinalizer(AMIModel4303D.close_all)
+    request.addfinalizer(Instrument.close_all)
 
     badly_typed_instrument_z_argument = 123
 


### PR DESCRIPTION
* Don't trigger warnings when snapshotting a AMI430 without an enabled switch heater
* Deprecate confusing setter/getter methods that duplicate parameters
* Deprecate some more aliases 

- [x] News fragment