### PR TITLE
Fix deprecation warning from codecov action

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -110,7 +110,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         env_vars: OS,PYTHON
         token: ${{ secrets.CODECOV_TOKEN }}
       if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
file has been replaced by files (called the same way since we only upload one file)