### PR TITLE
Small build fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,9 +3,6 @@ include src/qcodes/monitor/dist/js/*
 include src/qcodes/monitor/dist/css/*
 include src/qcodes/configuration/*.json
 include src/qcodes/instrument/sims/*.yaml
-include src/qcodes/tests/dataset/fixtures/data_2018_01_17/*/*
-include src/qcodes/tests/delegate/data/*.yml
-include src/qcodes/tests/drivers/auxiliary_files/*
 include src/qcodes/py.typed
 include src/qcodes/dist/schemas/*
 include src/qcodes/dist/tests/station/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 68.1.0",
+    "setuptools >= 77.0.0",
     "versioningit >= 2.2.1",
 ]
 build-backend = 'setuptools.build_meta'
@@ -12,14 +12,13 @@ description = "Python-based data acquisition framework developed by the Copenhag
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "broadbean>=0.11.0",


### PR DESCRIPTION
* Avoid warning by not trying to include missing files in MANIFEST.in
* Adapt license configuration to pep639 to silence warnings from setuptools
* Bump min version of setuptools for building for pep 639 support