### PR TITLE
add vals property and setter to delegate_parameter

### DIFF
--- a/docs/changes/newsfragments/6796.improved
+++ b/docs/changes/newsfragments/6796.improved
@@ -1,0 +1,1 @@
+Add vals property and @vals.setter to qcodes.parameters.delegate_parameter.DelegateParameter to propagate the Validator from source to DelegateParameter.

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -176,6 +176,7 @@ class DelegateParameter(Parameter):
         super().__init__(name, *args, **kwargs)
         self.label = kwargs.get("label", None)
         self.unit = kwargs.get("unit", None)
+        self.vals = kwargs.get("vals", None)
 
         # Hack While we inherit the settable status from the parent parameter
         # we do allow param.set_to to temporary override _settable in a

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
 
+    from qcodes.validators import Validator
+
     from .parameter_base import ParamDataType, ParamRawDataType
 
 
@@ -222,6 +224,23 @@ class DelegateParameter(Parameter):
     @unit.setter
     def unit(self, unit: str | None) -> None:
         self._unit_override = unit
+
+    @property
+    def vals(self) -> Validator | None:
+        """
+        The validator of the parameter. Read from source if not explicitly overwritten.
+        Set to None to disable overwrite.
+        """
+        if self._vals_override is not None:
+            return self._vals_override
+        elif self.source is not None:
+            return self.source.vals
+        else:
+            return None
+
+    @vals.setter
+    def vals(self, vals: Validator | None) -> None:
+        self._vals_override = vals
 
     @property
     def label(self) -> str:

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -173,6 +173,7 @@ class DelegateParameter(Parameter):
 
         initial_cache_value = kwargs.pop("initial_cache_value", None)
         self.source = source
+        self._vals_override = None
         super().__init__(name, *args, **kwargs)
         self.label = kwargs.get("label", None)
         self.unit = kwargs.get("unit", None)
@@ -334,3 +335,5 @@ class DelegateParameter(Parameter):
         super().validate(value)
         if self.source is not None:
             self.source.validate(self._from_value_to_raw_value(value))
+            if self.vals is not None:
+                self.vals.validate(value)

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -173,7 +173,7 @@ class DelegateParameter(Parameter):
 
         initial_cache_value = kwargs.pop("initial_cache_value", None)
         self.source = source
-        self._vals_override = None
+        self._vals_override: Validator | None = None
         super().__init__(name, *args, **kwargs)
         self.label = kwargs.get("label", None)
         self.unit = kwargs.get("unit", None)

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -574,20 +574,52 @@ def test_value_validation() -> None:
     source_param = Parameter("source", set_cmd=None, get_cmd=None)
     delegate_param = DelegateParameter("delegate", source=source_param)
 
+    # Test case where source parameter validator is None and delegate parameter validator is
+    # specified.
     delegate_param.vals = vals.Numbers(-10, 10)
     source_param.vals = None
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(11)
 
+    # Test where delegate parameter validator is None and source parameter validator is
+    # specified.
     delegate_param.vals = None
     source_param.vals = vals.Numbers(-5, 5)
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(6)
 
+    # Test case where source parameter validator is more restricted than delegate parameter.
     delegate_param.vals = vals.Numbers(-10, 10)
     source_param.vals = vals.Numbers(-5, 5)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case that the order of setting validator on source and delegate parameters does not matter.
+    source_param.vals = vals.Numbers(-5, 5)
+    delegate_param.vals = vals.Numbers(-10, 10)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case where delegate parameter validator is more restricted than source parameter.
+    delegate_param.vals = vals.Numbers(-5, 5)
+    source_param.vals = vals.Numbers(-10, 10)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case that the order of setting validator on source and delegate parameters does not matter.
+    source_param.vals = vals.Numbers(-10, 10)
+    delegate_param.vals = vals.Numbers(-5, 5)
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(6)


### PR DESCRIPTION
Add `vals` property and  `@vals.setter` to qcodes.parameters.delegate_parameter.DelegateParameter to propagate the Validator from source to DelegateParameter.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
