### PR TITLE
Fix repetitive logging document index

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -14,12 +14,3 @@ examples you can download them directly from the git repository.
     driver_examples/index
     writing_drivers/index
     logging/index
-
-
-Logging
---------
-
-.. toctree::
-    :glob:
-
-    logging/*


### PR DESCRIPTION
Remove the repetitive toctree entry to remove repetitive "Logging" entries in the document index.
<img width="215" alt="image" src="https://github.com/user-attachments/assets/a1949ed5-3a9f-41d2-a449-5075dbd5720f" />

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
