### PR TITLE
Fix link to `qcodes_loop` docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The modules ``qcodes.data``, ``qcodes.plots``, ``qcodes.actions``,
 and ``qcodes.utils.magic`` that were part of QCoDeS until version 0.37.0.
 have been moved into an independent package called qcodes_loop.
 Please see it's `repository <https://github.com/QCoDeS/Qcodes_loop/>`_ and
-`documentation <https://microsoft.github.io/Qcodes_loop/>`_ for more information.
+`documentation <https://qcodes.github.io/Qcodes_loop/index.html>`_ for more information.
 
 For the time being it is possible to automatically install the qcodes_loop
 package when installing qcodes by executing ``pip install qcodes[loop]``.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->

Fixes broken link to qcodes_loop documentation.
