### PR TITLE
Check for numeric type using numbers.Real

### DIFF
--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import collections.abc
 import logging
-import numbers
 import time
 import warnings
 from collections import defaultdict
@@ -20,6 +19,7 @@ from qcodes.instrument import Instrument, InstrumentChannel, IPInstrument
 from qcodes.math_utils import FieldVector
 from qcodes.parameters import Parameter
 from qcodes.utils import QCoDeSDeprecationWarning
+from qcodes.utils.types import NumberType
 from qcodes.validators import Anything, Bool, Enum, Ints, Numbers
 
 if TYPE_CHECKING:
@@ -635,7 +635,7 @@ class AMI430_3D(Instrument):
         self._field_limit: float | Iterable[CartesianFieldLimitFunction]
         if isinstance(field_limit, collections.abc.Iterable):
             self._field_limit = field_limit
-        elif isinstance(field_limit, numbers.Real):
+        elif isinstance(field_limit, NumberType):
             # Conversion to float makes related driver logic simpler
             self._field_limit = float(field_limit)
         else:
@@ -978,7 +978,7 @@ class AMI430_3D(Instrument):
     def _verify_safe_setpoint(
         self, setpoint_values: tuple[float, float, float]
     ) -> bool:
-        if isinstance(self._field_limit, numbers.Real):
+        if isinstance(self._field_limit, NumberType):
             return bool(np.linalg.norm(setpoint_values) < self._field_limit)
 
         answer = any(

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -978,7 +978,7 @@ class AMI430_3D(Instrument):
     def _verify_safe_setpoint(
         self, setpoint_values: tuple[float, float, float]
     ) -> bool:
-        if isinstance(self._field_limit, (int, float)):
+        if isinstance(self._field_limit, numbers.Real):
             return bool(np.linalg.norm(setpoint_values) < self._field_limit)
 
         answer = any(

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -1073,7 +1073,7 @@ class AMIModel4303D(Instrument):
     def _verify_safe_setpoint(
         self, setpoint_values: tuple[float, float, float]
     ) -> bool:
-        if isinstance(self._field_limit, (int, float)):
+        if isinstance(self._field_limit, numbers.Real):
             return bool(np.linalg.norm(setpoint_values) < self._field_limit)
 
         answer = any(

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import numbers
 import time
 import warnings
 from collections import defaultdict
@@ -24,6 +23,7 @@ from qcodes.instrument import (
 from qcodes.math_utils import FieldVector
 from qcodes.parameters import Parameter
 from qcodes.utils import QCoDeSDeprecationWarning
+from qcodes.utils.types import NumberType
 from qcodes.validators import Anything, Bool, Enum, Ints, Numbers
 
 if TYPE_CHECKING:
@@ -730,7 +730,7 @@ class AMIModel4303D(Instrument):
         self._field_limit: float | Iterable[CartesianFieldLimitFunction]
         if isinstance(field_limit, Iterable):
             self._field_limit = field_limit
-        elif isinstance(field_limit, numbers.Real):
+        elif isinstance(field_limit, NumberType):
             # Conversion to float makes related driver logic simpler
             self._field_limit = float(field_limit)
         else:
@@ -1073,7 +1073,7 @@ class AMIModel4303D(Instrument):
     def _verify_safe_setpoint(
         self, setpoint_values: tuple[float, float, float]
     ) -> bool:
-        if isinstance(self._field_limit, numbers.Real):
+        if isinstance(self._field_limit, NumberType):
             return bool(np.linalg.norm(setpoint_values) < self._field_limit)
 
         answer = any(
@@ -1240,9 +1240,7 @@ class AMIModel4303D(Instrument):
         ):
             axis_instrument.pause()
 
-    def _request_field_change(
-        self, instrument: AMIModel430, value: numbers.Real
-    ) -> None:
+    def _request_field_change(self, instrument: AMIModel430, value: NumberType) -> None:
         """
         This method is called by the child x/y/z magnets if they are set
         individually. It results in additional safety checks being

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -5,10 +5,11 @@ coordinate systems.
 
 from __future__ import annotations
 
-import numbers
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 import numpy as np
+
+from qcodes.utils.types import NumberType
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -293,7 +294,7 @@ class FieldVector:
         self.set_component(**{component: value})
 
     def __mul__(self, other: Any) -> FieldVector:
-        if not isinstance(other, numbers.Real):
+        if not isinstance(other, NumberType):
             return NotImplemented
 
         return FieldVector(
@@ -301,13 +302,13 @@ class FieldVector:
         )
 
     def __rmul__(self, other: Any) -> FieldVector:
-        if not isinstance(other, numbers.Real):
+        if not isinstance(other, NumberType):
             return NotImplemented
 
         return self * other
 
     def __truediv__(self, other: Any) -> FieldVector:
-        if not isinstance(other, numbers.Real):
+        if not isinstance(other, NumberType):
             return NotImplemented
 
         return self * (1.0 / other)

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -5,6 +5,7 @@ coordinate systems.
 
 from __future__ import annotations
 
+import numbers
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 import numpy as np
@@ -292,7 +293,7 @@ class FieldVector:
         self.set_component(**{component: value})
 
     def __mul__(self, other: Any) -> FieldVector:
-        if not isinstance(other, (float, int)):
+        if not isinstance(other, numbers.Real):
             return NotImplemented
 
         return FieldVector(
@@ -300,13 +301,13 @@ class FieldVector:
         )
 
     def __rmul__(self, other: Any) -> FieldVector:
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, numbers.Real):
             return NotImplemented
 
         return self * other
 
     def __truediv__(self, other: Any) -> FieldVector:
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, numbers.Real):
             return NotImplemented
 
         return self * (1.0 / other)

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -298,7 +298,7 @@ class FieldVector:
             return NotImplemented
 
         return FieldVector(
-            **{component: self[component] * other for component in "xyz"}
+            **{component: self[component] * float(other) for component in "xyz"}
         )
 
     def __rmul__(self, other: Any) -> FieldVector:

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -784,8 +784,8 @@ class ParameterBase(MetadatableWithName):
         return set_wrapper
 
     def get_ramp_values(
-        self, value: float | Sized, step: float | None = None
-    ) -> Sequence[float | Sized]:
+        self, value: NumberType | Sized, step: NumberType | None = None
+    ) -> Sequence[NumberType | Sized]:
         """
         Return values to sweep from current value to target value.
         This method can be overridden to have a custom sweep behaviour.
@@ -859,7 +859,7 @@ class ParameterBase(MetadatableWithName):
                 validator.validate(value, self._validate_context)
 
     @property
-    def step(self) -> float | None:
+    def step(self) -> NumberType | None:
         """
         Stepsize that this Parameter uses during set operation.
         Stepsize must be a positive number or None.
@@ -883,9 +883,9 @@ class ParameterBase(MetadatableWithName):
         return self._step
 
     @step.setter
-    def step(self, step: float | None) -> None:
+    def step(self, step: NumberType | None) -> None:
         if step is None:
-            self._step: float | None = step
+            self._step: NumberType | None = step
         elif not all(getattr(vals, "is_numeric", True) for vals in self._vals):
             raise TypeError("you can only step numeric parameters")
         elif not isinstance(step, NumberType):

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections.abc
 import logging
+import numbers
 import time
 import warnings
 from contextlib import contextmanager
@@ -809,8 +810,8 @@ class ParameterBase(MetadatableWithName):
                 self.get()
             start_value = self.get_latest()
             if not (
-                isinstance(start_value, (int, float))
-                and isinstance(value, (int, float))
+                isinstance(start_value, numbers.Real)
+                and isinstance(value, numbers.Real)
             ):
                 # parameter is numeric but either one of the endpoints
                 # is not or the starting point is unknown. The later
@@ -888,7 +889,7 @@ class ParameterBase(MetadatableWithName):
             self._step: float | None = step
         elif not all(getattr(vals, "is_numeric", True) for vals in self._vals):
             raise TypeError("you can only step numeric parameters")
-        elif not isinstance(step, (int, float)):
+        elif not isinstance(step, numbers.Real):
             raise TypeError("step must be a number")
         elif step == 0:
             self._step = None
@@ -928,7 +929,7 @@ class ParameterBase(MetadatableWithName):
 
     @post_delay.setter
     def post_delay(self, post_delay: float) -> None:
-        if not isinstance(post_delay, (int, float)):
+        if not isinstance(post_delay, numbers.Real):
             raise TypeError(f"post_delay ({post_delay}) must be a number")
         if post_delay < 0:
             raise ValueError(f"post_delay ({post_delay}) must not be negative")
@@ -957,7 +958,7 @@ class ParameterBase(MetadatableWithName):
 
     @inter_delay.setter
     def inter_delay(self, inter_delay: float) -> None:
-        if not isinstance(inter_delay, (int, float)):
+        if not isinstance(inter_delay, numbers.Real):
             raise TypeError(f"inter_delay ({inter_delay}) must be a number")
         if inter_delay < 0:
             raise ValueError(f"inter_delay ({inter_delay}) must not be negative")

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import collections.abc
 import logging
-import numbers
 import time
 import warnings
 from contextlib import contextmanager
@@ -14,6 +13,7 @@ from qcodes.metadatable import Metadatable, MetadatableWithName
 from qcodes.utils import DelegateAttributes, full_class, qcodes_abstractmethod
 from qcodes.validators import Enum, Ints, Validator
 
+from ..utils.types import NumberType
 from .cache import _Cache, _CacheProtocol
 from .named_repr import named_repr
 from .permissive_range import permissive_range
@@ -810,8 +810,7 @@ class ParameterBase(MetadatableWithName):
                 self.get()
             start_value = self.get_latest()
             if not (
-                isinstance(start_value, numbers.Real)
-                and isinstance(value, numbers.Real)
+                isinstance(start_value, NumberType) and isinstance(value, NumberType)
             ):
                 # parameter is numeric but either one of the endpoints
                 # is not or the starting point is unknown. The later
@@ -889,7 +888,7 @@ class ParameterBase(MetadatableWithName):
             self._step: float | None = step
         elif not all(getattr(vals, "is_numeric", True) for vals in self._vals):
             raise TypeError("you can only step numeric parameters")
-        elif not isinstance(step, numbers.Real):
+        elif not isinstance(step, NumberType):
             raise TypeError("step must be a number")
         elif step == 0:
             self._step = None
@@ -929,7 +928,7 @@ class ParameterBase(MetadatableWithName):
 
     @post_delay.setter
     def post_delay(self, post_delay: float) -> None:
-        if not isinstance(post_delay, numbers.Real):
+        if not isinstance(post_delay, NumberType):
             raise TypeError(f"post_delay ({post_delay}) must be a number")
         if post_delay < 0:
             raise ValueError(f"post_delay ({post_delay}) must not be negative")
@@ -958,7 +957,7 @@ class ParameterBase(MetadatableWithName):
 
     @inter_delay.setter
     def inter_delay(self, inter_delay: float) -> None:
-        if not isinstance(inter_delay, numbers.Real):
+        if not isinstance(inter_delay, NumberType):
             raise TypeError(f"inter_delay ({inter_delay}) must be a number")
         if inter_delay < 0:
             raise ValueError(f"inter_delay ({inter_delay}) must not be negative")

--- a/src/qcodes/parameters/permissive_range.py
+++ b/src/qcodes/parameters/permissive_range.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import math
-from typing import SupportsAbs
+from typing import TYPE_CHECKING, SupportsAbs
+
+if TYPE_CHECKING:
+    from qcodes.utils.types import NumberType
 
 
 # could use numpy.arange here, but
 # I'd like to be more flexible with the sign of step
 def permissive_range(
-    start: float, stop: float, step: SupportsAbs[float]
-) -> list[float]:
+    start: NumberType, stop: NumberType, step: SupportsAbs[NumberType]
+) -> list[NumberType]:
     """
     Returns a range (as a list of values) with floating point steps.
     Always starts at start and moves toward stop, regardless of the

--- a/src/qcodes/utils/types.py
+++ b/src/qcodes/utils/types.py
@@ -86,3 +86,6 @@ concrete_complex_types = (*numpy_concrete_complex, complex)
 complex_types = (*numpy_concrete_complex, complex)
 
 NumberType: TypeAlias = int | float | np.integer | np.floating
+"""
+Python or NumPy real number.
+"""

--- a/src/qcodes/utils/types.py
+++ b/src/qcodes/utils/types.py
@@ -4,6 +4,8 @@ Useful collections of types used around QCoDeS
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 
 complex_type_union = np.complex64 | np.complex128 | np.complexfloating | complex
@@ -82,3 +84,5 @@ All numpy complex types
 
 concrete_complex_types = (*numpy_concrete_complex, complex)
 complex_types = (*numpy_concrete_complex, complex)
+
+NumberType: TypeAlias = int | float | np.integer | np.floating


### PR DESCRIPTION
In several places code tests variables for numeric type using `isinstance(value, (int, float))`. This creates problems for native numpy types (among others I would presume). For example, `isinstance(np.int32(0), int)` evaluates to false.

Checking instead for `numbers.Real` should resolve this.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
