### PR TITLE
operation mode for SGS100A instrument

### DIFF
--- a/docs/changes/newsfragments/7344.improved_driver
+++ b/docs/changes/newsfragments/7344.improved_driver
@@ -1,0 +1,1 @@
+Added operation mode in the SGS100A instrument to be able to change between NORMal and BBBYpass operation modes. Defaults to NORMal.

--- a/docs/changes/newsfragments/7344.new
+++ b/docs/changes/newsfragments/7344.new
@@ -1,1 +1,0 @@
-Added operation mode in the SGS100A instrument to be able to change between NORMal and BBBYpass operation modes. Defaults to NORMal.

--- a/docs/changes/newsfragments/7344.new
+++ b/docs/changes/newsfragments/7344.new
@@ -1,0 +1,1 @@
+Added operation mode in the SGS100A instrument to be able to change between NORMal and BBBYpass operation modes. Defaults to NORMal.

--- a/docs/examples/driver_examples/Qcodes example with Rohde Schwarz SGS100A.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Rohde Schwarz SGS100A.ipynb
@@ -101,6 +101,16 @@
     "# stop RF outout\n",
     "sgsa.status(False)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set bypass operation mode\n",
+    "sgsa.operation_mode(\"BBBYpass\")"
+   ]
   }
  ],
  "metadata": {

--- a/src/qcodes/instrument/sims/RSSGS100A.yaml
+++ b/src/qcodes/instrument/sims/RSSGS100A.yaml
@@ -201,6 +201,14 @@ devices:
         setter:
           q: "SOUR:IQ:IMP:QUAD {:.2f}"
 
+      operation_mode:
+        default: "NORMal"
+        getter:
+          q: ":SOUR:OPMode?"
+          r: "{}"
+        setter:
+          q: ":SOUR:OPMode {}"
+
 resources:
   GPIB::1::INSTR:
     device: SGS100A

--- a/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
+++ b/src/qcodes/instrument_drivers/rohde_schwarz/SGS100A.py
@@ -322,6 +322,17 @@ class RohdeSchwarzSGS100A(VisaInstrument):
             vals=vals.Numbers(20e-9, 100),
         )
         """Parameter pulsemod_width"""
+        self.operation_mode: Parameter = self.add_parameter(
+            "operation_mode",
+            label="Operation Mode",
+            get_cmd=":SOUR:OPMode?",
+            set_cmd=":SOUR:OPMode {}",
+            vals=vals.Enum(
+                "NORMal",  # Normal - Normal Mode
+                "BBBYpass",  # Bypass - Bypass Mode
+            ),
+        )
+        """Parameter operation_mode"""
         self.add_function("reset", call_cmd="*RST")
         self.add_function("run_self_tests", call_cmd="*TST?")
 

--- a/tests/drivers/test_RS_SGS100A.py
+++ b/tests/drivers/test_RS_SGS100A.py
@@ -98,3 +98,8 @@ def test_IQ_gain_imbalance(sg) -> None:
 
 def test_IQ_angle(sg) -> None:
     verify_property(sg, "IQ_angle", [-8, -4, 0, 4, 8])
+
+
+def test_operation_mode(sg) -> None:
+    print(f"operation mode is set to {sg.operation_mode()}")
+    verify_property(sg, "operation_mode", ["NORMal", "BBBYpass"])


### PR DESCRIPTION
This PR brings the capability to change the operation mode in the Rohde & Schwartz SGS100A instrument. The two operation modes the instrument support are:

- NORMal (normal operation mode, default.)
- BBBYpass (bypass operation mode).

When resetting the instrument, the operation mode defaults to NORMal.