### PR TITLE
Remove transitive dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,6 @@ dependencies = [
     "opentelemetry-api>=1.17.0",
     "pillow>=9.2.0",
     "dask>=2022.1.0", # we are making use of xarray features that requires dask implicitly
-    # transitive dependencies. We list these explicitly to",
-    # ensure that we always use versions that do not have",
-    # known security vulnerabilities",
-    "tornado>=6.3.3",
-    "ipython>=8.10.0",
 ]
 
 dynamic = ["version"]
@@ -91,7 +86,6 @@ test = [
     "qcodes_loop>=0.1.1",
     "zhinst.qcodes>=0.5", # typecheck zhinst driver alias
     "libcst>=1.2.0", # refactor tests
-    "jinja2>=3.1.3", # transitive dependency pin due to cve in earlier version
 ]
 docs = [
     "autodocsumm>=0.2.9",
@@ -106,7 +100,6 @@ docs = [
     "towncrier>=24.8.0,<25.0.0", #  sphinxcontrib-towncrier is likely to break with new versions
     "scipy>=1.10.0", # examples using scipy
     "qcodes_loop>=0.1.1", # legacy dataset import examples
-    "jinja2>=3.1.3", # transitive dependency pin due to cve in earlier version
 ]
 refactor = [
     "libcst>=1.2.0"


### PR DESCRIPTION
Resolves #7264

Thinking a bit more about this I don't think it is reasonable that qcodes includes transitive dependencies. The main issue is that it is very realistic that a transitive dependency is dropped from the upstream and now this pin in qcodes will only result in an extra package being installed which may itself introduce a security issue. This can be illustrated by ipykernel planning to drop the use of tornado in a future release

