### PR TITLE
Fix typo in Raises docstrings

### DIFF
--- a/src/qcodes/dataset/descriptions/dependencies.py
+++ b/src/qcodes/dataset/descriptions/dependencies.py
@@ -228,7 +228,7 @@ class InterDependencies_:
             ps: the parameter to look up
 
         Raises:
-            ValueError if the parameter is not part of this object
+            ValueError: If the parameter is not part of this object
 
         """
         if ps not in self:
@@ -245,7 +245,7 @@ class InterDependencies_:
             ps: the parameter to look up
 
         Raises:
-            ValueError if the parameter is not part of this object
+            ValueError: If the parameter is not part of this object
 
         """
         if ps not in self:
@@ -480,8 +480,8 @@ class InterDependencies_:
             parameters: The collection of ParamSpecBases to validate
 
         Raises:
-            DependencyError, if a dependency is missing
-            InferenceError, if an inference is missing
+            DependencyError: If a dependency is missing
+            InferenceError: If an inference is missing
 
         """
         params = {p.name for p in parameters}


### PR DESCRIPTION
Fix incorrect rendering such as 

![image](https://github.com/user-attachments/assets/d0d74ffe-28ff-4426-b75c-f353ca3bdfe4)
