### PR TITLE
Remove setuptools runtime dependency and upgrade precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.9.5'
+    rev: 'v0.9.8'
     hooks:
     - id: ruff
       types_or: [python, pyi, jupyter, toml]
@@ -22,7 +22,7 @@ repos:
     - id: mixed-line-ending
       args: ['--fix=no']
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.3
+    rev: v8.24.0
     hooks:
     - id: gitleaks
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/docs/changes/newsfragments/6919.breaking
+++ b/docs/changes/newsfragments/6919.breaking
@@ -1,0 +1,2 @@
+QCoDeS no longer ships a ``setup.py`` script and all package config is done in ``pyproject.toml``
+A version of `pip` or other package manager supporting ``PEP621`` is required to build from source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ test = [
     "sphinx>=4.5.0",  # sphinx extension tests
     "types-jsonschema>=4.16.0",
     "types_requests>=0.1.8",
-    "types-setuptools>=57.0.0",
     "types-tabulate>=0.1.0",
     "types-tqdm>=4.64.6",
     "types_pywin32>=305.0.0.7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,8 +110,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.5.0
     # via opentelemetry-api
-incremental==24.7.2
-    # via towncrier
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
@@ -361,8 +359,6 @@ schema==0.7.7
     # via broadbean
 scipy==1.15.2
     # via qcodes (pyproject.toml)
-setuptools==75.8.2
-    # via incremental
 six==1.17.0
     # via python-dateutil
 snowballstemmer==2.2.0
@@ -463,6 +459,7 @@ types-tqdm==4.67.0.20250228
 typing-extensions==4.12.2
     # via
     #   qcodes (pyproject.toml)
+    #   beautifulsoup4
     #   mypy
     #   pyvisa
     #   pyvisa-sim

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-"""
-This file only exists as a fallback for older versions of pip/setuptools
-All configuration is done in pyproject.toml
-"""
-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()


### PR DESCRIPTION
* Regenerate requirements.txt now that setuptools is no longer a runtime dependency with new versions of towncrier
* Remove legacy setup.py script. This means we don't import setuptools so types-setuptools can be removed
* Upgrade precommit hooks
