### PR TITLE
Add note about deprecated methods to docstrings

### DIFF
--- a/src/qcodes/instrument/instrument_base.py
+++ b/src/qcodes/instrument/instrument_base.py
@@ -701,7 +701,7 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
 
 
         Note:
-            This is deprecated call set directly on the parameter.
+            This is deprecated. Call set directly on the parameter.
 
         """
         self.parameters[param_name].set(value)
@@ -721,7 +721,7 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
             The current value of the parameter.
 
         Note:
-            This is deprecated call get directly on the parameter.
+            This is deprecated. Call get directly on the parameter.
 
         """
         return self.parameters[param_name].get()
@@ -742,7 +742,7 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
             The return value of the function.
 
         Note:
-            This is deprecated call the function directly.
+            This is deprecated. Call the function directly.
 
         """
         return self.functions[func_name].call(*args)

--- a/src/qcodes/instrument/instrument_base.py
+++ b/src/qcodes/instrument/instrument_base.py
@@ -674,7 +674,14 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         category=QCoDeSDeprecationWarning,
     )
     def __getitem__(self, key: str) -> Callable[..., Any] | Parameter:
-        """Delegate instrument['name'] to parameter or function 'name'."""
+        """
+        Delegate instrument['name'] to parameter or function 'name'.
+
+        Note:
+            This is deprecated. Use attributes directly or if dynamic attribute required look up via
+            .parameters or .functions dictionaries
+
+        """
         try:
             return self.parameters[key]
         except KeyError:
@@ -691,6 +698,10 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         Args:
             param_name: The name of a parameter of this instrument.
             value: The new value to set.
+
+
+        Note:
+            This is deprecated call set directly on the parameter.
 
         """
         self.parameters[param_name].set(value)
@@ -709,6 +720,9 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         Returns:
             The current value of the parameter.
 
+        Note:
+            This is deprecated call get directly on the parameter.
+
         """
         return self.parameters[param_name].get()
 
@@ -726,6 +740,9 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
 
         Returns:
             The return value of the function.
+
+        Note:
+            This is deprecated call the function directly.
 
         """
         return self.functions[func_name].call(*args)


### PR DESCRIPTION
As noted in #6648 this really should be documented. 
