### PR TITLE
Hotfix data_set.py: flatten 2D arrays

### DIFF
--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1395,13 +1395,13 @@ class DataSet(BaseDataSet):
                     res_list += new_res
             elif param.type == "numeric":
                 if value.shape:
-                    res_list += [{param.name: number} for number in value]
+                    res_list += [{param.name: number} for number in value.flatten()]
                 else:
                     new_res = [{param.name: float(value)}]
                     res_list += new_res
             elif param.type == "complex":
                 if value.shape:
-                    res_list += [{param.name: number} for number in value]
+                    res_list += [{param.name: number} for number in value.flatten()]
                 else:
                     new_res = [{param.name: complex(value)}]
                     res_list += new_res


### PR DESCRIPTION
When adding a 2D array as a standalone parameter in a dataset, the whole numpy array would be save in bit form. Flatten is needed to make a proper array to be saved alongside the data.