### PR TITLE
Add units and docstring to SGS100 driver

### DIFF
--- a/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
@@ -164,8 +164,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:LEAK:I {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-10, 10),
-            unit='%',
-            docstring='Carrier offset for I channel in percentage of the peak envelope power.'
+            unit="%",
+            docstring="Carrier offset for I channel in percentage of the peak envelope power.",
         )
         """Parameter I_offset. Carrier offset for I channel in percentage of the peak envelope power."""
         self.Q_offset: Parameter = self.add_parameter(
@@ -175,8 +175,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:LEAK:Q {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-10, 10),
-            unit='%',
-            docstring='Carrier offset for Q channel in percentage of the peak envelope power.'
+            unit="%",
+            docstring="Carrier offset for Q channel in percentage of the peak envelope power.",
         )
         """Parameter Q_offset. Carrier offset for Q channel in percentage of the peak envelope power."""
         self.IQ_gain_imbalance: Parameter = self.add_parameter(
@@ -186,8 +186,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:IQR {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-1, 1),
-            unit='dB',
-            docstring='IQ Gain imbalance. Postive value means the Q vector is amplified more.'
+            unit="dB",
+            docstring="IQ Gain imbalance. Postive value means the Q vector is amplified more.",
         )
         """Parameter IQ_gain_imbalance. Postive value means the Q vector is amplified more."""
         self.IQ_angle: Parameter = self.add_parameter(
@@ -197,7 +197,7 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:QUAD {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-8, 8),
-            unit='deg'
+            unit="deg",
         )
         """Parameter IQ_angle"""
         # Determines the signal at the input/output of the multi purpose [TRIG] connector.

--- a/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
@@ -167,7 +167,7 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             unit='%',
             docstring='Carrier offset for I channel in percentage of the peak envelope power.'
         )
-        """Parameter I_offset"""
+        """Parameter I_offset. Carrier offset for I channel in percentage of the peak envelope power."""
         self.Q_offset: Parameter = self.add_parameter(
             "Q_offset",
             label="Q Offset",
@@ -178,7 +178,7 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             unit='%',
             docstring='Carrier offset for Q channel in percentage of the peak envelope power.'
         )
-        """Parameter Q_offset"""
+        """Parameter Q_offset. Carrier offset for Q channel in percentage of the peak envelope power."""
         self.IQ_gain_imbalance: Parameter = self.add_parameter(
             "IQ_gain_imbalance",
             label="IQ Gain Imbalance",
@@ -189,7 +189,7 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             unit='dB',
             docstring='IQ Gain imbalance. Postive value means the Q vector is amplified more.'
         )
-        """Parameter IQ_gain_imbalance"""
+        """Parameter IQ_gain_imbalance. Postive value means the Q vector is amplified more."""
         self.IQ_angle: Parameter = self.add_parameter(
             "IQ_angle",
             label="IQ Angle Offset",

--- a/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
@@ -164,6 +164,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:LEAK:I {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-10, 10),
+            unit='%',
+            docstring='Carrier offset for I channel in percentage of the peak envelope power.'
         )
         """Parameter I_offset"""
         self.Q_offset: Parameter = self.add_parameter(
@@ -173,6 +175,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:LEAK:Q {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-10, 10),
+            unit='%',
+            docstring='Carrier offset for Q channel in percentage of the peak envelope power.'
         )
         """Parameter Q_offset"""
         self.IQ_gain_imbalance: Parameter = self.add_parameter(
@@ -182,6 +186,8 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:IQR {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-1, 1),
+            unit='dB',
+            docstring='IQ Gain imbalance. Postive value means the Q vector is amplified more.'
         )
         """Parameter IQ_gain_imbalance"""
         self.IQ_angle: Parameter = self.add_parameter(
@@ -191,6 +197,7 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             set_cmd="SOUR:IQ:IMP:QUAD {:.2f}",
             get_parser=float,
             vals=vals.Numbers(-8, 8),
+            unit='deg'
         )
         """Parameter IQ_angle"""
         # Determines the signal at the input/output of the multi purpose [TRIG] connector.


### PR DESCRIPTION
Add units and docstrings for a few parameters of the SGS100 driver.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
