### PR TITLE
Oxford Triton driver: only add magnet parameters if one is present

### DIFF
--- a/docs/changes/newsfragments/6792.improved
+++ b/docs/changes/newsfragments/6792.improved
@@ -1,0 +1,1 @@
+Only add magnet parameters if a magnet is detected in the Oxford Triton driver.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
This patch tests if the Triton can communicate with the magnet. If not, parameters pertaining to the magnet are not added to the instrument. This avoids complications when snapshotting the instrument for instance.

Reasons for communication failure are 
1) no magnet is equipped to begin with.
2) the magnet power supply (Mercury iPS) is set up for a different communication protocol (TCP/IP for example).
