### PR TITLE
Set python version in copilot ci job

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,6 +44,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
+          python-version: 3.13
           cache-dependency-path: |
             pyproject.toml
             requirements.txt


### PR DESCRIPTION
E.g. there are warnings that pip cannot install to the global sitepackages dir and falls back to user dir