### PR TITLE
Only use base type in log attribute

### DIFF
--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -287,6 +287,6 @@ def xarray_to_h5netcdf_with_complex_numbers(
             with TqdmCallback(desc="Combining files"):
                 _LOG.info(
                     "Writing netcdf file using Dask delayed writer.",
-                    extra={"file_name": file_path},
+                    extra={"file_name": str(file_path)},
                 )
                 maybe_write_job.compute()


### PR DESCRIPTION
Opentelemetry does not like the use of WindowsPath which will trigger a warning 