### PR TITLE
Fix add_to_spyder_UMR_excludelist for Spyder 6

### DIFF
--- a/src/qcodes/utils/spyder_utils.py
+++ b/src/qcodes/utils/spyder_utils.py
@@ -35,7 +35,14 @@ def add_to_spyder_UMR_excludelist(modulename: str) -> None:
                 # This object can be found via the magics manager
                 from IPython import get_ipython  # pyright: ignore
                 ipython = get_ipython()
-                runfile_method = ipython.magics_manager.magics['line']['runfile']
+                if ipython is None:
+                    # no ipython environment
+                    return
+                try:
+                    runfile_method = ipython.magics_manager.magics['line']['runfile']
+                except KeyError:
+                    # no runfile magic
+                    return
                 spyder_code_runner = runfile_method.__self__
                 umr = spyder_code_runner.umr
 


### PR DESCRIPTION
The import of qcodes fails with Spyder 6, because add_to_spyder_UMR_excludelist raises an exception.

This pull request fixes the code to work with Spyder 6.0.
I've removed a bit of old code that was only useful for Spyder 3.x

I don't think this is easy to test with an automatic test, because a test would require Spyder 6.
