### PR TITLE
Export data directly to xarray when shape is known

### DIFF
--- a/docs/changes/newsfragments/7413.underthehood
+++ b/docs/changes/newsfragments/7413.underthehood
@@ -1,0 +1,3 @@
+``DataSetProtocol.to_xarray_dataset`` and ``DataSetProtocol.to_xarray_dataarray_dict`` now avoids creating a Pandas MultiIndex to infer the
+correct dataset shape if the shape is already known. This will resolve issues where datasets are exported with incorrect array shapes due to
+round off errors in the setpoints (coordinates).

--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -68,7 +68,6 @@ def _load_to_xarray_dataarray_dict_no_metadata(
     *,
     use_multi_index: Literal["auto", "always", "never"] = "auto",
 ) -> dict[str, xr.DataArray]:
-    import pandas as pd
     import xarray as xr
 
     if use_multi_index not in ("auto", "always", "never"):
@@ -79,38 +78,22 @@ def _load_to_xarray_dataarray_dict_no_metadata(
     data_xrdarray_dict: dict[str, xr.DataArray] = {}
 
     for name, subdict in datadict.items():
-        if (
-            (
-                dataset.description.shapes is not None
-                and name in dataset.description.shapes
-            )
-            and use_multi_index != "always"
+        shape_is_consistent = (
+            dataset.description.shapes is not None
+            and name in dataset.description.shapes
             and subdict[name].shape == dataset.description.shapes[name]
-        ):
+        )
+
+        if shape_is_consistent and use_multi_index != "always":
             _LOG.info("Exporting %s to xarray using direct method", name)
-            meas_paramspec = dataset.description.interdeps.graph.nodes[name]["value"]
-
-            _, deps, _ = dataset.description.interdeps.all_parameters_in_tree_by_group(
-                meas_paramspec
-            )
-            dep_axis = {}
-            for axis, dep in enumerate(deps):
-                dep_array = subdict[dep.name]
-                dep_axis[dep.name] = dep_array[
-                    tuple(
-                        slice(None) if i == axis else 0 for i in range(dep_array.ndim)
-                    )
-                ]
-
-            data_xrdarray_dict[name] = xr.Dataset(
-                {name: (tuple(dep_axis.keys()), subdict[name])},
-                coords=dep_axis,
-            )[name]
-
+            data_xrdarray_dict[name] = _xarray_data_array_direct(dataset, name, subdict)
         else:
             _LOG.info("Exporting %s to xarray via pandas index", name)
             index = _generate_pandas_index(
                 subdict, dataset.description.interdeps, top_level_param_name=name
+            )
+            index_is_unique = (
+                len(index.unique()) == len(index) if index is not None else False
             )
 
             if index is None:
@@ -120,54 +103,80 @@ def _load_to_xarray_dataarray_dict_no_metadata(
                     .get(name, xr.DataArray())
                 )
                 data_xrdarray_dict[name] = xrdarray
-            else:
-                index_unique = len(index.unique()) == len(index)
-
+            elif index_is_unique:
                 df = _data_to_dataframe(subdict, index)
-
-                if not index_unique:
-                    _LOG.info(
-                        "Exporting %s to xarray, could not determine unique index falling back to "
-                        "using counter as an index. Setpoints are stored as data variables.",
-                        name,
-                    )
-                    xrdata_temp = df.reset_index().to_xarray()
-                    for _name in subdict:
-                        data_xrdarray_dict[_name] = xrdata_temp[_name]
-                else:
-                    calc_index = _calculate_index_shape(index)
-                    index_prod = prod(calc_index.values())
-                    # if the product of the len of individual index dims == len(total_index)
-                    # we are on a grid
-
-                    on_grid = index_prod == len(index)
-
-                    export_with_multi_index = (
-                        not on_grid
-                        and dataset.description.shapes is None
-                        and use_multi_index == "auto"
-                    ) or use_multi_index == "always"
-
-                    if export_with_multi_index:
-                        assert isinstance(df.index, pd.MultiIndex)
-                        _LOG.info(
-                            "Exporting %s to xarray using a MultiIndex since on_grid=%s, shape=%s, use_multi_index=%s",
-                            name,
-                            on_grid,
-                            dataset.description.shapes,
-                            use_multi_index,
-                        )
-
-                        coords = xr.Coordinates.from_pandas_multiindex(
-                            df.index, "multi_index"
-                        )
-                        xrdarray = xr.DataArray(df[name], coords=coords)
-                    else:
-                        xrdarray = df.to_xarray().get(name, xr.DataArray())
-
-                    data_xrdarray_dict[name] = xrdarray
+                data_xrdarray_dict[name] = _xarray_data_array_from_pandas_multi_index(
+                    dataset, use_multi_index, name, df, index
+                )
+            else:
+                df = _data_to_dataframe(subdict, index)
+                xrdata_temp = df.reset_index().to_xarray()
+                for _name in subdict:
+                    data_xrdarray_dict[_name] = xrdata_temp[_name]
 
     return data_xrdarray_dict
+
+
+def _xarray_data_array_from_pandas_multi_index(
+    dataset: DataSetProtocol,
+    use_multi_index: Literal["auto", "always", "never"],
+    name: str,
+    df: pd.DataFrame,
+    index: pd.Index | pd.MultiIndex,
+) -> xr.DataArray:
+    import pandas as pd
+    import xarray as xr
+
+    calc_index = _calculate_index_shape(index)
+    index_prod = prod(calc_index.values())
+    # if the product of the len of individual index dims == len(total_index)
+    # we are on a grid
+
+    on_grid = index_prod == len(index)
+
+    export_with_multi_index = (
+        not on_grid and dataset.description.shapes is None and use_multi_index == "auto"
+    ) or use_multi_index == "always"
+
+    if export_with_multi_index:
+        assert isinstance(df.index, pd.MultiIndex)
+        _LOG.info(
+            "Exporting %s to xarray using a MultiIndex since on_grid=%s, shape=%s, use_multi_index=%s",
+            name,
+            on_grid,
+            dataset.description.shapes,
+            use_multi_index,
+        )
+
+        coords = xr.Coordinates.from_pandas_multiindex(df.index, "multi_index")
+        xrdarray = xr.DataArray(df[name], coords=coords)
+    else:
+        xrdarray = df.to_xarray().get(name, xr.DataArray())
+
+    return xrdarray
+
+
+def _xarray_data_array_direct(
+    dataset: DataSetProtocol, name: str, subdict: Mapping[str, npt.NDArray]
+) -> xr.DataArray:
+    import xarray as xr
+
+    meas_paramspec = dataset.description.interdeps.graph.nodes[name]["value"]
+    _, deps, _ = dataset.description.interdeps.all_parameters_in_tree_by_group(
+        meas_paramspec
+    )
+    dep_axis = {}
+    for axis, dep in enumerate(deps):
+        dep_array = subdict[dep.name]
+        dep_axis[dep.name] = dep_array[
+            tuple(slice(None) if i == axis else 0 for i in range(dep_array.ndim))
+        ]
+
+    da = xr.Dataset(
+        {name: (tuple(dep_axis.keys()), subdict[name])},
+        coords=dep_axis,
+    )[name]
+    return da
 
 
 def load_to_xarray_dataarray_dict(

--- a/tests/dataset/measurement/test_inferred_parameters_fix.py
+++ b/tests/dataset/measurement/test_inferred_parameters_fix.py
@@ -10,6 +10,7 @@ from itertools import chain
 import numpy as np
 
 from qcodes.dataset import Measurement
+from qcodes.dataset.descriptions.detect_shapes import detect_shape_of_measurement
 from qcodes.parameters import DelegateParameter, ManualParameter, Parameter
 
 
@@ -242,6 +243,9 @@ def test_inferred_parameters_in_actual_measurement_2d(experiment, DAC):
 
     # Register measurement parameter with 2D setpoints
     meas.register_parameter(meas_parameter, setpoints=(del_param_1, del_param_2))
+    meas.set_shapes(
+        detect_shape_of_measurement([meas_parameter], (num_points_x, num_points_y))
+    )
 
     with meas.run() as datasaver:
         for x in np.linspace(0, 1, num_points_x):
@@ -276,7 +280,9 @@ def test_inferred_parameters_in_actual_measurement_2d(experiment, DAC):
 
     total_points = num_points_x * num_points_y
     for k in expected_keys:
-        assert len(tree[k]) == total_points, f"{k} should have {total_points} entries"
+        assert len(tree[k].ravel()) == total_points, (
+            f"{k} should have {total_points} entries"
+        )
 
     # xarray export
     xarr = dataset.to_xarray_dataset()

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -26,6 +26,7 @@ from qcodes.dataset import (
     load_from_netcdf,
     new_data_set,
 )
+from qcodes.dataset.data_set import DataSet
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.versioning import serialization as serial
@@ -660,7 +661,9 @@ def test_export_from_config_set_name_elements(
     ]
 
 
-def test_same_setpoint_warning_for_df_and_xarray(different_setpoint_dataset) -> None:
+def test_same_setpoint_warning_for_df_and_xarray(
+    different_setpoint_dataset: DataSetProtocol,
+) -> None:
     warning_message = (
         "Independent parameter setpoints are not equal. "
         "Check concatenated output carefully."
@@ -1293,7 +1296,7 @@ def test_multi_index_options_incomplete_grid(mock_dataset_grid_incomplete) -> No
 
 
 def test_multi_index_options_incomplete_grid_with_shapes(
-    mock_dataset_grid_incomplete_with_shapes,
+    mock_dataset_grid_incomplete_with_shapes: DataSet,
 ) -> None:
     assert mock_dataset_grid_incomplete_with_shapes.description.shapes == {"z": (10, 5)}
 
@@ -1316,7 +1319,7 @@ def test_multi_index_options_incomplete_grid_with_shapes(
     assert xds_always.sizes == {"multi_index": 39}
 
 
-def test_multi_index_options_non_grid(mock_dataset_non_grid) -> None:
+def test_multi_index_options_non_grid(mock_dataset_non_grid: DataSet) -> None:
     assert mock_dataset_non_grid.description.shapes is None
 
     xds = mock_dataset_non_grid.to_xarray_dataset()
@@ -1332,18 +1335,18 @@ def test_multi_index_options_non_grid(mock_dataset_non_grid) -> None:
     assert xds_always.sizes == {"multi_index": 50}
 
 
-def test_multi_index_wrong_option(mock_dataset_non_grid) -> None:
+def test_multi_index_wrong_option(mock_dataset_non_grid: DataSet) -> None:
     with pytest.raises(ValueError, match="Invalid value for use_multi_index"):
-        mock_dataset_non_grid.to_xarray_dataset(use_multi_index=True)
-
-    with pytest.raises(ValueError, match="Invalid value for use_multi_index"):
-        mock_dataset_non_grid.to_xarray_dataset(use_multi_index=False)
+        mock_dataset_non_grid.to_xarray_dataset(use_multi_index=True)  # pyright: ignore[reportArgumentType]
 
     with pytest.raises(ValueError, match="Invalid value for use_multi_index"):
-        mock_dataset_non_grid.to_xarray_dataset(use_multi_index="perhaps")
+        mock_dataset_non_grid.to_xarray_dataset(use_multi_index=False)  # pyright: ignore[reportArgumentType]
+
+    with pytest.raises(ValueError, match="Invalid value for use_multi_index"):
+        mock_dataset_non_grid.to_xarray_dataset(use_multi_index="perhaps")  # pyright: ignore[reportArgumentType]
 
 
-def test_geneate_pandas_index():
+def test_geneate_pandas_index() -> None:
     x = ParamSpecBase("x", "numeric")
     y = ParamSpecBase("y", "numeric")
     z = ParamSpecBase("z", "numeric")

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -872,8 +872,10 @@ def test_export_dataset_delayed_numeric(
         in caplog.records[0].msg
     )
     assert "Writing individual files to temp dir" in caplog.records[1].msg
-    assert "Combining temp files into one file" in caplog.records[2].msg
-    assert "Writing netcdf file using Dask delayed writer" in caplog.records[3].msg
+    for i in range(2, 52):
+        assert "Exporting z to xarray via pandas index" in caplog.records[i].message
+    assert "Combining temp files into one file" in caplog.records[52].msg
+    assert "Writing netcdf file using Dask delayed writer" in caplog.records[53].msg
 
     loaded_ds = xr.load_dataset(mock_dataset_grid.export_info.export_paths["nc"])
     assert loaded_ds.x.shape == (10,)
@@ -901,13 +903,16 @@ def test_export_dataset_delayed(
     with caplog.at_level(logging.INFO):
         mock_dataset_numpy.export(export_type="netcdf", path=tmp_path, prefix="qcodes_")
 
+    assert len(caplog.records) == 16
     assert (
         "Dataset is expected to be larger that threshold. Using distributed export."
         in caplog.records[0].msg
     )
     assert "Writing individual files to temp dir" in caplog.records[1].msg
-    assert "Combining temp files into one file" in caplog.records[2].msg
-    assert "Writing netcdf file using Dask delayed writer" in caplog.records[3].msg
+    for i in range(2, 12):
+        assert "Exporting z to xarray via pandas index" in caplog.records[i].message
+    assert "Combining temp files into one file" in caplog.records[12].msg
+    assert "Writing netcdf file using Dask delayed writer" in caplog.records[13].msg
 
     loaded_ds = xr.load_dataset(mock_dataset_numpy.export_info.export_paths["nc"])
     assert loaded_ds.x.shape == (10,)
@@ -942,8 +947,10 @@ def test_export_dataset_delayed_complex(
         in caplog.records[0].msg
     )
     assert "Writing individual files to temp dir" in caplog.records[1].msg
-    assert "Combining temp files into one file" in caplog.records[2].msg
-    assert "Writing netcdf file using Dask delayed writer" in caplog.records[3].msg
+    for i in range(2, 12):
+        assert "Exporting z to xarray via pandas index" in caplog.records[i].message
+    assert "Combining temp files into one file" in caplog.records[12].msg
+    assert "Writing netcdf file using Dask delayed writer" in caplog.records[13].msg
 
     loaded_ds = xr.load_dataset(
         mock_dataset_numpy_complex.export_info.export_paths["nc"]


### PR DESCRIPTION
When the shape is known up front there is no need to go via pandas multi index

TODO
- [x] Cleanup nested if statements
- [x] Cover this in tests
- [x] Some form of validation (Only export if the shape of data matches the metadata shape)

