### PR TITLE
Set coverage config in pyproject.toml

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -102,11 +102,11 @@ jobs:
       if: ${{ !matrix.min-version }}
     - name: Run parallel tests
       run: |
-        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci  --durations=20 $PYTEST_OPT tests
+        pytest -m "not serial" --cov --cov-report xml --hypothesis-profile ci  --durations=20 $PYTEST_OPT tests
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
     - name: Run serial tests
       run: |
-        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci $PYTEST_OPT tests
+        pytest -m "serial" -n 0 --dist no --cov --cov-report xml --cov-append --hypothesis-profile ci $PYTEST_OPT tests
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ qcodes-dynacool-server = "qcodes.instrument_drivers.QuantumDesign.DynaCoolPPMS.p
 log_exported_ds = "qcodes.extensions:log_dataset_export_info"
 
 [tool.coverage.run]
+source_pkgs = ["qcodes"]
 omit = [
     "src/qcodes/__init__.py",
     "*/__init__.py",
@@ -210,7 +211,7 @@ typeCheckingMode = "standard"
 minversion = "7.2"
 junit_family = "legacy"
 testpaths = "tests"
-addopts = "-n auto --dist=loadfile"
+addopts = "-n auto --dist=loadfile --cov-config=pyproject.toml"
 asyncio_default_fixture_loop_scope = "function"
 markers = "serial"
 


### PR DESCRIPTION
Move configuration of which package to cover to pyproject.toml which makes more sense 

Unfortunately does not silence warnings when using xdist.