### PR TITLE
Replace np.ndarray with npt alias

### DIFF
--- a/src/qcodes/dataset/data_export.py
+++ b/src/qcodes/dataset/data_export.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import TypedDict
 
 from qcodes.utils import list_of_data_to_maybe_ragged_nd_array
@@ -23,7 +24,7 @@ class DSPlotData(TypedDict):
     name: str
     unit: str
     label: str
-    data: np.ndarray
+    data: npt.NDArray
     shape: tuple[int, ...] | None
 
 
@@ -62,7 +63,7 @@ def _get_data_from_ds(ds: DataSetProtocol) -> list[list[DSPlotData]]:
     return output
 
 
-def _all_steps_multiples_of_min_step(rows: np.ndarray) -> bool:
+def _all_steps_multiples_of_min_step(rows: npt.NDArray) -> bool:
     """
     Are all steps integer multiples of the smallest step?
     This is used in determining whether the setpoints correspond
@@ -76,7 +77,7 @@ def _all_steps_multiples_of_min_step(rows: np.ndarray) -> bool:
 
     """
 
-    steps_list: list[np.ndarray] = []
+    steps_list: list[npt.NDArray] = []
     for row in rows:
         # TODO: What is an appropriate precision?
         steps_list += list(np.unique(np.diff(row).round(decimals=15)))
@@ -90,7 +91,7 @@ def _all_steps_multiples_of_min_step(rows: np.ndarray) -> bool:
     return asmoms
 
 
-def _rows_from_datapoints(inputsetpoints: np.ndarray) -> np.ndarray:
+def _rows_from_datapoints(inputsetpoints: npt.NDArray) -> npt.NDArray:
     """
     Cast the (potentially) unordered setpoints into rows
     of sorted, unique setpoint values. Because of the way they are ordered,
@@ -126,7 +127,7 @@ def _rows_from_datapoints(inputsetpoints: np.ndarray) -> np.ndarray:
     return list_of_data_to_maybe_ragged_nd_array(rows)
 
 
-def _all_in_group_or_subgroup(rows: np.ndarray) -> bool:
+def _all_in_group_or_subgroup(rows: npt.NDArray) -> bool:
     """
     Detects whether the setpoints correspond to two groups of
     of identical rows, one being contained in the other.
@@ -173,7 +174,7 @@ def _all_in_group_or_subgroup(rows: np.ndarray) -> bool:
     return aigos
 
 
-def _strings_as_ints(inputarray: np.ndarray) -> np.ndarray:
+def _strings_as_ints(inputarray: npt.NDArray) -> npt.NDArray:
     """
     Return an integer-valued array version of a string-valued array. Maps, e.g.
     array(['a', 'b', 'c', 'a', 'c']) to array([0, 1, 2, 0, 2]). Useful for
@@ -189,7 +190,7 @@ def _strings_as_ints(inputarray: np.ndarray) -> np.ndarray:
     return newdata
 
 
-def get_1D_plottype(xpoints: np.ndarray, ypoints: np.ndarray) -> str:
+def get_1D_plottype(xpoints: npt.NDArray, ypoints: npt.NDArray) -> str:
     """
     Determine plot type for a 1D plot by inspecting the data
 
@@ -218,7 +219,7 @@ def get_1D_plottype(xpoints: np.ndarray, ypoints: np.ndarray) -> str:
         return datatype_from_setpoints_1d(xpoints)
 
 
-def datatype_from_setpoints_1d(setpoints: np.ndarray) -> str:
+def datatype_from_setpoints_1d(setpoints: npt.NDArray) -> str:
     """
     Figure out what type of visualisation is proper for the
     provided setpoints.
@@ -241,7 +242,7 @@ def datatype_from_setpoints_1d(setpoints: np.ndarray) -> str:
 
 
 def get_2D_plottype(
-    xpoints: np.ndarray, ypoints: np.ndarray, zpoints: np.ndarray
+    xpoints: npt.NDArray, ypoints: npt.NDArray, zpoints: npt.NDArray
 ) -> str:
     """
     Determine plot type for a 2D plot by inspecting the data
@@ -267,7 +268,7 @@ def get_2D_plottype(
     return plottype
 
 
-def datatype_from_setpoints_2d(xpoints: np.ndarray, ypoints: np.ndarray) -> str:
+def datatype_from_setpoints_2d(xpoints: npt.NDArray, ypoints: npt.NDArray) -> str:
     """
     For a 2D plot, figure out what kind of visualisation we can use
     to display the data.
@@ -329,8 +330,8 @@ def datatype_from_setpoints_2d(xpoints: np.ndarray, ypoints: np.ndarray) -> str:
 
 
 def reshape_2D_data(
-    x: np.ndarray, y: np.ndarray, z: np.ndarray
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    x: npt.NDArray, y: npt.NDArray, z: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     xrow = np.array(_rows_from_datapoints(x)[0])
     yrow = np.array(_rows_from_datapoints(y)[0])
     nx = len(xrow)

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.dataset.exporters.export_info import ExportInfo
 from qcodes.dataset.sqlite.queries import completed, load_new_data_for_rundescriber
@@ -110,7 +111,7 @@ class DataSetCache(Generic[DatasetType_co]):
         from disk
         """
 
-    def add_data(self, new_data: Mapping[str, Mapping[str, np.ndarray]]) -> None:
+    def add_data(self, new_data: Mapping[str, Mapping[str, npt.NDArray]]) -> None:
         if self.live is False:
             raise RuntimeError(
                 "Cannot append live data to a dataset that has "
@@ -206,8 +207,8 @@ def load_new_data_from_db_and_append(
     rundescriber: RunDescriber,
     write_status: Mapping[str, int | None],
     read_status: Mapping[str, int],
-    existing_data: Mapping[str, Mapping[str, np.ndarray]],
-) -> tuple[dict[str, int | None], dict[str, int], dict[str, dict[str, np.ndarray]]]:
+    existing_data: Mapping[str, Mapping[str, npt.NDArray]],
+) -> tuple[dict[str, int | None], dict[str, int], dict[str, dict[str, npt.NDArray]]]:
     """
     Append any new data in the db to an already existing datadict and return the merged
     data.
@@ -244,9 +245,9 @@ def load_new_data_from_db_and_append(
 def append_shaped_parameter_data_to_existing_arrays(
     rundescriber: RunDescriber,
     write_status: Mapping[str, int | None],
-    existing_data: Mapping[str, Mapping[str, np.ndarray]],
-    new_data: Mapping[str, Mapping[str, np.ndarray]],
-) -> tuple[dict[str, int | None], dict[str, dict[str, np.ndarray]]]:
+    existing_data: Mapping[str, Mapping[str, npt.NDArray]],
+    new_data: Mapping[str, Mapping[str, npt.NDArray]],
+) -> tuple[dict[str, int | None], dict[str, dict[str, npt.NDArray]]]:
     """
     Append datadict to an already existing datadict and return the merged
     data.
@@ -294,12 +295,12 @@ def append_shaped_parameter_data_to_existing_arrays(
 
 
 def _merge_data(
-    existing_data: Mapping[str, np.ndarray],
-    new_data: Mapping[str, np.ndarray],
+    existing_data: Mapping[str, npt.NDArray],
+    new_data: Mapping[str, npt.NDArray],
     shape: tuple[int, ...] | None,
     single_tree_write_status: int | None,
     meas_parameter: str,
-) -> tuple[dict[str, np.ndarray], int | None]:
+) -> tuple[dict[str, npt.NDArray], int | None]:
     subtree_merged_data = {}
     subtree_parameters = existing_data.keys()
 
@@ -335,12 +336,12 @@ def _merge_data(
 
 
 def _merge_data_single_param(
-    existing_values: np.ndarray | None,
-    new_values: np.ndarray | None,
+    existing_values: npt.NDArray | None,
+    new_values: npt.NDArray | None,
     shape: tuple[int, ...] | None,
     single_tree_write_status: int | None,
-) -> tuple[np.ndarray | None, int | None]:
-    merged_data: np.ndarray | None
+) -> tuple[npt.NDArray | None, int | None]:
+    merged_data: npt.NDArray | None
     if (
         existing_values is not None and existing_values.size != 0
     ) and new_values is not None:
@@ -359,8 +360,8 @@ def _merge_data_single_param(
 
 
 def _create_new_data_dict(
-    new_values: np.ndarray, shape: tuple[int, ...] | None
-) -> tuple[np.ndarray, int]:
+    new_values: npt.NDArray, shape: tuple[int, ...] | None
+) -> tuple[npt.NDArray, int]:
     if shape is None:
         return new_values, new_values.size
     elif new_values.size > 0:
@@ -379,11 +380,11 @@ def _create_new_data_dict(
 
 
 def _insert_into_data_dict(
-    existing_values: np.ndarray,
-    new_values: np.ndarray,
+    existing_values: npt.NDArray,
+    new_values: npt.NDArray,
     write_status: int | None,
     shape: tuple[int, ...] | None,
-) -> tuple[np.ndarray, int | None]:
+) -> tuple[npt.NDArray, int | None]:
     if new_values.size == 0:
         return existing_values, write_status
 
@@ -427,8 +428,8 @@ def _insert_into_data_dict(
 
 
 def _expand_single_param_dict(
-    single_param_dict: Mapping[str, np.ndarray],
-) -> dict[str, np.ndarray]:
+    single_param_dict: Mapping[str, npt.NDArray],
+) -> dict[str, npt.NDArray]:
     sizes = {name: array.size for name, array in single_param_dict.items()}
     maxsize = max(sizes.values())
     max_names = tuple(name for name, size in sizes.items() if size == maxsize)

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.dataset.data_set_protocol import (
     SPECS,
@@ -377,8 +378,8 @@ class DataSetInMem(BaseDataSet):
     @staticmethod
     def _from_xarray_dataset_to_qcodes_raw_data(
         xr_data: xr.Dataset,
-    ) -> dict[str, dict[str, np.ndarray]]:
-        output: dict[str, dict[str, np.ndarray]] = {}
+    ) -> dict[str, dict[str, npt.NDArray]]:
+        output: dict[str, dict[str, npt.NDArray]] = {}
         for datavar in xr_data.data_vars:
             output[str(datavar)] = {}
             data = xr_data[datavar]
@@ -639,7 +640,9 @@ class DataSetInMem(BaseDataSet):
 
         self._export_info = export_info
 
-    def _enqueue_results(self, result_dict: Mapping[ParamSpecBase, np.ndarray]) -> None:
+    def _enqueue_results(
+        self, result_dict: Mapping[ParamSpecBase, npt.NDArray]
+    ) -> None:
         """
         Enqueue the results, for this dataset directly into cache
 
@@ -656,7 +659,7 @@ class DataSetInMem(BaseDataSet):
         interdeps = self._rundescriber.interdeps
 
         toplevel_params = set(interdeps.dependencies).intersection(set(result_dict))
-        new_results: dict[str, dict[str, np.ndarray]] = {}
+        new_results: dict[str, dict[str, npt.NDArray]] = {}
         for toplevel_param in toplevel_params:
             inff_params = set(interdeps.inferences.get(toplevel_param, ()))
             deps_params = set(interdeps.dependencies.get(toplevel_param, ()))

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
@@ -53,12 +54,12 @@ _EXPORT_CALLBACKS = set(entry_points(group="qcodes.dataset.on_export"))
 ScalarResTypes: TypeAlias = (
     str | complex | np.integer | np.floating | np.complexfloating
 )
-ValuesType: TypeAlias = ScalarResTypes | np.ndarray | Sequence[ScalarResTypes]
+ValuesType: TypeAlias = ScalarResTypes | npt.NDArray | Sequence[ScalarResTypes]
 ResType: TypeAlias = "tuple[ParameterBase | str, ValuesType]"
 SetpointsType: TypeAlias = "Sequence[str | ParameterBase]"
 
 # deprecated alias left for backwards compatibility
-array_like_types = (tuple, list, np.ndarray)
+array_like_types = (tuple, list, npt.NDArray)
 scalar_res_types: TypeAlias = ScalarResTypes  # noqa PYI042
 values_type: TypeAlias = ValuesType  # noqa PYI042
 res_type: TypeAlias = ResType  # noqa PYI042
@@ -70,7 +71,7 @@ SPECS: TypeAlias = list[ParamSpec]
 # the DataSet constructor for a while, then deprecate SPECS and finally remove
 # the ParamSpec class
 SpecsOrInterDeps: TypeAlias = SPECS | InterDependencies_
-ParameterData: TypeAlias = dict[str, dict[str, np.ndarray]]
+ParameterData: TypeAlias = dict[str, dict[str, npt.NDArray]]
 
 LOG = logging.getLogger(__name__)
 
@@ -257,7 +258,7 @@ class DataSetProtocol(Protocol):
     # private members called by various other parts or the api
 
     def _enqueue_results(
-        self, result_dict: Mapping[ParamSpecBase, np.ndarray]
+        self, result_dict: Mapping[ParamSpecBase, npt.NDArray]
     ) -> None: ...
 
     def _flush_data_to_database(self, block: bool = False) -> None: ...
@@ -494,8 +495,8 @@ class BaseDataSet(DataSetProtocol, Protocol):
 
     @staticmethod
     def _reshape_array_for_cache(
-        param: ParamSpecBase, param_data: np.ndarray
-    ) -> np.ndarray:
+        param: ParamSpecBase, param_data: npt.NDArray
+    ) -> npt.NDArray:
         """
         Shape cache data so it matches data read from database.
         This means:

--- a/src/qcodes/dataset/descriptions/dependencies.py
+++ b/src/qcodes/dataset/descriptions/dependencies.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 from .param_spec import ParamSpec, ParamSpecBase
 
@@ -270,7 +271,7 @@ class InterDependencies_:
         }
         return output
 
-    def _empty_data_dict(self) -> dict[str, dict[str, np.ndarray]]:
+    def _empty_data_dict(self) -> dict[str, dict[str, npt.NDArray]]:
         """
         Create an dictionary with empty numpy arrays as values
         matching the expected output of ``DataSet``'s ``get_parameter_data`` /
@@ -279,7 +280,7 @@ class InterDependencies_:
         in this class.
         """
 
-        output: dict[str, dict[str, np.ndarray]] = {}
+        output: dict[str, dict[str, npt.NDArray]] = {}
         for dependent, independents in self.dependencies.items():
             dependent_name = dependent.name
             output[dependent_name] = {dependent_name: np.array([])}

--- a/src/qcodes/dataset/descriptions/detect_shapes.py
+++ b/src/qcodes/dataset/descriptions/detect_shapes.py
@@ -5,6 +5,7 @@ from numbers import Integral
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.parameters import (
     ArrayParameter,
@@ -68,7 +69,7 @@ def detect_shape_of_measurement(
     return shapes
 
 
-def _get_shape_of_step(step: int | np.integer[Any] | Sized | np.ndarray) -> int:
+def _get_shape_of_step(step: int | np.integer[Any] | Sized | npt.NDArray) -> int:
     if isinstance(step, Integral):
         return int(step)
     elif isinstance(step, np.ndarray):

--- a/src/qcodes/dataset/exporters/export_to_pandas.py
+++ b/src/qcodes/dataset/exporters/export_to_pandas.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -39,7 +40,7 @@ def load_to_concatenated_dataframe(datadict: ParameterData) -> pd.DataFrame:
 
 
 def _data_to_dataframe(
-    data: Mapping[str, np.ndarray], index: pd.Index | pd.MultiIndex | None
+    data: Mapping[str, npt.NDArray], index: pd.Index | pd.MultiIndex | None
 ) -> pd.DataFrame:
     import pandas as pd
 
@@ -60,7 +61,7 @@ def _data_to_dataframe(
 
 
 def _generate_pandas_index(
-    data: Mapping[str, np.ndarray],
+    data: Mapping[str, npt.NDArray],
 ) -> pd.Index | pd.MultiIndex | None:
     # the first element in the dict given by parameter_tree is always the dependent
     # parameter and the index is therefore formed from the rest
@@ -94,7 +95,7 @@ def _generate_pandas_index(
 
 
 def _parameter_data_identical(
-    param_dict_a: Mapping[str, np.ndarray], param_dict_b: Mapping[str, np.ndarray]
+    param_dict_a: Mapping[str, npt.NDArray], param_dict_b: Mapping[str, npt.NDArray]
 ) -> bool:
     try:
         np.testing.assert_equal(param_dict_a, param_dict_b)
@@ -105,7 +106,7 @@ def _parameter_data_identical(
 
 
 def _same_setpoints(datadict: ParameterData) -> bool:
-    def _get_setpoints(dd: ParameterData) -> Iterator[dict[str, np.ndarray]]:
+    def _get_setpoints(dd: ParameterData) -> Iterator[dict[str, npt.NDArray]]:
         for dep_name, param_dict in dd.items():
             out = {name: vals for name, vals in param_dict.items() if name != dep_name}
             yield out

--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Hashable, Mapping
     from pathlib import Path
 
-    import numpy as np
+    import numpy.typing as npt
     import pandas as pd
     import xarray as xr
 
@@ -64,7 +64,7 @@ def _calculate_index_shape(idx: pd.Index | pd.MultiIndex) -> dict[Hashable, int]
 
 def _load_to_xarray_dataarray_dict_no_metadata(
     dataset: DataSetProtocol,
-    datadict: Mapping[str, Mapping[str, np.ndarray]],
+    datadict: Mapping[str, Mapping[str, npt.NDArray]],
     *,
     use_multi_index: Literal["auto", "always", "never"] = "auto",
 ) -> dict[str, xr.DataArray]:
@@ -134,7 +134,7 @@ def _load_to_xarray_dataarray_dict_no_metadata(
 
 def load_to_xarray_dataarray_dict(
     dataset: DataSetProtocol,
-    datadict: Mapping[str, Mapping[str, np.ndarray]],
+    datadict: Mapping[str, Mapping[str, npt.NDArray]],
     *,
     use_multi_index: Literal["auto", "always", "never"] = "auto",
 ) -> dict[str, xr.DataArray]:

--- a/src/qcodes/dataset/measurements.py
+++ b/src/qcodes/dataset/measurements.py
@@ -20,6 +20,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
+import numpy.typing as npt
 from opentelemetry import trace
 
 import qcodes as qc
@@ -164,7 +165,7 @@ class DataSaver:
         # of all parameters. This also allows users to call
         # add_result with the arguments in any particular order, i.e. NOT
         # enforcing that setpoints come before dependent variables.
-        results_dict: dict[ParamSpecBase, np.ndarray] = {}
+        results_dict: dict[ParamSpecBase, npt.NDArray] = {}
 
         parameter_names = tuple(
             partial_result[0].register_name
@@ -234,7 +235,7 @@ class DataSaver:
         parameter: ParameterWithSetpoints,
         parameter_names: Sequence[str],
         partial_result: ResType,
-    ) -> dict[ParamSpecBase, np.ndarray]:
+    ) -> dict[ParamSpecBase, npt.NDArray]:
         local_results = {}
         setpoint_names = tuple(
             setpoint.register_name for setpoint in parameter.setpoints
@@ -258,7 +259,7 @@ class DataSaver:
 
     def _unpack_partial_result(
         self, partial_result: ResType
-    ) -> dict[ParamSpecBase, np.ndarray]:
+    ) -> dict[ParamSpecBase, npt.NDArray]:
         """
         Unpack a partial result (not containing :class:`ArrayParameters` or
         class:`MultiParameters`) into a standard results dict form and return
@@ -286,7 +287,7 @@ class DataSaver:
 
     def _unpack_arrayparameter(
         self, partial_result: ResType
-    ) -> dict[ParamSpecBase, np.ndarray]:
+    ) -> dict[ParamSpecBase, npt.NDArray]:
         """
         Unpack a partial result containing an :class:`Arrayparameter` into a
         standard results dict form and return that dict
@@ -324,7 +325,7 @@ class DataSaver:
 
     def _unpack_multiparameter(
         self, partial_result: ResType
-    ) -> dict[ParamSpecBase, np.ndarray]:
+    ) -> dict[ParamSpecBase, npt.NDArray]:
         """
         Unpack the `subarrays` and `setpoints` from a :class:`MultiParameter`
         and into a standard results dict form and return that dict
@@ -387,7 +388,7 @@ class DataSaver:
         setpoints: Sequence[Any],
         sp_names: Sequence[str] | None,
         fallback_sp_name: str,
-    ) -> dict[ParamSpecBase, np.ndarray]:
+    ) -> dict[ParamSpecBase, npt.NDArray]:
         """
         Unpack the `setpoints` and their values from a
         :class:`ArrayParameter` or :class:`MultiParameter`
@@ -469,7 +470,7 @@ class DataSaver:
 
     @staticmethod
     def _validate_result_types(
-        results_dict: Mapping[ParamSpecBase, np.ndarray],
+        results_dict: Mapping[ParamSpecBase, npt.NDArray],
     ) -> None:
         """
         Validate the type of the results

--- a/src/qcodes/dataset/plotting.py
+++ b/src/qcodes/dataset/plotting.py
@@ -14,6 +14,7 @@ from textwrap import wrap
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import numpy as np
+import numpy.typing as npt
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -317,7 +318,7 @@ def plot_dataset(
             if data[2]["shape"] is None:
                 xpoints = data[0]["data"].flatten()
                 ypoints = data[1]["data"].flatten()
-                zpoints = data[2]["data"].flatten()
+                zpoints: npt.NDArray = data[2]["data"].flatten()
                 plottype = get_2D_plottype(xpoints, ypoints, zpoints)
                 log.debug(f"Determined plottype: {plottype}")
             else:
@@ -601,9 +602,9 @@ def _set_data_axes_labels(
 
 
 def plot_2d_scatterplot(
-    x: np.ndarray,
-    y: np.ndarray,
-    z: np.ndarray,
+    x: npt.NDArray,
+    y: npt.NDArray,
+    z: npt.NDArray,
     ax: Axes,
     colorbar: Colorbar | None = None,
     **kwargs: Any,
@@ -666,9 +667,9 @@ def plot_2d_scatterplot(
 
 
 def plot_on_a_plain_grid(
-    x: np.ndarray,
-    y: np.ndarray,
-    z: np.ndarray,
+    x: npt.NDArray,
+    y: npt.NDArray,
+    z: npt.NDArray,
     ax: Axes,
     colorbar: Colorbar | None = None,
     **kwargs: Any,
@@ -780,9 +781,11 @@ def plot_on_a_plain_grid(
 
 
 def _clip_nan_from_shaped_data(
-    x: np.ndarray, y: np.ndarray, z: np.ndarray
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    def _on_rectilinear_grid_except_nan(x_data: np.ndarray, y_data: np.ndarray) -> bool:
+    x: npt.NDArray, y: npt.NDArray, z: npt.NDArray
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+    def _on_rectilinear_grid_except_nan(
+        x_data: npt.NDArray, y_data: npt.NDArray
+    ) -> bool:
         """
         Check that data is on a rectilinear grid. e.g. all points are the same as the first
         row and column with the exception of nans. Those represent points not yet measured.
@@ -908,7 +911,7 @@ def _rescale_ticks_and_units(
             cax.update_ticks()
 
 
-def _is_string_valued_array(values: np.ndarray) -> bool:
+def _is_string_valued_array(values: npt.NDArray) -> bool:
     """
     Check if the given 1D numpy array contains categorical data, or, in other
     words, if it is string-valued.

--- a/src/qcodes/dataset/sqlite/database.py
+++ b/src/qcodes/dataset/sqlite/database.py
@@ -15,6 +15,7 @@ from os.path import expanduser, normpath
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+import numpy.typing as npt
 
 import qcodes
 from qcodes.dataset.experiment_settings import reset_default_experiment_id
@@ -35,7 +36,7 @@ JournalMode = Literal["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"]
 
 
 # utility function to allow sqlite/numpy type
-def _adapt_array(arr: np.ndarray) -> sqlite3.Binary:
+def _adapt_array(arr: npt.NDArray) -> sqlite3.Binary:
     """
     See this:
     https://stackoverflow.com/questions/3425320/sqlite3-programmingerror-you-must-not-use-8-bit-bytestrings-unless-you-use-a-te
@@ -50,7 +51,7 @@ def _adapt_array(arr: np.ndarray) -> sqlite3.Binary:
     return sqlite3.Binary(out.read())
 
 
-def _convert_array(text: bytes) -> np.ndarray:
+def _convert_array(text: bytes) -> npt.NDArray:
     # Using np.lib.format.read_array (counterpart of np.lib.format.write_array)
     # npy format version 3.0 is 3 times faster than previous verions (no clean up step
     # for python 2 backward compatibility)

--- a/src/qcodes/dataset/sqlite/queries.py
+++ b/src/qcodes/dataset/sqlite/queries.py
@@ -126,7 +126,7 @@ def get_parameter_data(
     start: int | None = None,
     end: int | None = None,
     callback: Callable[[float], None] | None = None,
-) -> dict[str, dict[str, np.ndarray]]:
+) -> dict[str, dict[str, npt.NDArray]]:
     """
     Get data for one or more parameters and its dependencies. The data
     is returned as numpy arrays within 2 layers of nested dicts. The keys of
@@ -177,7 +177,7 @@ def get_shaped_parameter_data_for_one_paramtree(
     start: int | None,
     end: int | None,
     callback: Callable[[float], None] | None = None,
-) -> dict[str, np.ndarray]:
+) -> dict[str, npt.NDArray]:
     """
     Get the data for a parameter tree and reshape it according to the
     metadata about the dataset. This will only reshape the loaded data if
@@ -233,7 +233,7 @@ def get_parameter_data_for_one_paramtree(
     start: int | None,
     end: int | None,
     callback: Callable[[float], None] | None = None,
-) -> tuple[dict[str, np.ndarray], int]:
+) -> tuple[dict[str, npt.NDArray], int]:
     interdeps = rundescriber.interdeps
     data, paramspecs, n_rows = _get_data_for_one_param_tree(
         conn, table_name, interdeps, output_param, start, end, callback
@@ -402,7 +402,7 @@ def get_table_max_id(conn: AtomicConnection, table_name: str) -> int:
 
 def _get_offset_limit_for_callback(
     conn: AtomicConnection, table_name: str, param_name: str
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[npt.NDArray, npt.NDArray]:
     """
     Since sqlite3 does not allow to keep track of the data loading progress,
     we compute how many sqlite request correspond to a progress of
@@ -491,9 +491,9 @@ def get_parameter_tree_values(
     cursor = conn.cursor()
 
     # Without callback: int
-    # With callback: np.ndarray
-    offset: int | np.ndarray
-    limit: int | np.ndarray
+    # With callback: npt.NDArray
+    offset: int | npt.NDArray
+    limit: int | npt.NDArray
 
     offset = max((start - 1), 0) if start is not None else 0
     limit = max((end - offset), 0) if end is not None else -1
@@ -2088,7 +2088,7 @@ def load_new_data_for_rundescriber(
     table_name: str,
     rundescriber: RunDescriber,
     read_status: Mapping[str, int],
-) -> tuple[dict[str, dict[str, np.ndarray]], dict[str, int]]:
+) -> tuple[dict[str, dict[str, npt.NDArray]], dict[str, int]]:
     """
     Load all new data for a given rundesciber since the rows given by read_status.
 
@@ -2106,7 +2106,7 @@ def load_new_data_for_rundescriber(
 
     parameters = tuple(ps.name for ps in rundescriber.interdeps.non_dependencies)
     updated_read_status: dict[str, int] = dict(read_status)
-    new_data_dict: dict[str, dict[str, np.ndarray]] = {}
+    new_data_dict: dict[str, dict[str, npt.NDArray]] = {}
 
     for meas_parameter in parameters:
         start = read_status.get(meas_parameter, 0) + 1

--- a/src/qcodes/instrument/mockers/simulated_ats_api.py
+++ b/src/qcodes/instrument/mockers/simulated_ats_api.py
@@ -10,6 +10,7 @@ import ctypes
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.instrument_drivers.AlazarTech.ats_api import AlazarATSAPI
 from qcodes.instrument_drivers.AlazarTech.constants import (
@@ -32,16 +33,16 @@ class SimulatedATS9360API(AlazarATSAPI):
     def __init__(
         self,
         dll_path: str | None = None,  # Need this for meta super class
-        buffer_generator: "Callable[[np.ndarray], None] | None" = None,
+        buffer_generator: "Callable[[npt.NDArray], None] | None" = None,
     ):
-        def _default_buffer_generator(buffer: np.ndarray) -> None:
+        def _default_buffer_generator(buffer: npt.NDArray) -> None:
             upper = buffer.size // 2
             buffer[0:upper] = 30000 * np.ones(upper)
 
         # don't call `super().__init__` here to avoid dependence on the
         # alazar driver, when loading the dll
         self._buffer_generator = buffer_generator or _default_buffer_generator
-        self.buffers: dict[int, np.ndarray] = {}
+        self.buffers: dict[int, npt.NDArray] = {}
 
     def _sync_dll_call(self, c_name: str, *args: Any) -> None:
         _mark_params_as_updated(*args)

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import deprecated
 
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
@@ -775,7 +776,7 @@ class Buffer:
 
     def __init__(self, c_sample_type: CtypesTypes, size_bytes: int):
         self.size_bytes = size_bytes
-        self.buffer: np.ndarray
+        self.buffer: npt.NDArray
 
         bytes_per_sample = {
             ctypes.c_uint8: 1,
@@ -864,7 +865,7 @@ class AcquisitionInterface(Generic[OutputType]):
         pass
 
     def handle_buffer(
-        self, buffer: np.ndarray, buffer_number: int | None = None
+        self, buffer: npt.NDArray, buffer_number: int | None = None
     ) -> None:
         """
         This method should store or process the information that is contained

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -2,6 +2,7 @@ import math
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 from .ATS import AcquisitionController
 
@@ -39,9 +40,9 @@ class DemodulationAcquisitionController(AcquisitionController[float]):
         self.records_per_buffer = 0
         self.buffers_per_acquisition = 0
         self.number_of_channels = 2
-        self.cos_list: np.ndarray | None = None
-        self.sin_list: np.ndarray | None = None
-        self.buffer: np.ndarray | None = None
+        self.cos_list: npt.NDArray | None = None
+        self.sin_list: npt.NDArray | None = None
+        self.buffer: npt.NDArray | None = None
         # make a call to the parent class and by extension, create the parameter
         # structure of this class
         super().__init__(name, alazar_name, **kwargs)
@@ -101,7 +102,7 @@ class DemodulationAcquisitionController(AcquisitionController[float]):
         pass
 
     def handle_buffer(
-        self, buffer: np.ndarray, buffer_number: int | None = None
+        self, buffer: npt.NDArray, buffer_number: int | None = None
     ) -> None:
         """
         See AcquisitionController
@@ -145,7 +146,7 @@ class DemodulationAcquisitionController(AcquisitionController[float]):
         else:
             raise Exception("Could not find CHANNEL_B during data extraction")
 
-    def fit(self, buf: np.ndarray) -> tuple[float, float]:
+    def fit(self, buf: npt.NDArray) -> tuple[float, float]:
         """
         The DFT is implemented in this method
         :param buf: buffer to perform the transform on

--- a/src/qcodes/instrument_drivers/Galil/dmc_41x3.py
+++ b/src/qcodes/instrument_drivers/Galil/dmc_41x3.py
@@ -671,16 +671,16 @@ class GalilDMC4133Arm:
         self._right_top_position: tuple[int, int, int] | None = None
 
         # motion directions (all these values are in quadrature counts)
-        self._a: np.ndarray  # right_top - left_bottom
-        self._b: np.ndarray  # left_top - left_bottom
-        self._c: np.ndarray  # right_top - left_top
-        self._n: np.ndarray
+        self._a: npt.NDArray  # right_top - left_bottom
+        self._b: npt.NDArray  # left_top - left_bottom
+        self._c: npt.NDArray  # right_top - left_top
+        self._n: npt.NDArray
         self.norm_a: float
         self.norm_b: float
         self.norm_c: float
 
         # eqn of the chip plane (in quadrature counts)
-        self._plane_eqn: np.ndarray
+        self._plane_eqn: npt.NDArray
 
         # current vars
         self._current_row: int | None = None
@@ -699,7 +699,7 @@ class GalilDMC4133Arm:
 
         self._arm_pick_up_distance: int
 
-        self._target: np.ndarray
+        self._target: npt.NDArray
 
     @property
     def current_row(self) -> int | None:
@@ -861,7 +861,7 @@ class GalilDMC4133Arm:
         c.begin()
         c.wait_till_motor_motion_complete()
 
-    def _setup_motion(self, rel_vec: np.ndarray, d: float, speed: float) -> None:
+    def _setup_motion(self, rel_vec: npt.NDArray, d: float, speed: float) -> None:
         """
         Sets up motion parameters. all arguments have units in quadrature counts
         """

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import TypedDict, Unpack
 
 from qcodes.instrument import InstrumentChannel, VisaInstrument, VisaInstrumentKWArgs
@@ -338,7 +339,7 @@ class Keithley2450Sense(InstrumentChannel):
         buffer_name = self.parent.buffer_name()
         return float(self.ask(f":MEASure? '{buffer_name}'"))
 
-    def _measure_sweep(self) -> np.ndarray:
+    def _measure_sweep(self) -> npt.NDArray:
         source = cast("Keithley2450Source", self.parent.source)
         source.sweep_start()
         buffer_name = self.parent.buffer_name()
@@ -518,7 +519,7 @@ class Keithley2450Source(InstrumentChannel):
         if self.block_during_ramp():
             self.ask("*OPC?")
 
-    def get_sweep_axis(self) -> np.ndarray:
+    def get_sweep_axis(self) -> npt.NDArray:
         if self._sweep_arguments is None:
             raise ValueError(
                 "Please setup the sweep before getting values of this parameter"

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_7510.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_7510.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.instrument import (
     InstrumentBaseKWArgs,
@@ -72,7 +73,7 @@ class GeneratedSetPoints(Parameter):
         self._stop = stop
         self._n_points = n_points
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         start = self._start()
         assert start is not None
         stop = self._stop()

--- a/src/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/src/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
+import numpy.typing as npt
 
 import qcodes.validators as vals
 from qcodes.instrument import (
@@ -95,7 +96,7 @@ class LuaSweepParameter(ArrayParameter):
         self.steps = steps
         self.mode = mode
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         if self.instrument is not None:
             data = self.instrument._fast_sweep(
                 self.start, self.stop, self.steps, self.mode
@@ -154,7 +155,7 @@ class TimeTrace(ParameterWithSetpoints):
             self.unit = "V"
             self.label = "Voltage"
 
-    def _time_trace(self) -> np.ndarray:
+    def _time_trace(self) -> npt.NDArray:
         """
         The function that prepares a Lua script for timetrace data acquisition.
 
@@ -188,7 +189,7 @@ class TimeTrace(ParameterWithSetpoints):
 
         return self.instrument._execute_lua(script, npts)
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         if self.instrument is None:
             raise RuntimeError("No instrument attached to Parameter.")
 
@@ -203,7 +204,7 @@ class TimeAxis(Parameter):
     measurement start) at which the points of the time trace were acquired.
     """
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         if self.instrument is None:
             raise RuntimeError("No instrument attached to Parameter.")
 
@@ -678,7 +679,7 @@ class Keithley2600Channel(InstrumentChannel):
         stop: float,
         steps: int,
         mode: Literal["IV", "VI", "VIfourprobe"] = "IV",
-    ) -> np.ndarray:
+    ) -> npt.NDArray:
         """
         Perform a fast sweep using a deployed Lua script.
         This is the engine that forms the script, uploads it,
@@ -744,7 +745,7 @@ class Keithley2600Channel(InstrumentChannel):
 
         return self._execute_lua(script, steps)
 
-    def _execute_lua(self, _script: list[str], steps: int) -> np.ndarray:
+    def _execute_lua(self, _script: list[str], steps: int) -> npt.NDArray:
         """
         This is the function that sends the Lua script to be executed and
         returns the corresponding data from the buffer.

--- a/src/qcodes/instrument_drivers/Keysight/Infiniium.py
+++ b/src/qcodes/instrument_drivers/Keysight/Infiniium.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import numpy as np
+import numpy.typing as npt
 from pyvisa import VisaIOError
 from pyvisa.constants import StatusCode
 
@@ -45,7 +46,7 @@ class DSOTimeAxisParam(Parameter):
         self.xincrement = xincrement
         self.points = points
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Return the array corresponding to this time axis.
         """
@@ -73,7 +74,7 @@ class DSOFrequencyAxisParam(Parameter):
         self.xincrement = xincrement
         self.points = points
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Return the array corresponding to this time axis.
         """
@@ -201,7 +202,7 @@ class DSOTraceParam(ParameterWithSetpoints):
         instrument.frequency_axis.xorigin = float(preamble[5])
         instrument.frequency_axis.xincrement = float(preamble[4])
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Get waveform data from scope
         """
@@ -226,10 +227,10 @@ class DSOTraceParam(ParameterWithSetpoints):
         root_instr.write(":WAV:DATA?")
         # Ignore first two bytes, which should be "#0"
         _ = root_instr.visa_handle.read_bytes(2)
-        data: np.ndarray
+        data: npt.NDArray
         data = root_instr.visa_handle.read_binary_values(  # type: ignore[assignment]
             "h",
-            container=np.ndarray,
+            container=npt.NDArray,
             header_fmt="empty",
             expect_termination=True,
             data_points=self._points,
@@ -1263,7 +1264,7 @@ class KeysightInfiniium(VisaInstrument):
         with_time: bool = False,
         time_fmt: str = "%Y-%m-%d_%H-%M-%S",
         divider: str = "_",
-    ) -> np.ndarray | None:
+    ) -> npt.NDArray | None:
         """Save screen to {path} with {image_type}: bmp, jpg, gif, tif, png
 
         return np.array if sucessfully saved, else return None

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -3,6 +3,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from pyvisa import constants, errors
 from typing_extensions import deprecated
 
@@ -45,7 +46,7 @@ class PNAAxisParameter(Parameter):
         self._stopparam = stopparam
         self._pointsparam = pointsparam
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Return the axis values, with values retrieved from the parent instrument
         """
@@ -53,7 +54,7 @@ class PNAAxisParameter(Parameter):
 
 
 class PNALogAxisParamter(PNAAxisParameter):
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Return the axis values on a log scale, with values retrieved from
         the parent instrument
@@ -62,7 +63,7 @@ class PNALogAxisParamter(PNAAxisParameter):
 
 
 class PNATimeAxisParameter(PNAAxisParameter):
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Return the axis values on a time scale, with values retrieved from
         the parent instrument
@@ -116,7 +117,7 @@ class FormattedSweep(ParameterWithSetpoints):
         """
         return
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         if self.instrument is None:
             raise RuntimeError("Cannot get data without instrument")
         root_instr = self.instrument.root_instrument
@@ -300,7 +301,7 @@ class KeysightPNATrace(InstrumentChannel):
         self.write(f"DISP:TRAC{self.trace_num}:STAT 0")
 
     @staticmethod
-    def _parse_polar_data(data: np.ndarray) -> np.ndarray:
+    def _parse_polar_data(data: npt.NDArray) -> npt.NDArray:
         """
         Parse the 2*n-length flat array coming from the instrument
         and convert to n-length array of complex numbers

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -2,6 +2,7 @@ import re
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import TypedDict, Unpack, deprecated
 
 from qcodes.instrument import InstrumentBaseKWArgs, InstrumentChannel
@@ -247,7 +248,7 @@ def get_name_label_unit_of_impedance_model(
 #   it might make more sense to generate one for each **channel**
 
 
-def get_measurement_summary(status_array: "np.ndarray | Sequence[str]") -> str:
+def get_measurement_summary(status_array: "npt.NDArray | Sequence[str]") -> str:
     unique_error_statuses = np.unique(status_array[status_array != "N"])
     if len(unique_error_statuses) > 0:
         summary = " ".join(

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -3,6 +3,7 @@ import textwrap
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, cast, overload
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import TypedDict, Unpack
 
 import qcodes.validators as vals
@@ -1070,10 +1071,10 @@ class KeysightB1517A(KeysightB1500Module):
         else:
             raise Exception("set timing parameters first")
 
-    def _get_time_axis(self) -> np.ndarray:
+    def _get_time_axis(self) -> npt.NDArray:
         sample_rate = self._timing_parameters["interval"]
         total_time = self._total_measurement_time()
-        time_xaxis: np.ndarray = np.arange(0, total_time, sample_rate)
+        time_xaxis: npt.NDArray = np.arange(0, total_time, sample_rate)
         return time_xaxis
 
     def _total_measurement_time(self) -> float:

--- a/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from packaging import version
 from typing_extensions import deprecated
 
@@ -548,7 +549,7 @@ class TimeTrace(ParameterWithSetpoints):
         conf = self.instrument.sense_function()
         self.unit, self.label = units_and_labels[conf]
 
-    def _acquire_time_trace(self) -> np.ndarray:
+    def _acquire_time_trace(self) -> npt.NDArray:
         """
         The function that prepares the measurement and fetches the data
         """
@@ -583,7 +584,7 @@ class TimeTrace(ParameterWithSetpoints):
 
         return data  # pyright: ignore[reportPossiblyUnboundVariable]
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         self._validate_dt()
         self._set_units_and_labels()
         data = self._acquire_time_trace()
@@ -597,7 +598,7 @@ class TimeAxis(Parameter):
     measurement start) at which the points of the time trace were acquired.
     """
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Construct a time axis by querying the number of points and step size
         from the instrument.
@@ -1180,7 +1181,7 @@ mode."""
 
         return float(response)
 
-    def fetch(self) -> np.ndarray:
+    def fetch(self) -> npt.NDArray:
         """
         Waits for measurements to complete and copies all available
         measurements to the instrument's output buffer. The readings remain
@@ -1197,7 +1198,7 @@ mode."""
         raw_vals: str = self.ask("FETCH?")
         return _raw_vals_to_array(raw_vals)
 
-    def read(self) -> np.ndarray:
+    def read(self) -> npt.NDArray:
         """
         Starts a new set of measurements, waits for all measurements to
         complete, and transfers all available measurements.
@@ -1383,7 +1384,7 @@ class Display(Keysight344xxADisplay):
     pass
 
 
-def _raw_vals_to_array(raw_vals: str) -> np.ndarray:
+def _raw_vals_to_array(raw_vals: str) -> npt.NDArray:
     """
     Helper function that converts comma-delimited string of floating-point
     values to a numpy 1D array of them. Most data retrieval command of these

--- a/src/qcodes/instrument_drivers/mock_instruments/__init__.py
+++ b/src/qcodes/instrument_drivers/mock_instruments/__init__.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.instrument import (
     ChannelList,
@@ -939,8 +940,8 @@ class DummyParameterWithSetpointsComplex(ParameterWithSetpoints):
 
 
 def setpoint_generator(
-    *sp_bases: Sequence[float | np.floating] | np.ndarray,
-) -> tuple[np.ndarray, ...]:
+    *sp_bases: Sequence[float | np.floating] | npt.NDArray,
+) -> tuple[npt.NDArray, ...]:
     """
     Helper function to generate setpoints in the format that ArrayParameter
     (and MultiParameter) expects
@@ -952,7 +953,7 @@ def setpoint_generator(
         tuple of setpoints in the expected format.
 
     """
-    setpoints: list[np.ndarray] = []
+    setpoints: list[npt.NDArray] = []
     for i, sp_base in enumerate(sp_bases):
         if i == 0:
             setpoints.append(np.array(sp_base))

--- a/src/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
+++ b/src/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
@@ -7,7 +7,7 @@ from qcodes.validators import Anything, Enum, Ints, MultiType, Numbers
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    import numpy as np
+    import numpy.typing as npt
     from typing_extensions import Unpack
 
     from qcodes.parameters import Parameter
@@ -745,7 +745,7 @@ class RigolDG4000(VisaInstrument):
 
         self.connect_message()
 
-    def _upload_data(self, data: "Sequence[float] | np.ndarray") -> None:
+    def _upload_data(self, data: "Sequence[float] | npt.NDArray") -> None:
         """
         Upload data to the AWG memory.
 

--- a/src/qcodes/instrument_drivers/rigol/Rigol_DS1074Z.py
+++ b/src/qcodes/instrument_drivers/rigol/Rigol_DS1074Z.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.instrument import (
     ChannelList,
@@ -56,7 +57,7 @@ class RigolDS1074ZChannel(InstrumentChannel):
         )
         """Parameter trace"""
 
-    def _get_full_trace(self) -> np.ndarray:
+    def _get_full_trace(self) -> npt.NDArray:
         y_ori = self.root_instrument.waveform_yorigin()
         y_increm = self.root_instrument.waveform_yincrem()
         y_ref = self.root_instrument.waveform_yref()
@@ -65,7 +66,7 @@ class RigolDS1074ZChannel(InstrumentChannel):
         full_data = np.multiply(y_raw_shifted, y_increm)
         return full_data
 
-    def _get_raw_trace(self) -> np.ndarray:
+    def _get_raw_trace(self) -> npt.NDArray:
         # set the out type from oscilloscope channels to WORD
         self.root_instrument.write(":WAVeform:FORMat WORD")
 
@@ -222,7 +223,7 @@ class RigolDS1074Z(VisaInstrument):
 
         self.connect_message()
 
-    def _get_time_axis(self) -> np.ndarray:
+    def _get_time_axis(self) -> npt.NDArray:
         xorigin = self.waveform_xorigin()
         xincrem = self.waveform_xincrem()
         npts = self.waveform_npoints()

--- a/src/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -7,6 +7,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from packaging import version
 
 import qcodes.validators as vals
@@ -94,7 +95,7 @@ class ScopeTrace(ArrayParameter):
         # we must ensure that all this took effect before proceeding
         self.root_instrument.ask("*OPC?")
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Returns a trace
         """

--- a/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import deprecated
 
 import qcodes.validators as vals
@@ -89,7 +90,7 @@ class FixedFrequencyTraceIQ(MultiParameter):
         self.setpoints = ((t,), (t,))
         self.shapes = ((npts,), (npts,))
 
-    def get_raw(self) -> tuple[np.ndarray, np.ndarray]:
+    def get_raw(self) -> tuple[npt.NDArray, npt.NDArray]:
         """
         Gets the raw real and imaginary part of the data. If parameter
         `cw_check_sweep_first` is set to `True` then at the cost of a few ms
@@ -886,7 +887,7 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
                     pass
         self.sweep_time()
 
-    def _get_sweep_data(self, force_polar: bool = False) -> np.ndarray:
+    def _get_sweep_data(self, force_polar: bool = False) -> npt.NDArray:
         if not self._parent.rf_power():
             log.warning("RF output is off when getting sweep data")
         # It is possible that the instrument and QCoDeS disagree about
@@ -998,7 +999,7 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
         # Cache the sweep time so it is up to date when setting timeouts
         self.sweep_time()
 
-    def _get_cw_data(self) -> tuple[np.ndarray, np.ndarray]:
+    def _get_cw_data(self) -> tuple[npt.NDArray, npt.NDArray]:
         # Make the checking optional such that we can do super fast sweeps as
         # well, skipping the overhead of the other commands.
         if self.cw_check_sweep_first():

--- a/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/src/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -5,6 +5,7 @@ from time import sleep
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 import qcodes.validators as vals
 from qcodes.instrument import Instrument, InstrumentBaseKWArgs
@@ -159,7 +160,7 @@ class FrequencySweep(ArrayParameter):
         self.shape = (sweep_len,)
         self.instrument._trace_updated = True
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         if self.instrument is None:
             raise RuntimeError("No instrument is attached to 'FrequencySweep'")
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
@@ -727,7 +728,7 @@ class SignalHoundUSBSA124B(Instrument):
         self.check_for_error(err, "saQuerySweepInfo")
         return sweep_len.value, start_freq.value, stepsize.value
 
-    def _get_sweep_data(self) -> np.ndarray:
+    def _get_sweep_data(self) -> npt.NDArray:
         """
         This function performs a sweep over the configured ranges.
         The result of the sweep is returned along with the sweep points
@@ -825,7 +826,7 @@ class SignalHoundUSBSA124B(Instrument):
         output["firmware"] = fw_version.value.decode("ascii")
         return output
 
-    def _get_freq_axis(self) -> np.ndarray:
+    def _get_freq_axis(self) -> npt.NDArray:
         if not self._parameters_synced:
             self.sync_parameters()
         sweep_len, start_freq, stepsize = self.QuerySweep()

--- a/src/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/src/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.instrument import (
     ChannelList,
@@ -53,9 +54,9 @@ class SR86xBufferReadout(ArrayParameter):
             **kwargs,
         )
 
-        self._capture_data: np.ndarray | None = None
+        self._capture_data: npt.NDArray | None = None
 
-    def prepare_readout(self, capture_data: np.ndarray) -> None:
+    def prepare_readout(self, capture_data: npt.NDArray) -> None:
         """
         Prepare this parameter for readout.
 
@@ -72,7 +73,7 @@ class SR86xBufferReadout(ArrayParameter):
         self.setpoint_labels = ("Sample number",)
         self.setpoints = (tuple(np.arange(0, data_len)),)
 
-    def get_raw(self) -> np.ndarray:
+    def get_raw(self) -> npt.NDArray:
         """
         Public method to access the capture data
         """
@@ -368,7 +369,7 @@ class SR86xBuffer(InstrumentChannel):
         while n_captured_bytes < n_bytes_to_capture:
             n_captured_bytes = self.count_capture_bytes()
 
-    def get_capture_data(self, sample_count: int) -> dict[str, np.ndarray]:
+    def get_capture_data(self, sample_count: int) -> dict[str, npt.NDArray]:
         """
         Read the given number of samples of the capture data from the buffer.
 
@@ -404,7 +405,7 @@ class SR86xBuffer(InstrumentChannel):
 
         return data
 
-    def _get_raw_capture_data(self, size_in_kb: int) -> np.ndarray:
+    def _get_raw_capture_data(self, size_in_kb: int) -> npt.NDArray:
         """
         Read data from the buffer from its beginning avoiding the instrument
         limit of 64 kilobytes per reading.
@@ -427,7 +428,7 @@ class SR86xBuffer(InstrumentChannel):
                 f"buffer ({current_capture_length}kB)."
             )
 
-        values: np.ndarray = np.array([])
+        values: npt.NDArray = np.array([])
         data_size_to_read_in_kb = size_in_kb
         n_readings = 0
 
@@ -451,7 +452,7 @@ class SR86xBuffer(InstrumentChannel):
 
     def _get_raw_capture_data_block(
         self, size_in_kb: int, offset_in_kb: int = 0
-    ) -> np.ndarray:
+    ) -> npt.NDArray:
         """
         Read data from the buffer. The maximum amount of data that can be
         read with this function (size_in_kb) is 64kB (this limitation comes
@@ -522,7 +523,7 @@ class SR86xBuffer(InstrumentChannel):
 
     def capture_one_sample_per_trigger(
         self, trigger_count: int, start_triggers_pulsetrain: Callable[..., Any]
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, npt.NDArray]:
         """
         Capture one sample per each trigger, and return when the specified
         number of triggers has been received.
@@ -549,7 +550,7 @@ class SR86xBuffer(InstrumentChannel):
 
     def capture_samples_after_trigger(
         self, sample_count: int, send_trigger: Callable[..., Any]
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, npt.NDArray]:
         """
         Capture a number of samples after a trigger has been received.
         Please refer to page 135 of the manual for details.
@@ -574,7 +575,7 @@ class SR86xBuffer(InstrumentChannel):
         self.stop_capture()
         return self.get_capture_data(sample_count)
 
-    def capture_samples(self, sample_count: int) -> dict[str, np.ndarray]:
+    def capture_samples(self, sample_count: int) -> dict[str, npt.NDArray]:
         """
         Capture a number of samples at a capture rate, starting immediately.
         Unlike the "continuous" capture mode, here the buffer does not get

--- a/src/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import numpy as np
+import numpy.typing as npt
 from pyvisa.errors import VisaIOError
 
 from qcodes import validators as vals
@@ -175,7 +176,7 @@ class TektronixAWG5014(VisaInstrument):
         self._address = address
         self.num_channels = num_channels
 
-        self._values: dict[str, dict[str, dict[str, np.ndarray | float | None]]] = {}
+        self._values: dict[str, dict[str, dict[str, npt.NDArray | float | None]]] = {}
         self._values["files"] = {}
 
         self.add_function("reset", call_cmd="*RST")
@@ -912,7 +913,7 @@ class TektronixAWG5014(VisaInstrument):
     ######################
 
     def _pack_record(
-        self, name: str, value: float | str | Sequence[Any] | np.ndarray, dtype: str
+        self, name: str, value: float | str | Sequence[Any] | npt.NDArray, dtype: str
     ) -> bytes:
         """
         Packs awg_file record into a struct in the folowing way:
@@ -1166,8 +1167,8 @@ class TektronixAWG5014(VisaInstrument):
 
     def _generate_awg_file(
         self,
-        packed_waveforms: dict[str, np.ndarray],
-        wfname_l: np.ndarray,
+        packed_waveforms: dict[str, npt.NDArray],
+        wfname_l: npt.NDArray,
         nrep: Sequence[int],
         trig_wait: Sequence[int],
         goto_state: Sequence[int],
@@ -1364,9 +1365,9 @@ class TektronixAWG5014(VisaInstrument):
 
     def make_awg_file(
         self,
-        waveforms: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
-        m1s: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
-        m2s: Sequence[Sequence[np.ndarray]] | Sequence[np.ndarray],
+        waveforms: Sequence[Sequence[npt.NDArray]] | Sequence[npt.NDArray],
+        m1s: Sequence[Sequence[npt.NDArray]] | Sequence[npt.NDArray],
+        m2s: Sequence[Sequence[npt.NDArray]] | Sequence[npt.NDArray],
         nreps: Sequence[int],
         trig_waits: Sequence[int],
         goto_states: Sequence[int],
@@ -1422,19 +1423,19 @@ class TektronixAWG5014(VisaInstrument):
         packed_wfs = {}
         waveform_names = []
         if not isinstance(waveforms[0], abc.Sequence):
-            waveforms_int: Sequence[Sequence[np.ndarray]] = [
-                cast("Sequence[np.ndarray]", waveforms)
+            waveforms_int: Sequence[Sequence[npt.NDArray]] = [
+                cast("Sequence[npt.NDArray]", waveforms)
             ]
-            m1s_int: Sequence[Sequence[np.ndarray]] = [
-                cast("Sequence[np.ndarray]", m1s)
+            m1s_int: Sequence[Sequence[npt.NDArray]] = [
+                cast("Sequence[npt.NDArray]", m1s)
             ]
-            m2s_int: Sequence[Sequence[np.ndarray]] = [
-                cast("Sequence[np.ndarray]", m2s)
+            m2s_int: Sequence[Sequence[npt.NDArray]] = [
+                cast("Sequence[npt.NDArray]", m2s)
             ]
         else:
-            waveforms_int = cast("Sequence[Sequence[np.ndarray]]", waveforms)
-            m1s_int = cast("Sequence[Sequence[np.ndarray]]", m1s)
-            m2s_int = cast("Sequence[Sequence[np.ndarray]]", m2s)
+            waveforms_int = cast("Sequence[Sequence[npt.NDArray]]", waveforms)
+            m1s_int = cast("Sequence[Sequence[npt.NDArray]]", m1s)
+            m2s_int = cast("Sequence[Sequence[npt.NDArray]]", m2s)
 
         for ii in range(len(waveforms_int)):
             namelist = []
@@ -1469,9 +1470,9 @@ class TektronixAWG5014(VisaInstrument):
 
     def make_send_and_load_awg_file(
         self,
-        waveforms: Sequence[Sequence[np.ndarray]],
-        m1s: Sequence[Sequence[np.ndarray]],
-        m2s: Sequence[Sequence[np.ndarray]],
+        waveforms: Sequence[Sequence[npt.NDArray]],
+        m1s: Sequence[Sequence[npt.NDArray]],
+        m2s: Sequence[Sequence[npt.NDArray]],
         nreps: Sequence[int],
         trig_waits: Sequence[int],
         goto_states: Sequence[int],
@@ -1557,9 +1558,9 @@ class TektronixAWG5014(VisaInstrument):
 
     def make_and_save_awg_file(
         self,
-        waveforms: Sequence[Sequence[np.ndarray]],
-        m1s: Sequence[Sequence[np.ndarray]],
-        m2s: Sequence[Sequence[np.ndarray]],
+        waveforms: Sequence[Sequence[npt.NDArray]],
+        m1s: Sequence[Sequence[npt.NDArray]],
+        m2s: Sequence[Sequence[npt.NDArray]],
         nreps: Sequence[int],
         trig_waits: Sequence[int],
         goto_states: Sequence[int],
@@ -1645,8 +1646,8 @@ class TektronixAWG5014(VisaInstrument):
         return self.ask("SYSTEM:ERRor:NEXT?")
 
     def _pack_waveform(
-        self, wf: np.ndarray, m1: np.ndarray, m2: np.ndarray
-    ) -> np.ndarray:
+        self, wf: npt.NDArray, m1: npt.NDArray, m2: npt.NDArray
+    ) -> npt.NDArray:
         """
         Converts/packs a waveform and two markers into a 16-bit format
         according to the AWG Integer format specification.
@@ -1703,8 +1704,8 @@ class TektronixAWG5014(VisaInstrument):
     ###########################
 
     def _file_dict(
-        self, wf: np.ndarray, m1: np.ndarray, m2: np.ndarray, clock: float | None
-    ) -> dict[str, np.ndarray | float | None]:
+        self, wf: npt.NDArray, m1: npt.NDArray, m2: npt.NDArray, clock: float | None
+    ) -> dict[str, npt.NDArray | float | None]:
         """
         Make a file dictionary as used by self.send_waveform_to_list
 
@@ -1789,7 +1790,7 @@ class TektronixAWG5014(VisaInstrument):
         return True
 
     def send_waveform_to_list(
-        self, w: np.ndarray, m1: np.ndarray, m2: np.ndarray, wfmname: str
+        self, w: npt.NDArray, m1: npt.NDArray, m2: npt.NDArray, wfmname: str
     ) -> None:
         """
         Send a single complete waveform directly to the "User defined"

--- a/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -11,6 +11,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from broadbean.sequence import InvalidForgedSequenceError, fs_schema
 from typing_extensions import deprecated
 
@@ -725,7 +726,7 @@ class TektronixAWG70000Base(VisaInstrument):
         self.write("WLISt:WAVeform:DELete ALL")
 
     @staticmethod
-    def makeWFMXFile(data: np.ndarray, amplitude: float) -> bytes:
+    def makeWFMXFile(data: npt.NDArray, amplitude: float) -> bytes:
         """
         Compose a WFMX file
 
@@ -978,7 +979,7 @@ class TektronixAWG70000Base(VisaInstrument):
         return xmlstr
 
     @staticmethod
-    def _makeWFMXFileBinaryData(data: np.ndarray, amplitude: float) -> bytes:
+    def _makeWFMXFileBinaryData(data: npt.NDArray, amplitude: float) -> bytes:
         """
         For the binary part.
 
@@ -1247,7 +1248,7 @@ class TektronixAWG70000Base(VisaInstrument):
         event_jumps: Sequence[int],
         event_jump_to: Sequence[int],
         go_to: Sequence[int],
-        wfms: Sequence[Sequence[np.ndarray]],
+        wfms: Sequence[Sequence[npt.NDArray]],
         amplitudes: Sequence[float],
         seqname: str,
         flags: Sequence[Sequence[Sequence[int]]] | None = None,

--- a/src/qcodes/instrument_drivers/tektronix/AWGFileParser.py
+++ b/src/qcodes/instrument_drivers/tektronix/AWGFileParser.py
@@ -5,6 +5,7 @@ import struct
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 AWG_FILE_FORMAT = {
     "MAGIC": "h",
@@ -307,8 +308,8 @@ _parser3_output = tuple[
 
 
 def _unpacker(
-    binaryarray: np.ndarray, dacbitdepth: int = 14
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    binaryarray: npt.NDArray, dacbitdepth: int = 14
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
     """
     Unpacks an awg-file integer wave into a waveform and two markers
     in the same way as the AWG does. This can be useful for checking
@@ -473,7 +474,7 @@ def _parser1(
     return instdict, waveformlist, sequencelist
 
 
-def _parser2(waveformlist: list[list[Any]]) -> dict[str, dict[str, np.ndarray]]:
+def _parser2(waveformlist: list[list[Any]]) -> dict[str, dict[str, npt.NDArray]]:
     """
     Cast the waveformlist from _parser1 into a dict used by _parser3.
 

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -10,6 +10,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import Unpack, deprecated
 
 from qcodes.instrument import (
@@ -324,7 +325,7 @@ class TektronixDPOWaveform(InstrumentChannel):
 
         return inner
 
-    def _get_trace_data(self) -> np.ndarray:
+    def _get_trace_data(self) -> npt.NDArray:
         self.root_instrument.data.source(self._identifier)
         waveform = self.root_instrument.waveform
 
@@ -350,7 +351,7 @@ class TektronixDPOWaveform(InstrumentChannel):
 
         return (raw_data - self.raw_data_offset()) * self.scale() + self.offset()
 
-    def _get_trace_setpoints(self) -> np.ndarray:
+    def _get_trace_setpoints(self) -> npt.NDArray:
         """
         Infer the set points of the waveform
         """

--- a/src/qcodes/instrument_drivers/tektronix/TPS2012.py
+++ b/src/qcodes/instrument_drivers/tektronix/TPS2012.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from pyvisa.errors import VisaIOError
 from typing_extensions import TypedDict, Unpack
 
@@ -64,7 +65,7 @@ class ScopeArray(ArrayParameter):
         )
         self.channel = channel
 
-    def calc_set_points(self) -> tuple[np.ndarray, int]:
+    def calc_set_points(self) -> tuple[npt.NDArray, int]:
         assert isinstance(self.instrument, TektronixTPS2012Channel)
         message = self.instrument.ask("WFMPre?")
         preamble = self._preambleparser(message)
@@ -116,7 +117,7 @@ class ScopeArray(ArrayParameter):
         return message
 
     @staticmethod
-    def _binaryparser(curve: str) -> np.ndarray:
+    def _binaryparser(curve: str) -> npt.NDArray:
         """
         Helper function for parsing the curve data
 
@@ -181,7 +182,7 @@ class ScopeArray(ArrayParameter):
 
     def _curveparameterparser(
         self, waveform: str
-    ) -> tuple[np.ndarray, np.ndarray, int]:
+    ) -> tuple[npt.NDArray, npt.NDArray, int]:
         """
         The parser for the curve parameter. Note that WAVFrm? is equivalent
         to WFMPre?; CURVe?

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.utils.types import NumberType
 
@@ -406,11 +407,11 @@ class FieldVector:
 
     # Homogeneous Coordinates #
 
-    def as_homogeneous(self) -> np.ndarray:
+    def as_homogeneous(self) -> npt.NDArray:
         return np.array([self.x, self.y, self.z, 1])
 
     @classmethod
-    def from_homogeneous(cls: type[Self], hvec: np.ndarray) -> Self:
+    def from_homogeneous(cls: type[Self], hvec: npt.NDArray) -> Self:
         # Homogeneous coordinates define an equivalence relation
         #     [x / s, y / s, z / s, 1] == [x, y, z, s].
         # More generally,

--- a/src/qcodes/parameters/combined_parameter.py
+++ b/src/qcodes/parameters/combined_parameter.py
@@ -7,6 +7,7 @@ from copy import copy
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 from qcodes.metadatable import Metadatable
 from qcodes.utils import full_class
@@ -128,7 +129,7 @@ class CombinedParameter(Metadatable):
             setFunction(value)
         return values
 
-    def sweep(self, *array: np.ndarray) -> CombinedParameter:
+    def sweep(self, *array: npt.NDArray) -> CombinedParameter:
         """
         Creates a new combined parameter to be iterated over.
         One can sweep over either:

--- a/src/qcodes/plotting/auto_range.py
+++ b/src/qcodes/plotting/auto_range.py
@@ -3,13 +3,14 @@ This file holds auto ranging logic that is independent of plotting backend
 """
 
 import numpy as np
+import numpy.typing as npt
 
 # turn off limiting percentiles by default
 DEFAULT_PERCENTILE = (50, 50)
 
 
 def auto_range_iqr(
-    data_array: np.ndarray,
+    data_array: npt.NDArray,
     cutoff_percentile: tuple[float, float] | float = DEFAULT_PERCENTILE,
 ) -> tuple[float, float]:
     """

--- a/src/qcodes/plotting/axis_labels.py
+++ b/src/qcodes/plotting/axis_labels.py
@@ -5,6 +5,7 @@ This file holds scaling logic for axis that is independent of plotting backend
 from collections import OrderedDict
 
 import numpy as np
+import numpy.typing as npt
 
 _UNITS_FOR_RESCALING: set[str] = {
     # SI units (without some irrelevant ones like candela)
@@ -63,7 +64,7 @@ _THRESHOLDS: dict[float, int] = OrderedDict(
 )
 
 
-def find_scale_and_prefix(data: np.ndarray, unit: str) -> tuple[str, int]:
+def find_scale_and_prefix(data: npt.NDArray, unit: str) -> tuple[str, int]:
     """
     Given a numpy array of data and a unit find the best engineering prefix
     and matching scale that best describes the data.

--- a/src/qcodes/plotting/matplotlib_helpers.py
+++ b/src/qcodes/plotting/matplotlib_helpers.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     import matplotlib.colorbar
 
 import numpy as np
+import numpy.typing as npt
 
 from .auto_range import DEFAULT_PERCENTILE, auto_range_iqr
 
@@ -55,7 +56,7 @@ def apply_color_scale_limits(
     colorbar: matplotlib.colorbar.Colorbar,
     new_lim: tuple[float | None, float | None],
     data_lim: tuple[float, float] | None = None,
-    data_array: np.ndarray | None = None,
+    data_array: npt.NDArray | None = None,
     color_over: Any = DEFAULT_COLOR_OVER,
     color_under: Any = DEFAULT_COLOR_UNDER,
 ) -> None:
@@ -98,7 +99,7 @@ def apply_color_scale_limits(
         )
     if data_lim is None:
         if data_array is None:
-            data_array = cast("np.ndarray", colorbar.mappable.get_array())
+            data_array = cast("npt.NDArray", colorbar.mappable.get_array())
         data_lim = np.nanmin(data_array), np.nanmax(data_array)
     elif data_array is not None:
         raise RuntimeError(
@@ -133,7 +134,7 @@ def apply_color_scale_limits(
 
 def apply_auto_color_scale(
     colorbar: matplotlib.colorbar.Colorbar,
-    data_array: np.ndarray | None = None,
+    data_array: npt.NDArray | None = None,
     cutoff_percentile: tuple[float, float] | float = DEFAULT_PERCENTILE,
     color_over: Any | None = DEFAULT_COLOR_OVER,
     color_under: Any | None = DEFAULT_COLOR_UNDER,
@@ -169,7 +170,7 @@ def apply_auto_color_scale(
     if data_array is None:
         if not isinstance(colorbar.mappable, matplotlib.collections.QuadMesh):
             raise RuntimeError("Can only scale mesh data.")
-        data_array = cast("np.ndarray", colorbar.mappable.get_array())
+        data_array = cast("npt.NDArray", colorbar.mappable.get_array())
     assert data_array is not None
     new_lim = auto_range_iqr(data_array, cutoff_percentile)
     apply_color_scale_limits(
@@ -184,7 +185,7 @@ def apply_auto_color_scale(
 def auto_color_scale_from_config(
     colorbar: matplotlib.colorbar.Colorbar,
     auto_color_scale: bool | None = None,
-    data_array: np.ndarray | None = None,
+    data_array: npt.NDArray | None = None,
     cutoff_percentile: tuple[float, float] | float | None = DEFAULT_PERCENTILE,
     color_over: Any | None = None,
     color_under: Any | None = None,

--- a/src/qcodes/utils/numpy_utils.py
+++ b/src/qcodes/utils/numpy_utils.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,7 +19,7 @@ except ImportError:
 def list_of_data_to_maybe_ragged_nd_array(
     column_data: Sequence[Any],
     dtype: type | None = None,
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Convert a (nested) Sequence of data to numpy arrays. Handle that
     the elements of the sequence may not have the same length in which

--- a/src/qcodes/validators/validators.py
+++ b/src/qcodes/validators/validators.py
@@ -12,6 +12,7 @@ from collections.abc import Hashable
 from typing import Any, Generic, Literal, TypeVar, cast, get_args
 
 import numpy as np
+import numpy.typing as npt
 
 BIGSTRING = 1000000000
 BIGINT = int(1e18)
@@ -842,7 +843,7 @@ class MultiTypeAnd(MultiType):
         return "<MultiTypeAnd: {}>".format(", ".join(parts))
 
 
-class Arrays(Validator[np.ndarray]):
+class Arrays(Validator[npt.NDArray]):
     """
     Validator for numerical numpy arrays of numeric types (int, float, complex).
     By default it validates int and float arrays.
@@ -965,7 +966,7 @@ class Arrays(Validator[np.ndarray]):
             self._shape = tuple(shape)
 
     @property
-    def valid_values(self) -> tuple[np.ndarray]:
+    def valid_values(self) -> tuple[npt.NDArray]:
         valid_type = self.valid_types[0]
         if valid_type == np.integer:
             valid_type = np.int32
@@ -977,7 +978,7 @@ class Arrays(Validator[np.ndarray]):
         if self.shape is None:
             return (np.array([self._min_value], dtype=valid_type),)
         else:
-            val_arr: np.ndarray = np.empty(self.shape, dtype=valid_type)
+            val_arr: npt.NDArray = np.empty(self.shape, dtype=valid_type)
             val_arr.fill(self._min_value)
             return (val_arr,)
 
@@ -998,7 +999,7 @@ class Arrays(Validator[np.ndarray]):
         shape = tuple(shape_array)
         return shape
 
-    def validate(self, value: np.ndarray, context: str = "") -> None:
+    def validate(self, value: npt.NDArray, context: str = "") -> None:
         if not isinstance(value, np.ndarray):
             raise TypeError(f"{value!r} is not a numpy array; {context}")
 

--- a/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/tests/dataset/measurement/test_measurement_context_manager.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import hypothesis.strategies as hst
 import numpy as np
+import numpy.typing as npt
 import pytest
 import xarray as xr
 from hypothesis import HealthCheck, given, settings
@@ -2123,10 +2124,10 @@ def test_datasaver_2d_multi_parameters_array(
     ds = load_by_id(datasaver.run_id)
 
     # 30 points in each setpoint value list
-    this_sp_val: np.ndarray = np.array(
+    this_sp_val: npt.NDArray = np.array(
         reduce(list.__add__, [[n] * 3 for n in range(5, 10)], [])  # type: ignore[arg-type]
     )
-    that_sp_val: np.ndarray = np.array(
+    that_sp_val: npt.NDArray = np.array(
         reduce(list.__add__, [[n] for n in range(9, 12)], []) * 5  # type: ignore[arg-type]
     )
 

--- a/tests/dataset/test_data_set_cache.py
+++ b/tests/dataset/test_data_set_cache.py
@@ -5,6 +5,7 @@ from string import ascii_uppercase
 
 import hypothesis.strategies as hst
 import numpy as np
+import numpy.typing as npt
 import pytest
 from hypothesis import HealthCheck, given, settings
 
@@ -697,7 +698,7 @@ def test_cache_complex_array_param_in_1d(
     meas = Measurement()
     if outer_param_type == "numeric":
         outer_param = DAC.ch1
-        outer_setpoints: np.ndarray | list[str] = np.linspace(-1, 1, n_points)
+        outer_setpoints: npt.NDArray | list[str] = np.linspace(-1, 1, n_points)
         outer_storage_type = storage_type
     else:
         outer_param = channel_array_instrument.A.dummy_text

--- a/tests/dataset/test_dataset_basic.py
+++ b/tests/dataset/test_dataset_basic.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import hypothesis.strategies as hst
 import numpy as np
+import numpy.typing as npt
 import pytest
 from hypothesis import HealthCheck, given, settings
 from pytest import FixtureRequest
@@ -658,7 +659,7 @@ def test_numpy_inf(dataset) -> None:
 
 def test_backward_compat__adapt_array_v0_33() -> None:
     for dtype in numpy_floats + complex_types:
-        arr: np.ndarray = np.asarray([1.0], dtype=np.dtype(dtype))
+        arr: npt.NDArray = np.asarray([1.0], dtype=np.dtype(dtype))
         out = io.BytesIO()
         np.save(out, arr)
         out.seek(0)


### PR DESCRIPTION
When dtype and or shape is unspecified this gives a better type as it is an alias for 
```
numpy.ndarray[tuple[int, ...], numpy.dtype[+_ScalarType_co]]
```
Rather than 

```
numpy.ndarray[Any, Any]
```
which is the default


https://numpy.org/doc/stable/reference/typing.html#numpy.typing.NDArray