### PR TITLE
Lakeshore336: Add None as possible input_channel name for heater_outputs

### DIFF
--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -25,9 +25,10 @@ _channel_name_to_command_map: dict[str, str] = {"A": "A", "B": "B", "C": "C", "D
 # within this driver.
 _channel_name_to_outmode_command_map: dict[str, int] = {
     ch_name: num_for_cmd
-    for num_for_cmd, ch_name in enumerate(['None']+list(_channel_name_to_command_map.keys()))
+    for num_for_cmd, ch_name in enumerate(
+        ["None"] + list(_channel_name_to_command_map.keys())
+    )
 }
-
 
 
 class LakeshoreModel336CurrentSource(LakeshoreBaseOutput):

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -24,9 +24,10 @@ _channel_name_to_command_map: dict[str, str] = {"A": "A", "B": "B", "C": "C", "D
 # created in order to preserve uniformity of referencing to sensor channels
 # within this driver.
 _channel_name_to_outmode_command_map: dict[str, int] = {
-    ch_name: num_for_cmd + 1
-    for num_for_cmd, ch_name in enumerate(_channel_name_to_command_map.keys())
+    ch_name: num_for_cmd
+    for num_for_cmd, ch_name in enumerate(['None']+list(_channel_name_to_command_map.keys()))
 }
+
 
 
 class LakeshoreModel336CurrentSource(LakeshoreBaseOutput):


### PR DESCRIPTION
The Lakeshore336 has a hardware option to set the input_channel of a heater output to 'None'. This option is currently not reflected in the driver/LakeshoreModel336CurrentSource and if it was manually set to 'None' at the hardware, the driver will fail to get or set the input_channel of the output remotely. 

This commit fixes this by adding `ch_name='None'` with `num_for_cmd=0` to `_input_channel_parameter_kwargs`.

