### PR TITLE
Add source validators to delegate parameter validators

### DIFF
--- a/docs/changes/newsfragments/6585.improved
+++ b/docs/changes/newsfragments/6585.improved
@@ -1,0 +1,3 @@
+``DelegateParameter`` now includes validators of its source Parameter into its validators. This ensures that a ``DelegateParameter``
+with a non numeric source parameter is registered correctly in a measurement when the ``DelegateParameter`` it self does not
+set a validator.

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -330,4 +330,4 @@ class DelegateParameter(Parameter):
             self.source.validators if self.source is not None else ()
         )
 
-        return source_validators + tuple(self._vals)
+        return tuple(self._vals) + source_validators

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
 
+    from qcodes.validators.validators import Validator
+
     from .parameter_base import ParamDataType, ParamRawDataType
 
 
@@ -314,3 +316,18 @@ class DelegateParameter(Parameter):
         super().validate(value)
         if self.source is not None:
             self.source.validate(self._from_value_to_raw_value(value))
+
+    @property
+    def validators(self) -> tuple[Validator, ...]:
+        """
+        Tuple of all validators associated with the parameter. Note that this
+        includes validators of the source parameter if source parameter is set
+        and has any validators.
+
+        :getter: All validators associated with the parameter.
+        """
+        source_validators: tuple[Validator, ...] = (
+            self.source.validators if self.source is not None else ()
+        )
+
+        return source_validators + tuple(self._vals)

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -383,9 +383,10 @@ class ParameterBase(MetadatableWithName):
             RuntimeError: If removing the first validator when more than one validator is set.
 
         """
+        validators = self.validators
 
-        if len(self._vals):
-            return self._vals[0]
+        if len(validators):
+            return validators[0]
         else:
             return None
 

--- a/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/tests/dataset/measurement/test_measurement_context_manager.py
@@ -224,6 +224,26 @@ def test_register_delegate_parameters():
     assert meas.parameters["x"].type == "numeric"
 
 
+def test_register_delegate_parameters_with_late_source():
+    x_param = Parameter("x", set_cmd=None, get_cmd=None)
+
+    complex_param = Parameter(
+        "complex_param", get_cmd=None, set_cmd=None, vals=ComplexNumbers()
+    )
+    delegate_param = DelegateParameter("delegate", source=None)
+
+    meas = Measurement()
+
+    meas.register_parameter(x_param)
+
+    delegate_param.source = complex_param
+
+    meas.register_parameter(delegate_param, setpoints=(x_param,))
+    assert len(meas.parameters) == 2
+    assert meas.parameters["delegate"].type == "complex"
+    assert meas.parameters["x"].type == "numeric"
+
+
 def test_unregister_parameter(DAC, DMM) -> None:
     """
     Test the unregistering of parameters.

--- a/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/tests/dataset/measurement/test_measurement_context_manager.py
@@ -24,8 +24,14 @@ from qcodes.dataset.experiment_container import new_experiment
 from qcodes.dataset.export_config import DataExportType
 from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.connection import atomic_transaction
-from qcodes.parameters import ManualParameter, Parameter, expand_setpoints_helper
+from qcodes.parameters import (
+    DelegateParameter,
+    ManualParameter,
+    Parameter,
+    expand_setpoints_helper,
+)
 from qcodes.station import Station
+from qcodes.validators import ComplexNumbers
 from tests.common import retry_until_does_not_throw
 
 
@@ -199,6 +205,23 @@ def test_register_custom_parameter(DAC) -> None:
         meas.register_custom_parameter(
             "double dependence", "label", "unit", setpoints=(name,)
         )
+
+
+def test_register_delegate_parameters():
+    x_param = Parameter("x", set_cmd=None, get_cmd=None)
+
+    complex_param = Parameter(
+        "complex_param", get_cmd=None, set_cmd=None, vals=ComplexNumbers()
+    )
+    delegate_param = DelegateParameter("delegate", source=complex_param)
+
+    meas = Measurement()
+
+    meas.register_parameter(x_param)
+    meas.register_parameter(delegate_param, setpoints=(x_param,))
+    assert len(meas.parameters) == 2
+    assert meas.parameters["delegate"].type == "complex"
+    assert meas.parameters["x"].type == "numeric"
 
 
 def test_unregister_parameter(DAC, DMM) -> None:

--- a/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/tests/dataset/measurement/test_measurement_context_manager.py
@@ -207,7 +207,7 @@ def test_register_custom_parameter(DAC) -> None:
         )
 
 
-def test_register_delegate_parameters():
+def test_register_delegate_parameters() -> None:
     x_param = Parameter("x", set_cmd=None, get_cmd=None)
 
     complex_param = Parameter(
@@ -224,7 +224,7 @@ def test_register_delegate_parameters():
     assert meas.parameters["x"].type == "numeric"
 
 
-def test_register_delegate_parameters_with_late_source():
+def test_register_delegate_parameters_with_late_source() -> None:
     x_param = Parameter("x", set_cmd=None, get_cmd=None)
 
     complex_param = Parameter(
@@ -241,6 +241,28 @@ def test_register_delegate_parameters_with_late_source():
     meas.register_parameter(delegate_param, setpoints=(x_param,))
     assert len(meas.parameters) == 2
     assert meas.parameters["delegate"].type == "complex"
+    assert meas.parameters["x"].type == "numeric"
+
+
+def test_register_delegate_parameters_with_late_source_chain():
+    x_param = Parameter("x", set_cmd=None, get_cmd=None)
+
+    complex_param = Parameter(
+        "complex_param", get_cmd=None, set_cmd=None, vals=ComplexNumbers()
+    )
+    delegate_inner = DelegateParameter("delegate_inner", source=None)
+    delegate_outer = DelegateParameter("delegate_outer", source=None)
+
+    meas = Measurement()
+
+    meas.register_parameter(x_param)
+
+    delegate_outer.source = delegate_inner
+    delegate_inner.source = complex_param
+
+    meas.register_parameter(delegate_outer, setpoints=(x_param,))
+    assert len(meas.parameters) == 2
+    assert meas.parameters["delegate_outer"].type == "complex"
     assert meas.parameters["x"].type == "numeric"
 
 

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -574,20 +574,52 @@ def test_value_validation() -> None:
     source_param = Parameter("source", set_cmd=None, get_cmd=None)
     delegate_param = DelegateParameter("delegate", source=source_param)
 
+    # Test case where source parameter validator is None and delegate parameter validator is
+    # specified.
     delegate_param.vals = vals.Numbers(-10, 10)
     source_param.vals = None
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(11)
 
+    # Test where delegate parameter validator is None and source parameter validator is
+    # specified.
     delegate_param.vals = None
     source_param.vals = vals.Numbers(-5, 5)
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(6)
 
+    # Test case where source parameter validator is more restricted than delegate parameter.
     delegate_param.vals = vals.Numbers(-10, 10)
     source_param.vals = vals.Numbers(-5, 5)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case that the order of setting validator on source and delegate parameters does not matter.
+    source_param.vals = vals.Numbers(-5, 5)
+    delegate_param.vals = vals.Numbers(-10, 10)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case where delegate parameter validator is more restricted than source parameter.
+    delegate_param.vals = vals.Numbers(-5, 5)
+    source_param.vals = vals.Numbers(-10, 10)
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+
+    # Test case that the order of setting validator on source and delegate parameters does not matter.
+    source_param.vals = vals.Numbers(-10, 10)
+    delegate_param.vals = vals.Numbers(-5, 5)
     delegate_param.validate(1)
     with pytest.raises(ValueError):
         delegate_param.validate(6)

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -640,6 +640,26 @@ def test_validator_delegates_as_expected() -> None:
     assert delegate_param.vals == some_validator
 
 
+def test_validator_delegates_and_source() -> None:
+    source_param = Parameter("source", set_cmd=None, get_cmd=None)
+    delegate_param = DelegateParameter("delegate", source=source_param)
+    some_validator = vals.Numbers(-10, 10)
+    some_other_validator = vals.Numbers(-5, 5)
+    source_param.vals = some_validator
+    delegate_param.vals = some_other_validator
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(6)
+    assert delegate_param.validators == (some_other_validator, some_validator)
+    assert delegate_param.vals == some_other_validator
+
+    assert delegate_param.source is not None
+    delegate_param.source.vals = None
+
+    assert delegate_param.validators == (some_other_validator,)
+    assert delegate_param.vals == some_other_validator
+
+
 def test_value_validation_with_offset_and_scale() -> None:
     source_param = Parameter(
         "source", set_cmd=None, get_cmd=None, vals=vals.Numbers(-5, 5)

--- a/tests/parameter/test_delegate_parameter.py
+++ b/tests/parameter/test_delegate_parameter.py
@@ -627,6 +627,19 @@ def test_value_validation() -> None:
         delegate_param.validate(11)
 
 
+def test_validator_delegates_as_expected() -> None:
+    source_param = Parameter("source", set_cmd=None, get_cmd=None)
+    delegate_param = DelegateParameter("delegate", source=source_param)
+    some_validator = vals.Numbers(-10, 10)
+    source_param.vals = some_validator
+    delegate_param.vals = None
+    delegate_param.validate(1)
+    with pytest.raises(ValueError):
+        delegate_param.validate(11)
+    assert delegate_param.validators == (some_validator,)
+    assert delegate_param.vals == some_validator
+
+
 def test_value_validation_with_offset_and_scale() -> None:
     source_param = Parameter(
         "source", set_cmd=None, get_cmd=None, vals=vals.Numbers(-5, 5)


### PR DESCRIPTION
Extracted from #6832

Add validators from source to DelegateParameter. This ensures that a non numeric DelegateParameter is registred with the correct type in measurements