### PR TITLE
Enable Pyright standard rules

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,6 +1,6 @@
 {
 "devDependencies": {
-	"pyright": "1.1.397"
+	"pyright": "1.1.398"
 },
 "packageManager": "npm@11"
 }

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,6 +1,1 @@
-{
-"devDependencies": {
-	"pyright": "1.1.398"
-},
-"packageManager": "npm@11"
-}
+{"devDependencies": {"pyright": "1.1.398"}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,6 @@ reportUnnecessaryContains = "none"
 
 [tool.pytest.ini_options]
 minversion = "7.2"
-junit_family = "legacy"
 testpaths = "tests"
 addopts = "-n auto --dist=loadfile --cov-config=pyproject.toml"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,6 @@ filterwarnings = [
 [tool.ruff]
 
 extend-include = ["*.ipynb"]
-extend-exclude = ["typings"]
 
 [tool.ruff.lint]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,13 +216,11 @@ reportUnusedFunction = "none"
 reportUnusedImport = "none"
 reportUnknownLambdaType = "none"
 reportUnnecessaryIsInstance = "none"
-reportArgumentType = "none"
 reportUntypedNamedTuple = "none"
 reportUnnecessaryComparison = "none"
 reportConstantRedefinition = "none"
 reportUnusedClass = "none"
 reportUnnecessaryCast = "none"  # mypy already checks this. If it fails for pyright its because mypy requires it
-reportAssignmentType = "none"
 reportUnnecessaryContains = "none"
 
 [tool.pytest.ini_options]

--- a/src/qcodes/dataset/plotting.py
+++ b/src/qcodes/dataset/plotting.py
@@ -524,7 +524,8 @@ def _convert_complex_to_real(
         "name": new_names[1],
         "label": new_labels[1],
         "unit": new_units[1],
-        "data": new_data[1],
+        "data": new_data[1],  # pyright: ignore[reportAssignmentType]
+        # the type of the converter cannot be infered due to the nested dict converters
         "shape": parameter["shape"],
     }
 

--- a/src/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
+++ b/src/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
@@ -301,7 +301,7 @@ class RigolDG1062Channel(InstrumentChannel):
         """Public interface to get the current waveform"""
         return self._get_waveform_params()
 
-    def _get_waveform_param(self, param: str) -> float:
+    def _get_waveform_param(self, param: str) -> float | None:
         """
         Get a parameter of the current waveform. Valid param names are
         dependent on the waveform type (e.g. "DC" does not have a "phase")

--- a/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/tests/dataset/measurement/test_measurement_context_manager.py
@@ -298,7 +298,7 @@ def test_unregister_parameter(DAC, DMM) -> None:
     not_parameters = [DAC, DMM, 0.0, 1]
     for notparam in not_parameters:
         with pytest.raises(ValueError):
-            meas.unregister_parameter(notparam)
+            meas.unregister_parameter(notparam)  # pyright: ignore[reportArgumentType]
 
     # unregistering something not registered should silently "succeed"
     meas.unregister_parameter("totes_not_registered")

--- a/tests/drivers/test_ami430.py
+++ b/tests/drivers/test_ami430.py
@@ -6,7 +6,7 @@ import re
 import time
 import warnings
 from contextlib import ExitStack
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 import pytest
@@ -28,6 +28,9 @@ from qcodes.utils.types import (
     numpy_non_concrete_ints_instantiable,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
 
@@ -40,11 +43,10 @@ _time_resolution = time.get_clock_info("time").resolution
 
 # If any of the field limit functions are satisfied we are in the safe zone.
 # We can have higher field along the z-axis if x and y are zero.
-field_limit = [
+field_limit: list["Callable[[float, float, float], bool]"] = [
     lambda x, y, z: x == 0 and y == 0 and z < 3,
-    lambda x, y, z: np.linalg.norm([x, y, z]) < 2,
+    lambda x, y, z: bool(np.linalg.norm([x, y, z]) < 2),
 ]
-
 LOG_NAME = "qcodes.instrument.instrument_base"
 
 

--- a/tests/drivers/test_ami430_visa.py
+++ b/tests/drivers/test_ami430_visa.py
@@ -4,7 +4,7 @@ import re
 import time
 import warnings
 from contextlib import ExitStack
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 import pytest
@@ -30,13 +30,16 @@ from qcodes.utils.types import (
     numpy_non_concrete_ints_instantiable,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 _time_resolution = time.get_clock_info("time").resolution
 
 # If any of the field limit functions are satisfied we are in the safe zone.
 # We can have higher field along the z-axis if x and y are zero.
-field_limit = [
+field_limit: list["Callable[[float, float, float], bool]"] = [
     lambda x, y, z: x == 0 and y == 0 and z < 3,
-    lambda x, y, z: np.linalg.norm([x, y, z]) < 2,
+    lambda x, y, z: bool(np.linalg.norm([x, y, z]) < 2),
 ]
 
 LOG_NAME = "qcodes.instrument.instrument_base"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -20,7 +20,7 @@ from qcodes.logger.log_analysis import capture_dataframe
 from tests.drivers.test_lakeshore import Model_372_Mock
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
 TEST_LOG_MESSAGE = "test log message"
 
@@ -95,9 +95,9 @@ def AMI430_3D() -> (
         pyvisa_sim_file="AMI430.yaml",
         terminator="\n",
     )
-    field_limit = [
+    field_limit: list[Callable[[float, float, float], bool]] = [
         lambda x, y, z: x == 0 and y == 0 and z < 3,
-        lambda x, y, z: np.linalg.norm([x, y, z]) < 2,
+        lambda x, y, z: bool(np.linalg.norm([x, y, z]) < 2),
     ]
     driver = AMIModel4303D("AMI430_3D", mag_x, mag_y, mag_z, field_limit)
     try:

--- a/tests/validators/test_enum.py
+++ b/tests/validators/test_enum.py
@@ -25,7 +25,7 @@ def test_good() -> None:
 
         for v in [22, "bad data", [44, 55]]:
             with pytest.raises((ValueError, TypeError)):
-                e.validate(v)
+                e.validate(v)  # pyright: ignore[reportArgumentType]
 
         assert repr(e) == f"<Enum: {set(enum)!r}>"
 


### PR DESCRIPTION
These rules are standard and quite important so should never have been disabled in the first place.

Also various small cleanups of pytest and ruff settings
