### PR TITLE
Mark python 3.13 as supported and test / type check with it

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,14 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12","3.13.0-rc.3"]
+        python-version: ["3.10", "3.11", "3.12","3.13"]
         exclude:
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest
             python-version: 3.11
           - os: windows-latest
-            python-version: "3.13.0-rc.3"
+            python-version: "3.13"
     env:
       OS: ${{ matrix.os }}
       SPHINX_WARNINGS_AS_ERROR: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,12 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12","3.13.0-rc.3"]
         exclude:
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest
             python-version: 3.11
+          - os: windows-latest
+            python-version: "3.13.0-rc.3"
     env:
       OS: ${{ matrix.os }}
       SPHINX_WARNINGS_AS_ERROR: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,14 +29,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12","3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
         exclude:
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest
             python-version: 3.11
-          - os: windows-latest
-            python-version: "3.13"
     env:
       OS: ${{ matrix.os }}
       SPHINX_WARNINGS_AS_ERROR: true

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         min-version: [false]
         include:
           - os: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
           - os: windows-latest
-            python-version: "3.13.0-rc.3"
+            python-version: "3.13"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.0-rc.3"]
         min-version: [false]
         include:
           - os: ubuntu-latest
@@ -43,6 +43,8 @@ jobs:
             python-version: "3.11"
           - os: windows-latest
             python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.13.0-rc.3"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,8 @@ filterwarnings = [
     'ignore:pkg_resources is deprecated as an API:DeprecationWarning', # pyvisa-sim
     'ignore:open_binary is deprecated:DeprecationWarning', # pyvisa-sim
     'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version:DeprecationWarning', # tqdm dateutil
-    'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning' # jupyter
+    'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning', # jupyter
+    'ignore:Parsing dates involving a day of month without a year specified is ambiguious' # ipykernel 3.13+
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,8 @@ filterwarnings = [
     'ignore:open_binary is deprecated:DeprecationWarning', # pyvisa-sim
     'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version:DeprecationWarning', # tqdm dateutil
     'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning', # jupyter
-    'ignore:Parsing dates involving a day of month without a year specified is ambiguious' # ipykernel 3.13+
+    'ignore:Parsing dates involving a day of month without a year specified is ambiguious:DeprecationWarning', # ipykernel 3.13+
+    'ignore:unclosed database in:ResourceWarning' # internal should be fixed
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Filter new warnings.

- [x] Add 3.13 to CI
- [x] Add markers for 3.13
- [x] Can we find a clean way to ensure that connections to db are always closed? Tracked as #6584


Requires pr to bump pywin32 to be merged

Still missing release with support for 3.13 for 
(could be disabled)

- [x] Pyarrow https://github.com/microsoft/Qcodes/pull/6569
- [x] zhinst-core https://github.com/microsoft/Qcodes/pull/6582

Other issues
- [x] Docs don't build. Tracked in #6585