### PR TITLE
copilot install precommit hook envs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: install pre-commit hooks
         run: |
-          pre-commit install
+          pre-commit install --install-hooks
 
       - name: Get Pyright Version
         id: pyright-version


### PR DESCRIPTION
Copilot is firewalled so it cannot do this it self


