### PR TITLE
LakeShore335: fix typo in setpoint_ramp parameter group

### DIFF
--- a/docs/changes/newsfragments/6430.improved_driver
+++ b/docs/changes/newsfragments/6430.improved_driver
@@ -1,0 +1,1 @@
+LakeShore335: Fix typo in setpoint_ramp parameter group

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -275,7 +275,7 @@ class LakeshoreBaseOutput(InstrumentChannel):
                 self.setpoint_ramp_enabled,
                 self.setpoint_ramp_rate,
             ],
-            set_cmd=f"RAMP {output_index},{{setpoint_ramping_enabled}},{{setpoint_ramping_rate}}",
+            set_cmd=f"RAMP {output_index},{{setpoint_ramp_enabled}},{{setpoint_ramp_rate}}",
             get_cmd=f"RAMP? {output_index}",
         )
 


### PR DESCRIPTION
LakeShore335: fix typo in setpoint_ramp parameter group