### PR TITLE
Stop trying to exclude qcodes from Spyder UMR

### DIFF
--- a/docs/changes/newsfragments/6647.breaking
+++ b/docs/changes/newsfragments/6647.breaking
@@ -1,0 +1,5 @@
+QCoDeS no longer attempts to automatically disable Sypders User module reloader (UMR).
+The code was no longer working correctly with the latest version of Spyder and is not
+maintainable since Spyder does not have a public api to disable UMR. If you use
+QCoDeS from an editable install it is strongly recommended to disable UMR for QCoDeS.
+See :ref:`gettingstarted` for more details.

--- a/docs/start/index.rst
+++ b/docs/start/index.rst
@@ -248,6 +248,16 @@ or jupyter lab:
 
     jupyter lab
 
+
+Note that Spyder ships with functionality to automatically reload modules that are installed
+editable. This functionality called
+`User Module Reloader <https://docs.spyder-ide.org/current/panes/ipythonconsole.html#reload-changed-modules>`__
+is known to not work well with QCoDeS. If you install QCoDeS editable (with -e flag)
+we strongly recommend users to exclude QCoDeS from UMR. QCoDeS used to attempt to automatically
+disable this feature. However, as `Spyder does not provide a public API for doing this <https://github.com/spyder-ide/spyder/issues/2451>`__
+this relied on a private API in Spyder and broke with the last Spyder release.
+If at some point this becomes possible to do with a public API QCoDeS may again disable this automatically.
+
 For other options from the terminal you can activate the QCoDeS in that terminal
 then start any other application, such as *IPython* or
 just plain old *Python*.

--- a/docs/start/index.rst
+++ b/docs/start/index.rst
@@ -248,15 +248,16 @@ or jupyter lab:
 
     jupyter lab
 
+.. note::
 
-Note that Spyder ships with functionality to automatically reload modules that are installed
-editable. This functionality called
-`User Module Reloader <https://docs.spyder-ide.org/current/panes/ipythonconsole.html#reload-changed-modules>`__
-is known to not work well with QCoDeS. If you install QCoDeS editable (with -e flag)
-we strongly recommend users to exclude QCoDeS from UMR. QCoDeS used to attempt to automatically
-disable this feature. However, as `Spyder does not provide a public API for doing this <https://github.com/spyder-ide/spyder/issues/2451>`__
-this relied on a private API in Spyder and broke with the last Spyder release.
-If at some point this becomes possible to do with a public API QCoDeS may again disable this automatically.
+    Note that Spyder ships with functionality to automatically reload modules that are installed
+    editable. This functionality called
+    `User Module Reloader <https://docs.spyder-ide.org/current/panes/ipythonconsole.html#reload-changed-modules>`__
+    is known to not work well with QCoDeS. If you install QCoDeS editable (with -e flag)
+    we strongly recommend users to exclude QCoDeS from UMR. QCoDeS used to attempt to automatically
+    disable this feature. However, as `Spyder does not provide a public API for doing this <https://github.com/spyder-ide/spyder/issues/2451>`__
+    this relied on a private API in Spyder and broke with the last Spyder release.
+    If at some point this becomes possible to do with a public API QCoDeS may again disable this automatically.
 
 For other options from the terminal you can activate the QCoDeS in that terminal
 then start any other application, such as *IPython* or

--- a/src/qcodes/__init__.py
+++ b/src/qcodes/__init__.py
@@ -16,7 +16,6 @@ import qcodes._version
 import qcodes.configuration as qcconfig
 from qcodes.logger.logger import conditionally_start_all_logging
 from qcodes.utils import QCoDeSDeprecationWarning
-from qcodes.utils.spyder_utils import add_to_spyder_UMR_excludelist
 
 __version__ = qcodes._version.__version__
 
@@ -24,11 +23,6 @@ __version__ = qcodes._version.__version__
 config: qcconfig.Config = qcconfig.Config()
 
 conditionally_start_all_logging()
-
-# we dont want spyder to reload qcodes as this will overwrite the default station
-# instrument list and running monitor
-add_to_spyder_UMR_excludelist("qcodes")
-
 
 import atexit
 

--- a/src/qcodes/utils/helpers.py
+++ b/src/qcodes/utils/helpers.py
@@ -32,7 +32,9 @@ from .function_helpers import is_function
 from .json_utils import NumpyJSONEncoder
 from .partial_utils import partial_with_docstring
 from .path_helpers import QCODES_USER_PATH_ENV, get_qcodes_path, get_qcodes_user_path
-from .spyder_utils import add_to_spyder_UMR_excludelist
+from .spyder_utils import (
+    add_to_spyder_UMR_excludelist,  # pyright: ignore[reportDeprecated]
+)
 
 
 # on longer in used but left for backwards compatibility until

--- a/src/qcodes/utils/spyder_utils.py
+++ b/src/qcodes/utils/spyder_utils.py
@@ -1,9 +1,17 @@
 import logging
 import os
 
+from typing_extensions import deprecated
+
+from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+
 _LOG = logging.getLogger(__name__)
 
 
+@deprecated(
+    "Known to not work with latest Spyder and unused in QCoDeS",
+    category=QCoDeSDeprecationWarning,
+)
 def add_to_spyder_UMR_excludelist(modulename: str) -> None:
     """
     Spyder tries to reload any user module. This does not work well for


### PR DESCRIPTION
* Stop calling add_to_spyder_UMR_excludelist automatically and deprecate this function.
* Document that users should disable UMR when installing qcodes editable. 
- [x] Breaking change note

Alternative to #6544