### PR TITLE
Add curve header parameters to Lakeshore model 336, make group parameter take callable get_cmd

### DIFF
--- a/src/qcodes/instrument/sims/lakeshore_model336.yaml
+++ b/src/qcodes/instrument/sims/lakeshore_model336.yaml
@@ -53,6 +53,17 @@ devices:
         setter:
           q: "range A,\"{}\""
 
+      sensor_curve_number_A:
+        default: 42
+        getter:
+          q: "INCRV? A"
+          r: "{}"
+
+      curve_data_query_for_curve_42:
+        getter:
+          q: "CRVHDR? 42"
+          r: "DT-042,01110042,2,342.0,1"
+
 
       temperature_B:
         default: 100.0
@@ -96,7 +107,16 @@ devices:
         setter:
           q: "range A,\"{}\""
 
+      sensor_curve_number_B:
+        default: 41
+        getter:
+          q: "INCRV? B"
+          r: "{}"
 
+      curve_data_query_for_curve_41:
+        getter:
+          q: "CRVHDR? 41"
+          r: "DT-041,01110041,2,341.0,1"
 
       temperature_C:
         default: 100.0
@@ -140,7 +160,16 @@ devices:
         setter:
           q: "range A,\"{}\""
 
+      sensor_curve_number_C:
+        default: 40
+        getter:
+          q: "INCRV? C"
+          r: "{}"
 
+      curve_data_query_for_curve_40:
+        getter:
+          q: "CRVHDR? 40"
+          r: "DT-040,01110040,2,340.0,1"
 
       temperature_D:
         default: 100.0
@@ -183,6 +212,17 @@ devices:
           r: "{}"
         setter:
           q: "range A,\"{}\""
+
+      sensor_curve_number_D:
+        default: 39
+        getter:
+          q: "INCRV? D"
+          r: "{}"
+
+      curve_data_query_for_curve_39:
+        getter:
+          q: "CRVHDR? 39"
+          r: "DT-039,01110039,2,339.0,1"
 
 
 resources:

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -204,8 +204,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
 
         # Parameters related to temperature calibration curve (CRVHDR)
-        self.input_curve_number: Parameter = self.add_parameter(
-            "sensor_curve_number",
+        self.curve_number: Parameter = self.add_parameter(
+            "curve_number",
             get_cmd=f"INCRV? {self._channel}",
             set_cmd=False,
             get_parser=int,
@@ -214,8 +214,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         """
         Temperature calibration curve number that is selected now
         """
-        self.input_curve_name: GroupParameter = self.add_parameter(
-            "input_curve_name",
+        self.curve_name: GroupParameter = self.add_parameter(
+            "curve_name",
             label="Temperature calibration curve name",
             parameter_class=GroupParameter,
         )
@@ -223,8 +223,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve name
         for the current curve as selected by ``input_curve_number``
         """
-        self.input_curve_sn: GroupParameter = self.add_parameter(
-            "input_curve_sn",
+        self.curve_sn: GroupParameter = self.add_parameter(
+            "curve_sn",
             label="Temperature calibration curve SN",
             parameter_class=GroupParameter,
         )
@@ -232,8 +232,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve SN
         for the current curve as selected by ``input_curve_number``
         """
-        self.input_curve_format: GroupParameter = self.add_parameter(
-            "input_curve_format",
+        self.curve_format: GroupParameter = self.add_parameter(
+            "curve_format",
             label="Temperature calibration curve format",
             get_parser=int,
             val_mapping={"mV/K": 1, "V/K": 2, "Ohms/K": 3, "log Ohms/K": 4},
@@ -243,8 +243,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve format
         for the current curve as selected by ``input_curve_number``
         """
-        self.input_curve_limit: GroupParameter = self.add_parameter(
-            "input_curve_limit",
+        self.curve_limit: GroupParameter = self.add_parameter(
+            "curve_limit",
             get_parser=float,
             label="Temperature calibration curve limit value",
             parameter_class=GroupParameter,
@@ -253,8 +253,8 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve limit value
         for the current curve as selected by ``input_curve_number``
         """
-        self.input_curve_coefficient: GroupParameter = self.add_parameter(
-            "input_curve_coefficient",
+        self.curve_coefficient: GroupParameter = self.add_parameter(
+            "curve_coefficient",
             get_parser=int,
             label="Temperature calibration curve coefficient",
             val_mapping={"negative": 1, "positive": 2},
@@ -264,16 +264,16 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve coefficient
         for the current curve as selected by ``input_curve_number``
         """
-        self.input_curve_parameters_group = Group(
+        self.curve_parameters_group = Group(
             [
-                self.input_curve_name,
-                self.input_curve_sn,
-                self.input_curve_format,
-                self.input_curve_limit,
-                self.input_curve_coefficient,
+                self.curve_name,
+                self.curve_sn,
+                self.curve_format,
+                self.curve_limit,
+                self.curve_coefficient,
 
             ],
-            get_cmd=f"CRVHDR? {self.input_curve_number()}",
+            get_cmd=f"CRVHDR? {self.curve_number()}",
         )
 
 

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -203,25 +203,34 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
             get_cmd=f"INTYPE? {self._channel}",
         )
 
-        """
-        Temperature claibration curve parameters (READ-ONLY)
-        """
+        # Parameters related to temperature calibration curve (CRVHDR)
         self.input_curve_number: Parameter = self.add_parameter(
             "sensor_curve_number",
             get_cmd=f"INCRV? {self._channel}",
             get_parser=int,
             label="Temperature calibration curve number",
         )
+        """
+        Temperature calibration curve number that is selected now
+        """
         self.input_curve_name: GroupParameter = self.add_parameter(
             "input_curve_name",
             label="Temperature calibration curve name",
             parameter_class=GroupParameter,
         )
+        """
+        Temperature calibration curve name
+        for the current curve as selected by ``input_curve_number``
+        """
         self.input_curve_sn: GroupParameter = self.add_parameter(
             "input_curve_sn",
             label="Temperature calibration curve SN",
             parameter_class=GroupParameter,
         )
+        """
+        Temperature calibration curve SN
+        for the current curve as selected by ``input_curve_number``
+        """
         self.input_curve_format: GroupParameter = self.add_parameter(
             "input_curve_format",
             label="Temperature calibration curve format",
@@ -229,12 +238,20 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
             val_mapping={"mV/K": 1, "V/K": 2, "Ohms/K": 3, "log Ohms/K": 4},
             parameter_class=GroupParameter,
         )
+        """
+        Temperature calibration curve format
+        for the current curve as selected by ``input_curve_number``
+        """
         self.input_curve_limit: GroupParameter = self.add_parameter(
             "input_curve_limit",
             get_parser=float,
             label="Temperature calibration curve limit value",
             parameter_class=GroupParameter,
         )
+        """
+        Temperature calibration curve limit value
+        for the current curve as selected by ``input_curve_number``
+        """
         self.input_curve_coefficient: GroupParameter = self.add_parameter(
             "input_curve_coefficient",
             get_parser=int,
@@ -242,7 +259,10 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
             val_mapping={"negative": 1, "positive": 2},
             parameter_class=GroupParameter,
         )
-        self.output_group = Group(
+        """
+        Temperature calibration curve coefficient
+        for the current curve as selected by ``input_curve_number``
+        """
             [
                 self.input_curve_name,
                 self.input_curve_sn,

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, ClassVar
 
 import qcodes.validators as vals
-from qcodes.parameters import Group, GroupParameter
+from qcodes.parameters import Group, GroupParameter, Parameter
 
 from .lakeshore_base import (
     LakeshoreBase,
@@ -202,6 +202,59 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
             f"{{units}}",
             get_cmd=f"INTYPE? {self._channel}",
         )
+
+        """
+        Temperature claibration curve parameters (READ-ONLY)
+        """
+        self.input_curve_number: Parameter = self.add_parameter(
+            "sensor_curve_number",
+            get_cmd=f"INCRV? {self._channel}",
+            get_parser=int,
+            label="Temperature calibration curve number",
+        )
+        self.input_curve_name: GroupParameter = self.add_parameter(
+            "input_curve_name",
+            label="Temperature calibration curve name",
+            parameter_class=GroupParameter,
+        )
+        self.input_curve_sn: GroupParameter = self.add_parameter(
+            "input_curve_sn",
+            label="Temperature calibration curve SN",
+            parameter_class=GroupParameter,
+        )
+        self.input_curve_format: GroupParameter = self.add_parameter(
+            "input_curve_format",
+            label="Temperature calibration curve format",
+            get_parser=int,
+            val_mapping={"mV/K": 1, "V/K": 2, "Ohms/K": 3, "log Ohms/K": 4},
+            parameter_class=GroupParameter,
+        )
+        self.input_curve_limit: GroupParameter = self.add_parameter(
+            "input_curve_limit",
+            get_parser=float,
+            label="Temperature calibration curve limit value",
+            parameter_class=GroupParameter,
+        )
+        self.input_curve_coefficient: GroupParameter = self.add_parameter(
+            "input_curve_coefficient",
+            get_parser=int,
+            label="Temperature calibration curve coefficient",
+            val_mapping={"negative": 1, "positive": 2},
+            parameter_class=GroupParameter,
+        )
+        self.output_group = Group(
+            [
+                self.input_curve_name,
+                self.input_curve_sn,
+                self.input_curve_format,
+                self.input_curve_limit,
+                self.input_curve_coefficient,
+
+            ],
+            get_cmd=f"CRVHDR? {self.input_curve_number()}",
+        )
+
+
 
 
 class LakeshoreModel336(LakeshoreBase):

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -264,6 +264,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         Temperature calibration curve coefficient
         for the current curve as selected by ``input_curve_number``
         """
+        self.input_curve_parameters_group = Group(
             [
                 self.input_curve_name,
                 self.input_curve_sn,

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -221,7 +221,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
         """
         Temperature calibration curve name
-        for the current curve as selected by ``input_curve_number``
+        for the current curve as selected by ``curve_number``
         """
         self.curve_sn: GroupParameter = self.add_parameter(
             "curve_sn",
@@ -230,7 +230,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
         """
         Temperature calibration curve SN
-        for the current curve as selected by ``input_curve_number``
+        for the current curve as selected by ``curve_number``
         """
         self.curve_format: GroupParameter = self.add_parameter(
             "curve_format",
@@ -241,7 +241,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
         """
         Temperature calibration curve format
-        for the current curve as selected by ``input_curve_number``
+        for the current curve as selected by ``curve_number``
         """
         self.curve_limit: GroupParameter = self.add_parameter(
             "curve_limit",
@@ -251,7 +251,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
         """
         Temperature calibration curve limit value
-        for the current curve as selected by ``input_curve_number``
+        for the current curve as selected by ``curve_number``
         """
         self.curve_coefficient: GroupParameter = self.add_parameter(
             "curve_coefficient",
@@ -262,7 +262,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
         """
         Temperature calibration curve coefficient
-        for the current curve as selected by ``input_curve_number``
+        for the current curve as selected by ``curve_number``
         """
         self.curve_parameters_group = Group(
             [
@@ -271,7 +271,6 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
                 self.curve_format,
                 self.curve_limit,
                 self.curve_coefficient,
-
             ],
             get_cmd=f"CRVHDR? {self.curve_number()}",
         )

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -277,8 +277,6 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         )
 
 
-
-
 class LakeshoreModel336(LakeshoreBase):
     """
     QCoDeS driver for Lakeshore Model 336 Temperature Controller.

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -207,6 +207,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
         self.input_curve_number: Parameter = self.add_parameter(
             "sensor_curve_number",
             get_cmd=f"INCRV? {self._channel}",
+            set_cmd=False,
             get_parser=int,
             label="Temperature calibration curve number",
         )

--- a/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_336.py
@@ -272,7 +272,7 @@ class LakeshoreModel336Channel(LakeshoreBaseSensorChannel):
                 self.curve_limit,
                 self.curve_coefficient,
             ],
-            get_cmd=f"CRVHDR? {self.curve_number()}",
+            get_cmd=lambda: f"CRVHDR? {self.curve_number()}",
         )
 
 

--- a/src/qcodes/parameters/group_parameter.py
+++ b/src/qcodes/parameters/group_parameter.py
@@ -312,7 +312,9 @@ class Group:
                 f"parameters - {parameter_names} since it "
                 f"has no `get_cmd` defined."
             )
-        get_command = self._get_cmd if isinstance(self._get_cmd, str) else self._get_cmd()
+        get_command = (
+            self._get_cmd if isinstance(self._get_cmd, str) else self._get_cmd()
+        )
         ret = self.get_parser(self.instrument.ask(get_command))
         for name, p in list(self.parameters.items()):
             p.cache._set_from_raw_value(ret[name])

--- a/tests/drivers/test_lakeshore.py
+++ b/tests/drivers/test_lakeshore.py
@@ -89,7 +89,7 @@ class MockVisaInstrument:
             self.visa_log.debug(f"Response: {response}")
             return response
         else:
-            super().ask_raw(cmd)  # type: ignore[misc]
+            return super().ask_raw(cmd)  # type: ignore[misc]
 
 
 def query(name: str) -> Callable[[Callable[P, T]], Callable[P, T]]:

--- a/tests/drivers/test_lakeshore_336.py
+++ b/tests/drivers/test_lakeshore_336.py
@@ -80,8 +80,8 @@ class LakeshoreModel336Mock(MockVisaInstrument, LakeshoreModel336):
                 auto_range_enabled=0,  # 'off',
                 range=0,
                 compensation_enabled=0,  # False,
-                units=1,
-            )  # 'kelvin')
+                units=1,  # 'kelvin'
+            )
             for i in self.channel_name_command.keys()
         }
 
@@ -257,6 +257,19 @@ def test_setpoint(lakeshore_336) -> None:
     for h in outputs:  # a.k.a. heaters
         h.setpoint(setpoint)
         assert h.setpoint() == setpoint
+
+
+def test_curve_parameters(lakeshore_336) -> None:
+    # The curve numbers are assigned in the simulation pyvisa sim
+    # YAML file for each sensor/channel, and properties of the
+    # curves also include curve number in them to help testing
+    for ch, curve_number in zip(lakeshore_336.channels, (42, 41, 40, 39)):
+        assert ch.curve_number() == curve_number
+        assert ch.curve_name().endswith(str(curve_number))
+        assert ch.curve_sn().endswith(str(curve_number))
+        assert ch.curve_format() == "V/K"
+        assert str(int(ch.curve_limit())).endswith(str(curve_number))
+        assert ch.curve_coefficient() == "negative"
 
 
 def test_select_range_limits(lakeshore_336) -> None:


### PR DESCRIPTION

This driver update adds parameters to the Lakeshore 336 channel that allows query of the input channel curve header to read from the instrument:
- input_curve_number
- input_curve_name
- input_curve_sn
- input_curve_format
- input_curve_limit
- input_curve_coefficient

This is useful to verify remotely if the correct temperature calibration curve is selected.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
