### PR TITLE
Gracefully handle that a parameter could shadow a class attr

### DIFF
--- a/docs/changes/newsfragments/6394.improved
+++ b/docs/changes/newsfragments/6394.improved
@@ -1,0 +1,1 @@
+Improve handling of corner cases where `Instrument.remove_parameter` could raise an exception.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ minversion = "7.2"
 junit_family = "legacy"
 testpaths = "tests"
 addopts = "-n auto --dist=loadfile"
-
+asyncio_default_fixture_loop_scope = "function"
 markers = "serial"
 
 # we ignore warnings

--- a/src/qcodes/instrument/instrument_base.py
+++ b/src/qcodes/instrument/instrument_base.py
@@ -209,7 +209,12 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         is_property = isinstance(getattr(self.__class__, name, None), property)
 
         if not is_property and hasattr(self, name):
-            delattr(self, name)
+            try:
+                delattr(self, name)
+            except AttributeError:
+                self.log.warning(
+                    "Could not remove attribute %s from %s", name, self.full_name
+                )
 
     def add_function(self, name: str, **kwargs: Any) -> None:
         """

--- a/tests/parameter/test_parameter_override.py
+++ b/tests/parameter/test_parameter_override.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING
 
 import pytest
@@ -120,7 +121,7 @@ def test_removed_parameter_from_prop_instrument_works(request):
     a.voltage.set(1)
 
 
-def test_remove_parameter_from_class_attr_works(request):
+def test_remove_parameter_from_class_attr_works(request, caplog):
     request.addfinalizer(DummyClassAttrInstr.close_all)
     a = DummyClassAttrInstr("my_instr")
 
@@ -142,7 +143,12 @@ def test_remove_parameter_from_class_attr_works(request):
     # does not alter the class attribute
     assert hasattr(a, "frequency")
     assert a.frequency is None
-    a.remove_parameter("frequency")
+    with caplog.at_level(logging.WARNING):
+        a.remove_parameter("frequency")
+    assert (
+        "Could not remove attribute frequency from my_instr"
+        in caplog.records[0].message
+    )
     assert a.frequency is None
 
     # removing a classattr raises since it is not a parameter


### PR DESCRIPTION
When removing the parameter