### PR TITLE
Add stacklevel to all deprecated instruments

### DIFF
--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -908,6 +908,7 @@ class AcquisitionInterface(Generic[OutputType]):
 @deprecated(
     "AlazarTech_ATS is deprecated, use AlazarTechATS instead.",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AlazarTech_ATS(AlazarTechATS):
     pass

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -432,6 +432,7 @@ class Keysight33xxx(KeysightErrorQueueMixin, VisaInstrument):
 @deprecated(
     "The base class for Keysight33xxx waveform generators has been renamed to Keysight33xxx",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class WaveformGenerator_33XXX(Keysight33xxx):
     pass

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34410A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34410A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34410A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34410A(Keysight34410A):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34411A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34411A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34411A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34411A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34411A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34411A(Keysight34411A):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34460A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34460A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34460A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34460A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34460A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34460A(Keysight34460A):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34461A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34461A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34461A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34461A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34461A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34461A(Keysight344xxA):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34465A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34465A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34465A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34461A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34461A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34465A(Keysight34465A):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_34470A_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_34470A_submodules.py
@@ -27,7 +27,7 @@ class Keysight34470A(Keysight344xxA):
         super().__init__(name, address, silent, **kwargs)
 
 
-@deprecated("Use Keysight34460A", category=QCoDeSDeprecationWarning)
+@deprecated("Use Keysight34460A", category=QCoDeSDeprecationWarning, stacklevel=2)
 class Keysight_34470A(Keysight34470A):
     """
     Alias for backwards compatibility.

--- a/src/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/src/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -129,6 +129,10 @@ class KeysightN51x1(VisaInstrument):
         return IDN
 
 
-@deprecated("Base class is renamed KeysightN51x1", category=QCoDeSDeprecationWarning)
+@deprecated(
+    "Base class is renamed KeysightN51x1",
+    category=QCoDeSDeprecationWarning,
+    stacklevel=2,
+)
 class N51x1(KeysightN51x1):
     pass

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -830,11 +830,11 @@ class KeysightPNAxBase(KeysightPNABase):
         """Parameter aux_frequency"""
 
 
-@deprecated("Use KeysightPNABase", category=QCoDeSDeprecationWarning)
+@deprecated("Use KeysightPNABase", category=QCoDeSDeprecationWarning, stacklevel=2)
 class PNABase(KeysightPNABase):
     pass
 
 
-@deprecated("Use KeysightPNAxBase", category=QCoDeSDeprecationWarning)
+@deprecated("Use KeysightPNAxBase", category=QCoDeSDeprecationWarning, stacklevel=2)
 class PNAxBase(KeysightPNAxBase):
     pass

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34980a_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34980a_submodules.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from typing_extensions import Unpack
 
 
-@deprecated("Unused module", category=QCoDeSDeprecationWarning)
+@deprecated("Unused module", category=QCoDeSDeprecationWarning, stacklevel=2)
 class KeysightSubModule(InstrumentChannel):
     """
     A base class for submodules for the 34980A systems.
@@ -216,7 +216,9 @@ class Keysight34980ASwitchMatrixSubModule(InstrumentChannel):
 
 
 @deprecated(
-    "Use Keysight34980ASwitchMatrixSubModule", category=QCoDeSDeprecationWarning
+    "Use Keysight34980ASwitchMatrixSubModule",
+    category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class KeysightSwitchMatrixSubModule(Keysight34980ASwitchMatrixSubModule):
     pass

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -362,7 +362,7 @@ class KeysightB1500Module(InstrumentChannel):
         self.root_instrument.clear_timer_count(chnum=self.channels)
 
 
-@deprecated("Use KeysightB1500Module", category=QCoDeSDeprecationWarning)
+@deprecated("Use KeysightB1500Module", category=QCoDeSDeprecationWarning, stacklevel=2)
 class B1500Module(KeysightB1500Module):
     pass
 

--- a/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -1322,6 +1322,7 @@ mode."""
 @deprecated(
     "Base class for Keysight 344xxA renamed Keysight344xxA",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class _Keysight_344xxA(Keysight344xxA):
     pass
@@ -1330,6 +1331,7 @@ class _Keysight_344xxA(Keysight344xxA):
 @deprecated(
     "Trigger class for Keysight 344xxA renamed Keysight344xxATrigger",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class Trigger(Keysight344xxATrigger):
     pass
@@ -1338,6 +1340,7 @@ class Trigger(Keysight344xxATrigger):
 @deprecated(
     "Sample class for Keysight 344xxA renamed Keysight344xxASample",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class Sample(Keysight344xxASample):
     pass
@@ -1346,6 +1349,7 @@ class Sample(Keysight344xxASample):
 @deprecated(
     "Display class for Keysight 344xxA renamed Keysight344xxADisplay",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class Display(Keysight344xxADisplay):
     pass

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -506,7 +506,9 @@ class LakeshoreBaseOutput(InstrumentChannel):
 
 
 @deprecated(
-    "Base class renamed to LakeshoreBaseOutput", category=QCoDeSDeprecationWarning
+    "Base class renamed to LakeshoreBaseOutput",
+    category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class BaseOutput(LakeshoreBaseOutput):
     pass
@@ -669,6 +671,7 @@ class LakeshoreBaseSensorChannel(InstrumentChannel):
 @deprecated(
     "Base class renamed to LakeshoreBaseSensorChannel",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class BaseSensorChannel(LakeshoreBaseSensorChannel):
     pass

--- a/src/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
@@ -76,6 +76,7 @@ class MiniCircuitsSPDTSwitchChannelBase(InstrumentChannel):
 @deprecated(
     "Deprecated alias, use MiniCircuitsSPDTSwitchChannelBase.",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class SwitchChannelBase(MiniCircuitsSPDTSwitchChannelBase):
     pass
@@ -142,6 +143,7 @@ class MiniCircuitsSPDTBase(Instrument):
 @deprecated(
     "Deprecated alias, use MiniCircuitsSPDTBase.",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class SPDT_Base(MiniCircuitsSPDTBase):
     pass

--- a/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 @deprecated(
     "USBHIDMixin is deprecated. This is unused in QCoDeS",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class USBHIDMixin(Instrument):
     # The following class attributes should be set by subclasses

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -35,6 +35,7 @@ T = TypeVar("T")
 @deprecated(
     "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430Exception from qcodes.instrument_drivers.american_magnetics",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430Exception(Exception):
     pass
@@ -43,6 +44,7 @@ class AMI430Exception(Exception):
 @deprecated(
     "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430Warning from qcodes.instrument_drivers.american_magnetics",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430Warning(UserWarning):
     pass
@@ -51,6 +53,7 @@ class AMI430Warning(UserWarning):
 @deprecated(
     "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMI430SwitchHeater from qcodes.instrument_drivers.american_magnetics",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430SwitchHeater(InstrumentChannel):
     class _Decorators:
@@ -158,6 +161,7 @@ class AMI430SwitchHeater(InstrumentChannel):
 @deprecated(
     "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMIModel430 from qcodes.instrument_drivers.american_magnetics",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430(IPInstrument):
     """
@@ -556,6 +560,7 @@ class AMI430(IPInstrument):
 @deprecated(
     "qcodes.instrument_drivers.american_magnetics.AMI430 module is deprecated use AMIModel4303D from qcodes.instrument_drivers.american_magnetics",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430_3D(Instrument):
     def __init__(

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -137,6 +137,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use enabled parameter to enable/disable the switch heater.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def disable(self) -> None:
         self._disable()
@@ -144,6 +145,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use enabled parameter to enable/disable the switch heater.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def enable(self) -> None:
         self._enable()
@@ -154,6 +156,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use enabled parameter to inspect switch heater status.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def check_enabled(self) -> bool:
         return self._check_enabled()
@@ -167,6 +170,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use state parameter to turn on the switch heater.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def on(self) -> None:
         self._on()
@@ -180,6 +184,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use state parameter to turn off the switch heater.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def off(self) -> None:
         self._off()
@@ -192,6 +197,7 @@ class AMI430SwitchHeater(InstrumentChannel):
     @deprecated(
         "Use state parameter to inspect if switch heater is on.",
         category=QCoDeSDeprecationWarning,
+        stacklevel=2,
     )
     def check_state(self) -> bool:
         return self._check_state()
@@ -644,6 +650,7 @@ class AMIModel430(VisaInstrument):
 @deprecated(
     "Use qcodes.instrument_drivers.american_magnetics.AMIModel430 instead.",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430(AMIModel430):
     pass
@@ -1316,6 +1323,7 @@ class AMIModel4303D(Instrument):
 @deprecated(
     "Use qcodes.instrument_drivers.american_magnetics.AMIModel4303D instead.",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AMI430_3D(AMIModel4303D):
     pass

--- a/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -1210,6 +1210,7 @@ class RohdeSchwarzZNBBase(VisaInstrument):
 @deprecated(
     "The ZNB base class has been renamed RohdeSchwarzZNBBase",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class ZNB(RohdeSchwarzZNBBase):
     pass

--- a/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -1595,7 +1595,9 @@ class TektronixAWG70000Base(VisaInstrument):
 
 
 @deprecated(
-    "Base class renamed TektronixAWG70000Base", category=QCoDeSDeprecationWarning
+    "Base class renamed TektronixAWG70000Base",
+    category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class AWG70000A(TektronixAWG70000Base):
     pass

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -362,6 +362,7 @@ class TektronixDPOWaveform(InstrumentChannel):
 @deprecated(
     "TekronixDPOWaveform is deprecated use TektronixDPOWaveform",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class TekronixDPOWaveform(TektronixDPOWaveform):
     """
@@ -756,6 +757,7 @@ class TektronixDPOTrigger(InstrumentChannel):
 @deprecated(
     "TekronixDPOTrigger is deprecated use TektronixDPOTrigger",
     category=QCoDeSDeprecationWarning,
+    stacklevel=2,
 )
 class TekronixDPOTrigger(TektronixDPOTrigger):
     """


### PR DESCRIPTION
This makes it easier to track where the instrument is instantiated since the init method is called directly from the instrument meta class and therefore not informative

This was generated with the following libcst script

```
from pathlib import Path

import libcst as cst
import libcst.matchers as m


class AddStackLevelTransformer(cst.CSTTransformer):
    def leave_Decorator(
        self, original_node: cst.Decorator, updated_node: cst.Decorator
    ) -> cst.Decorator:
        match updated_node.decorator:
            case cst.Call(func=cst.Name("deprecated")):
                args = list(updated_node.decorator.args)
                if not any(
                    m.matches(arg, m.Arg(keyword=m.Name("stacklevel"))) for arg in args
                ):
                    args.append(
                        cst.Arg(value=cst.Integer("2"), keyword=cst.Name("stacklevel"))
                    )
                return updated_node.with_changes(
                    decorator=updated_node.decorator.with_changes(args=args)
                )
        return updated_node


class AddStackLevelVisitor(cst.CSTVisitor):
    def __init__(self) -> None:
        self.transformer = AddStackLevelTransformer()

    def visit_ClassDef(self, node) -> None:
        node = node.visit(self.transformer)

    def visit_FunctionDef(self, node) -> None:
        node = node.visit(self.transformer)


def add_stacklevel_to_deprecated(source_code: str) -> str:
    tree = cst.parse_module(source_code)
    transformer = AddStackLevelTransformer()
    modified_tree = tree.visit(transformer)
    return modified_tree.code


def process_file(file_path: Path):
    with open(file_path, encoding="utf-8") as file:
        source_code = file.read()
    new_code = add_stacklevel_to_deprecated(source_code)
    with open(file_path, "w", encoding="utf-8") as file:
        file.write(new_code)


def process_folder(folder_path: Path):
    for root, _, files in folder_path.walk():
        for file in files:
            if file.endswith(".py"):
                file_path = root / file
                process_file(file_path)


process_folder(Path(r"pathto...Qcodes\src\qcodes\instrument_drivers"))

```
