### PR TITLE
Remove typing stubs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = tests/dataset/fixtures/db_files
 	url = https://github.com/QCoDeS/qcodes_db_fixtures.git
 	branch = main
-[submodule "typings"]
-	path = typings
-	url = https://github.com/QCoDeS/qcodes-python-type-stubs.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,6 @@ ignore = [
     ]
 reportMissingTypeStubs = true
 reportDeprecated = true
-stubPath = "typings/stubs"
 
 typeCheckingMode = "standard"
 

--- a/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/USBHIDMixin.py
@@ -12,7 +12,9 @@ from typing_extensions import deprecated
 from qcodes.utils import QCoDeSDeprecationWarning
 
 try:
-    from pywinusb import hid  # pyright: ignore[reportMissingModuleSource]
+    from pywinusb import (  # pyright: ignore[reportMissingModuleSource,reportMissingImports]
+        hid,
+    )
 
     imported_hid = True
 except ImportError:


### PR DESCRIPTION
Pyright now infers types at runtime so this adds little value and risk using out of date stubs