### PR TITLE
Deprecate qcodes deprecation utils

### DIFF
--- a/docs/changes/newsfragments/6946.breaking
+++ b/docs/changes/newsfragments/6946.breaking
@@ -1,0 +1,4 @@
+The QCoDeS deprecation utils including ``qcodes.utils.deprecate.deprecation_message``,
+``qcodes.utils.deprecate.issue_deprecation_warning``,  ``qcodes.utils.deprecate.deprecate``  ``qcodes.utils.deprecate.assert_not_deprecated``
+and ``qcodes.utils.deprecate.assert_deprecated`` along with their reexports in `qcodes`, `qcodes.utils` and `qcodes.utils.helpers`
+are all deprecated and will be removed in QCoDeS 0.54.0. We recommend using `typing_extensions.deprecate` as an alternative.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ ignore_missing_imports = true
 include = ["src","tests"]
 ignore = [
     "src/qcodes/instrument_drivers/Harvard/Decadac.py",
+    "tests/test_deprecate.py"
     ]
 reportMissingTypeStubs = true
 reportDeprecated = true
@@ -218,6 +219,7 @@ markers = "serial"
 # and error on all other warnings
 filterwarnings = [
     'error',
+    'ignore:QCoDeS deprecation logic is deprecated:qcodes.utils.deprecate.QCoDeSDeprecationWarning', # deprecation of internal qcodes deprecated.
     'ignore:open_binary is deprecated:DeprecationWarning', # pyvisa-sim
     'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning', # jupyter
     'ignore:Parsing dates involving a day of month without a year specified is ambiguious:DeprecationWarning', # ipykernel 3.13+

--- a/src/qcodes/__init__.py
+++ b/src/qcodes/__init__.py
@@ -70,7 +70,7 @@ from qcodes.parameters import (
     combine,
 )
 from qcodes.station import Station
-from qcodes.utils import deprecate
+from qcodes.utils import deprecate  # pyright: ignore[reportDeprecated]
 
 # ensure to close all instruments when interpreter is closed
 atexit.register(Instrument.close_all)

--- a/src/qcodes/utils/__init__.py
+++ b/src/qcodes/utils/__init__.py
@@ -10,7 +10,11 @@ from .attribute_helpers import (
 )
 from .deep_update_utils import deep_update
 from .delaykeyboardinterrupt import DelayedKeyboardInterrupt
-from .deprecate import QCoDeSDeprecationWarning, deprecate, issue_deprecation_warning
+from .deprecate import (
+    QCoDeSDeprecationWarning,
+    deprecate,  # pyright: ignore[reportDeprecated]
+    issue_deprecation_warning,  # pyright: ignore[reportDeprecated]
+)
 from .full_class import full_class
 from .function_helpers import is_function
 from .installation_info import (

--- a/src/qcodes/utils/deprecate.py
+++ b/src/qcodes/utils/deprecate.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, cast
 
 import wrapt  # type: ignore[import-untyped]
+from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -17,6 +18,10 @@ class QCoDeSDeprecationWarning(RuntimeWarning):
     """
 
 
+@deprecated(
+    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    category=QCoDeSDeprecationWarning,
+)
 def deprecation_message(
     what: str, reason: str | None = None, alternative: str | None = None
 ) -> str:
@@ -29,6 +34,10 @@ def deprecation_message(
     return msg
 
 
+@deprecated(
+    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    category=QCoDeSDeprecationWarning,
+)
 def issue_deprecation_warning(
     what: str,
     reason: str | None = None,
@@ -39,12 +48,16 @@ def issue_deprecation_warning(
     Issue a `QCoDeSDeprecationWarning` with a consistently formatted message
     """
     warnings.warn(
-        deprecation_message(what, reason, alternative),
+        deprecation_message(what, reason, alternative),  # pyright: ignore[reportDeprecated]
         QCoDeSDeprecationWarning,
         stacklevel=stacklevel,
     )
 
 
+@deprecated(
+    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    category=QCoDeSDeprecationWarning,
+)
 def deprecate(
     reason: str | None = None, alternative: str | None = None
 ) -> Callable[..., Any]:
@@ -71,7 +84,7 @@ def deprecate(
             if func.__name__ == "__init__"
             else ("function", func.__name__)
         )
-        issue_deprecation_warning(f"{t} <{n}>", reason, alternative, stacklevel=3)
+        issue_deprecation_warning(f"{t} <{n}>", reason, alternative, stacklevel=3)  # pyright: ignore[reportDeprecated]
         return func(*args, **kwargs)
 
     def actual_decorator(obj: Any) -> Any:
@@ -113,6 +126,10 @@ def _catch_deprecation_warnings() -> "Iterator[list[warnings.WarningMessage]]":
         yield ws
 
 
+@deprecated(
+    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    category=QCoDeSDeprecationWarning,
+)
 @contextmanager
 def assert_not_deprecated() -> "Iterator[None]":
     with _catch_deprecation_warnings() as ws:
@@ -120,11 +137,14 @@ def assert_not_deprecated() -> "Iterator[None]":
     assert len(ws) == 0
 
 
+@deprecated(
+    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    category=QCoDeSDeprecationWarning,
+)
 @contextmanager
 def assert_deprecated(message: str) -> "Iterator[None]":
     with _catch_deprecation_warnings() as ws:
         yield
-    assert len(ws) == 1
     recorded_message = ws[0].message
     assert isinstance(recorded_message, Warning)
     assert recorded_message.args[0] == message

--- a/src/qcodes/utils/deprecate.py
+++ b/src/qcodes/utils/deprecate.py
@@ -19,7 +19,7 @@ class QCoDeSDeprecationWarning(RuntimeWarning):
 
 
 @deprecated(
-    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    "QCoDeS deprecation logic is deprecated. Use `deprecated` decorator from `typing_extensions`/`warnings` modules as an alternative.",
     category=QCoDeSDeprecationWarning,
 )
 def deprecation_message(
@@ -35,7 +35,7 @@ def deprecation_message(
 
 
 @deprecated(
-    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    "QCoDeS deprecation logic is deprecated. Use `deprecated` decorator from `typing_extensions`/`warnings` as an alternative.",
     category=QCoDeSDeprecationWarning,
 )
 def issue_deprecation_warning(
@@ -55,7 +55,7 @@ def issue_deprecation_warning(
 
 
 @deprecated(
-    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    "QCoDeS deprecation logic is deprecated. Use `deprecated` decorator from `typing_extensions`/`warnings` as an alternative.",
     category=QCoDeSDeprecationWarning,
 )
 def deprecate(
@@ -127,7 +127,7 @@ def _catch_deprecation_warnings() -> "Iterator[list[warnings.WarningMessage]]":
 
 
 @deprecated(
-    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    "QCoDeS deprecation logic is deprecated. Use `deprecated` decorator from `typing_extensions`/`warnings` as an alternative.",
     category=QCoDeSDeprecationWarning,
 )
 @contextmanager
@@ -138,7 +138,7 @@ def assert_not_deprecated() -> "Iterator[None]":
 
 
 @deprecated(
-    "QCoDeS deprecation logic is deprecated. Use deprecated decorator from typing_extensions/warnings as an alternative.",
+    "QCoDeS deprecation logic is deprecated. Use `deprecated` decorator from `typing_extensions`/`warnings` as an alternative.",
     category=QCoDeSDeprecationWarning,
 )
 @contextmanager

--- a/src/qcodes/utils/helpers.py
+++ b/src/qcodes/utils/helpers.py
@@ -17,7 +17,7 @@ from qcodes.parameters.permissive_range import permissive_range
 from qcodes.parameters.sequence_helpers import is_sequence, is_sequence_of
 from qcodes.parameters.sweep_values import make_sweep
 from qcodes.parameters.val_mapping import create_on_off_val_mapping
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils.deprecate import deprecate  # pyright: ignore[reportDeprecated]
 
 from .abstractmethod import qcodes_abstractmethod as abstractmethod
 from .attribute_helpers import (

--- a/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -1,12 +1,12 @@
 import pytest
 from sphinx.util.inspect import safe_getattr
+from typing_extensions import deprecated
 
 from qcodes.instrument import InstrumentBase, VisaInstrument
 from qcodes.sphinx_extensions.parse_parameter_attr import (
     ParameterProxy,
     qcodes_parameter_attr_getter,
 )
-from qcodes.utils import deprecate
 
 
 class DummyTestClass(InstrumentBase):
@@ -40,7 +40,7 @@ class DummyDecoratedInitTestClass(InstrumentBase):
     A class attribute
     """
 
-    @deprecate("Deprecate to test that decorated init is handled correctly")
+    @deprecated("Deprecate to test that decorated init is handled correctly")
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -50,7 +50,7 @@ class DummyDecoratedInitTestClass(InstrumentBase):
         """
 
 
-@deprecate("Deprecate to test that decorated class is handled correctly")
+@deprecated("Deprecate to test that decorated class is handled correctly")
 class DummyDecoratedClassTestClass(InstrumentBase):
     myattr: str = "ClassAttribute"
     """
@@ -102,7 +102,7 @@ def test_decorated_init_func() -> None:
 
 
 def test_decorated_class() -> None:
-    attr = qcodes_parameter_attr_getter(DummyDecoratedClassTestClass, "other_attr")
+    attr = qcodes_parameter_attr_getter(DummyDecoratedClassTestClass, "other_attr")  # pyright: ignore[reportDeprecated]
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == '"InstanceAttribute"'
 


### PR DESCRIPTION
There is no good reason to keep this around and along with https://github.com/microsoft/Qcodes/pull/6942 this will eventually allow us to drop the dependency on wrapt in qcodes