### PR TITLE
Enable building of docs using 3.13

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,12 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: windows-latest
             python-version: 3.10
           - os: windows-latest
             python-version: 3.11
+          - os: windows-latest
+            python-version: 3.13
     env:
       OS: ${{ matrix.os }}
       SPHINX_WARNINGS_AS_ERROR: true


### PR DESCRIPTION
Now that wrapt 1.17.0 is released we can build docs with 3.13

Lifted from #6494 since this is currently failing.

**Issue is resolved in wrapt 1.17.0rc1 just need to wait for release and we can merge this**


Disabling parallel build does not seem to make a difference.

Disabling the extensions one by one seems to indicate that the docs build error is related to autodocsumm, other debugging points towards viewsource. It may be a combination of these extensions

