### PR TITLE
Fix broken link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ by computer.
 To learn more about QCoDeS, browse our `homepage <http://microsoft.github.io/Qcodes>`_ .
 
 To get a feeling of QCoDeS read
-`15 minutes to QCoDeS <http://microsoft.github.io/Qcodes/examples/15_minutes_to_QCoDeS.html>`__,
+`15 minutes to QCoDeS <https://microsoft.github.io/Qcodes/examples/basic_examples/15_minutes_to_QCoDeS.html>`__,
 and/or browse the Jupyter notebooks in `docs/examples
 <https://github.com/QCoDeS/Qcodes/tree/main/docs/examples>`__ .
 


### PR DESCRIPTION
## Description

The link to the "15 minutes to QCoDeS" guide was broken in `/README.rst`, I updated it to match its current path.

## Related issue

Closes #7157

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
