### PR TITLE
Remove pyright pragmas that are no longer required

### DIFF
--- a/src/qcodes/dataset/descriptions/dependencies.py
+++ b/src/qcodes/dataset/descriptions/dependencies.py
@@ -273,8 +273,7 @@ class InterDependencies_:  # noqa: PLW1641
         """
         return tuple(
             cast("ParamSpecBase", paramspec)
-            # The type check for this does not correctly allow the `data` arg to be a string
-            for _, paramspec in self.graph.nodes(data="value")  # pyright: ignore[reportArgumentType]
+            for _, paramspec in self.graph.nodes(data="value")
         )
 
     @property

--- a/src/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -104,9 +104,7 @@ class DllWrapperMeta(type):
     # Only allow a single instance per DLL path.
     _instances: WeakValueDictionary[str, Any] = WeakValueDictionary()
 
-    def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        cls, dll_path: str, *args: Any, **kwargs: Any
-    ) -> Any:
+    def __call__(cls, dll_path: str, *args: Any, **kwargs: Any) -> Any:
         api = cls._instances.get(dll_path, None)
         if api is not None:
             logger.debug(f"Using existing instance for DLL path {dll_path}.")
@@ -185,7 +183,7 @@ class WrappedDll(metaclass=DllWrapperMeta):
                 # of it to type. The type checker therefor does not know
                 # that this type has a __supertype__ attribute
                 ret_type = (
-                    ret_type.__supertype__  # pyright: ignore[reportAttributeAccessIssue,reportFunctionMemberAccess]
+                    ret_type.__supertype__  # pyright: ignore[reportFunctionMemberAccess]
                 )
                 c_func.errcheck = _check_error_code
             elif ret_type in (

--- a/src/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/src/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -257,7 +257,7 @@ class _ParameterWithStatus(Parameter):
             for i in bin(int(float(meas_status))).replace("0b", "").zfill(16)[::-1]
         ]
 
-        status = _from_bits_tuple_to_status[(status_bits[0], status_bits[1])]  # pyright: ignore[reportArgumentType]
+        status = _from_bits_tuple_to_status[(status_bits[0], status_bits[1])]
 
         return float(value), status
 

--- a/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -580,7 +580,7 @@ class TimeTrace(ParameterWithSetpoints):
             self.instrument.trigger.force()
             data = self.instrument.fetch()
 
-        return data  # pyright: ignore[reportPossiblyUnboundVariable]
+        return data
 
     def get_raw(self) -> npt.NDArray:
         self._validate_dt()

--- a/src/qcodes/utils/delaykeyboardinterrupt.py
+++ b/src/qcodes/utils/delaykeyboardinterrupt.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from types import FrameType, TracebackType
 
-    from opentelemetry.util.types import (  # pyright: ignore[reportMissingTypeStubs]
+    from opentelemetry.util.types import (
         AttributeValue,
     )
 log = logging.getLogger(__name__)

--- a/tests/parameter/test_combined_par.py
+++ b/tests/parameter/test_combined_par.py
@@ -94,9 +94,7 @@ def test_aggregator(
     y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints).reshape(npoints, 1)
     z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints).reshape(npoints, 1)
     setpoints = np.hstack((x_set, y_set, z_set))
-    # setpoints is a 2D array with shape (npoints, 3)
-    # so set is a (3,) numpy array and not a float64 below
-    expected_results = [linear(*set) for set in setpoints]  # pyright: ignore[reportGeneralTypeIssues]
+    expected_results = [linear(*set) for set in setpoints]
     sweep_values = combine(*parameters, name="combined", aggregator=linear).sweep(
         setpoints
     )
@@ -125,7 +123,7 @@ def test_meta(parameters: list[ManualParameter]) -> None:
     out["full_name"] = name
     out["aggregator"] = repr(linear)
     for param in sweep_values.parameters:
-        out[param.full_name] = param.snapshot()  # type: ignore[assignment]
+        out[param.full_name] = param.snapshot()
     assert out == snap
 
 


### PR DESCRIPTION
Just a small cleanup since I happened to notice some of these. Done by manually setting the setting for pyright to warn and remove pyright specific pragmas that are unused