### PR TITLE
DelegateParameters inherit their source's settable/gettable/snapshot_value/unit/label

### DIFF
--- a/docs/changes/newsfragments/6648.improved
+++ b/docs/changes/newsfragments/6648.improved
@@ -1,0 +1,2 @@
+DelegateParameter now reads delegated properties from source rather than setting them at source change.
+This resolves an issue when delegating from another delegate parameter may result in incorrect attributes.

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -214,12 +214,8 @@ class DelegateParameter(Parameter):
 
     def _set_properties_from_source(self, source: Parameter | None) -> None:
         if source is None:
-            self._gettable = False
-            self._settable = False
             self._snapshot_value = False
         else:
-            self._gettable = source.gettable
-            self._settable = source.settable
             self._snapshot_value = source._snapshot_value
 
         for attr, attr_props in self._attr_inherit.items():
@@ -228,6 +224,18 @@ class DelegateParameter(Parameter):
                     source, attr, attr_props["value_when_without_source"]
                 )
                 setattr(self, attr, attr_val)
+
+    @property
+    def gettable(self) -> bool:
+        if self.source is None:
+            return False
+        return self.source.gettable
+
+    @property
+    def settable(self) -> bool:
+        if self.source is None:
+            return False
+        return self.source.settable
 
     def get_raw(self) -> Any:
         if self.source is None:

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -204,18 +204,6 @@ class DelegateParameter(Parameter):
         self._source: Parameter | None = source
 
     @property
-    def gettable(self) -> bool:
-        if self.source is None:
-            return False
-        return self.source.gettable
-
-    @property
-    def settable(self) -> bool:
-        if self._settable is False or self.source is None:
-            return False
-        return self.source.settable
-
-    @property
     def snapshot_value(self) -> bool:
         if self.source is None:
             return False

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -188,6 +188,12 @@ class DelegateParameter(Parameter):
         initial_cache_value = kwargs.pop("initial_cache_value", None)
         self.source = source
         super().__init__(name, *args, **kwargs)
+
+        # Hack While we inherit the settable status from the parent parameter
+        # we do allow param.set_to to temporary override _settable in a
+        # context. Here _settable should always be true except when set_to
+        # i.e. _SetParamContext overrides it
+        self._settable = True
         # explicitly set the source properties as
         # init will overwrite the ones set when assigning source
         self._set_properties_from_source(source)
@@ -233,7 +239,7 @@ class DelegateParameter(Parameter):
 
     @property
     def settable(self) -> bool:
-        if self.source is None:
+        if self._settable is False or self.source is None:
             return False
         return self.source.settable
 

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -244,6 +244,20 @@ class DelegateParameter(Parameter):
     def label(self, label: str | None) -> None:
         self._label_override = label
 
+    @property
+    def gettable(self) -> bool:
+        if self.source is None:
+            return False
+        return self.source.gettable
+
+    @property
+    def settable(self) -> bool:
+        if self._settable is False:
+            return False
+        if self.source is None:
+            return False
+        return self.source.settable
+
     def get_raw(self) -> Any:
         if self.source is None:
             raise TypeError(

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -219,11 +219,6 @@ class DelegateParameter(Parameter):
         self._source: Parameter | None = source
 
     def _set_properties_from_source(self, source: Parameter | None) -> None:
-        if source is None:
-            self._snapshot_value = False
-        else:
-            self._snapshot_value = source._snapshot_value
-
         for attr, attr_props in self._attr_inherit.items():
             if not attr_props["fixed"]:
                 attr_val = getattr(
@@ -242,6 +237,12 @@ class DelegateParameter(Parameter):
         if self._settable is False or self.source is None:
             return False
         return self.source.settable
+
+    @property
+    def snapshot_value(self) -> bool:
+        if self.source is None:
+            return False
+        return self.source.snapshot_value
 
     def get_raw(self) -> Any:
         if self.source is None:

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -156,19 +156,6 @@ class DelegateParameter(Parameter):
         if "bind_to_instrument" not in kwargs.keys():
             kwargs["bind_to_instrument"] = False
 
-        self._attr_inherit = {
-            "label": {"fixed": False, "value_when_without_source": name},
-            "unit": {"fixed": False, "value_when_without_source": ""},
-        }
-
-        for attr, attr_props in self._attr_inherit.items():
-            if attr in kwargs:
-                attr_props["fixed"] = True
-            else:
-                attr_props["fixed"] = False
-            source_attr = getattr(source, attr, attr_props["value_when_without_source"])
-            kwargs[attr] = kwargs.get(attr, source_attr)
-
         for cmd in ("set_cmd", "get_cmd"):
             if cmd in kwargs:
                 raise KeyError(
@@ -188,15 +175,14 @@ class DelegateParameter(Parameter):
         initial_cache_value = kwargs.pop("initial_cache_value", None)
         self.source = source
         super().__init__(name, *args, **kwargs)
+        self.label = kwargs.get("label", None)
+        self.unit = kwargs.get("unit", None)
 
         # Hack While we inherit the settable status from the parent parameter
         # we do allow param.set_to to temporary override _settable in a
         # context. Here _settable should always be true except when set_to
         # i.e. _SetParamContext overrides it
         self._settable = True
-        # explicitly set the source properties as
-        # init will overwrite the ones set when assigning source
-        self._set_properties_from_source(source)
 
         self.cache = self._DelegateCache(self)
         if initial_cache_value is not None:
@@ -215,16 +201,7 @@ class DelegateParameter(Parameter):
 
     @source.setter
     def source(self, source: Parameter | None) -> None:
-        self._set_properties_from_source(source)
         self._source: Parameter | None = source
-
-    def _set_properties_from_source(self, source: Parameter | None) -> None:
-        for attr, attr_props in self._attr_inherit.items():
-            if not attr_props["fixed"]:
-                attr_val = getattr(
-                    source, attr, attr_props["value_when_without_source"]
-                )
-                setattr(self, attr, attr_val)
 
     @property
     def gettable(self) -> bool:
@@ -243,6 +220,41 @@ class DelegateParameter(Parameter):
         if self.source is None:
             return False
         return self.source.snapshot_value
+
+    @property
+    def unit(self) -> str:
+        """
+        The unit of measure. Read from source if not explicitly overwritten.
+        Set to None to disable overwrite.
+        """
+        if self._unit_override is not None:
+            return self._unit_override
+        elif self.source is not None:
+            return self.source.unit
+        else:
+            return ""
+
+    @unit.setter
+    def unit(self, unit: str | None) -> None:
+        self._unit_override = unit
+
+    @property
+    def label(self) -> str:
+        """
+        Label of the data used for plots etc.
+        Read from source if not explicitly overwritten.
+        Set to None to disable overwrite.
+        """
+        if self._label_override is not None:
+            return self._label_override
+        elif self.source is not None:
+            return self.source.label
+        else:
+            return self.name
+
+    @label.setter
+    def label(self, label: str | None) -> None:
+        self._label_override = label
 
     def get_raw(self) -> Any:
         if self.source is None:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -537,7 +537,7 @@ class ParameterBase(MetadatableWithName):
 
         state: dict[str, Any] = {"__class__": full_class(self), "full_name": str(self)}
 
-        if self._snapshot_value:
+        if self.snapshot_value:
             has_get = self.gettable
             allowed_to_call_get_when_snapshotting = (
                 self._snapshot_get and update is not False

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -426,7 +426,7 @@ def test_gettable_settable_snapshotget_delegate_parameter(
     delegate_param = DelegateParameter("delegate", source=source_param)
     assert delegate_param.gettable is gettable
     assert delegate_param.settable is settable
-    assert delegate_param._snapshot_value is snapshot_value
+    assert delegate_param.snapshot_value is snapshot_value
 
 
 @pytest.mark.parametrize("snapshot_value", [True, False])
@@ -450,7 +450,7 @@ def test_gettable_settable_snapshotget_delegate_parameter_2(
     delegate_param.source = source_param
     assert delegate_param.gettable is gettable
     assert delegate_param.settable is settable
-    assert delegate_param._snapshot_value is snapshot_value
+    assert delegate_param.snapshot_value is snapshot_value
 
 
 def test_initial_value_and_none_source_raises() -> None:

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -657,3 +657,31 @@ def test_delegate_of_delegate_updates_settable_gettable():
 
     assert delegate_param_outer.gettable
     assert not delegate_param_outer.settable
+
+
+def test_delegate_parameter_context() -> None:
+    gettable_settable_source_param = Parameter(
+        "source", set_cmd=None, get_cmd=None, vals=vals.Numbers(-5, 5)
+    )
+
+    delegate_param = DelegateParameter(
+        "delegate_outer", source=None, vals=vals.Numbers(-10, 10)
+    )
+
+    delegate_param.source = gettable_settable_source_param
+
+    delegate_param(2)
+    assert delegate_param() == 2
+
+    with delegate_param.set_to(3):
+        assert delegate_param() == 3
+        with pytest.raises(NotImplementedError):
+            delegate_param(4)
+        assert delegate_param() == 3
+    assert delegate_param() == 2
+
+    with delegate_param.set_to(3, allow_changes=True):
+        assert delegate_param() == 3
+        delegate_param(4)
+        assert delegate_param() == 4
+    assert delegate_param() == 2


### PR DESCRIPTION
This PR fixes a bug observed when chaining multiple DelegateParameters, and changing the source at the bottom of the chain.

In the previous implementation, a DelegateParameter only updated it's internal `_settable` and `_gettable` attributes when the `source` was changed. But it is possible to set up a chain of DelegateParameters and then change the 'root' source Parameter. This updates the bottom-most DelegateParameter, but all of the other DelegateParameters in the chain will not update.

This PR changes the implementation to override the `ParameterBase` implementation of the `gettable` and `settable` properties, so that they reflect the underlying `source` parameter, no matter what it may be.
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [x] Make sure that the pull request contains a short description of the changes made.
- [x] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [x] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
