### PR TITLE
Simplify the README configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 license = "MIT"
+readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
     "broadbean>=0.11.0",
@@ -55,10 +56,6 @@ dependencies = [
 ]
 
 dynamic = ["version"]
-
-[project.readme]
-file = "README.rst"
-content-type = "text/x-rst"
 
 [project.urls]
 Homepage = "https://github.com/microsoft/Qcodes"


### PR DESCRIPTION
According to the spec https://packaging.python.org/en/latest/specifications/pyproject-toml/#readme specification, the `readme` with an rst extension is guaranteed to enforce the correct content type.


