### PR TITLE
Improved test coverage for exporting dataset with multiple setpoints

### DIFF
--- a/docs/changes/newsfragments/7442.improved
+++ b/docs/changes/newsfragments/7442.improved
@@ -1,2 +1,4 @@
-Exporting datasets to XArray no longer warns if two or more variables have setpoints of the same name but with different values.
-XArray automatically takes care of creating coordinates with names postfixed by `_n` to disambiguate these.
+Exporting datasets to XArray no longer warns if two or more variables are exported with different setpoints.
+No functionality of the export has changed
+If the setpoints have the same name missing values will be replaced by NaN and if different setpoints
+are used the exporter will automatically handle merging coordinates so each data variable is assigned its own coordinates.

--- a/tests/dataset/conftest.py
+++ b/tests/dataset/conftest.py
@@ -271,12 +271,15 @@ def multi_dataset(experiment, request: FixtureRequest):
         datasaver.dataset.conn.close()
 
 
-@pytest.fixture(scope="function", params=["array"])
+@pytest.fixture(scope="function", params=[True, False])
 def different_setpoint_dataset(experiment, request: FixtureRequest):
     meas = Measurement()
     param = Multi2DSetPointParam2Sizes()
 
-    meas.register_parameter(param, paramtype=request.param)
+    meas.register_parameter(param, paramtype="array")
+
+    if request.param is True:
+        meas.set_shapes({"this_5_3": (5, 3), "this_2_7": (2, 7)})
 
     with meas.run() as datasaver:
         datasaver.add_result(
@@ -292,8 +295,9 @@ def different_setpoint_dataset(experiment, request: FixtureRequest):
         datasaver.dataset.conn.close()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", params=[True, False])
 def two_params_partial_2d_dataset(
+    request: FixtureRequest,
     experiment: Experiment,
 ) -> Generator[DataSetProtocol, None, None]:
     """
@@ -306,6 +310,9 @@ def two_params_partial_2d_dataset(
     meas.register_custom_parameter("y", paramtype="numeric")
     meas.register_custom_parameter("m1", paramtype="numeric", setpoints=("x", "y"))
     meas.register_custom_parameter("m2", paramtype="numeric", setpoints=("x", "y"))
+
+    if request.param is True:
+        meas.set_shapes({"m1": (5, 4), "m2": (5, 2)})
 
     with meas.run() as datasaver:
         xs = np.linspace(0.0, 1.0, 5)

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -665,65 +665,39 @@ def test_export_from_config_set_name_elements(
     ]
 
 
-def test_same_setpoint_warning_for_df(
-    different_setpoint_dataset: DataSetProtocol,
+def test_same_setpoint_no_warning_for_df_two_params_partial(
+    two_params_partial_2d_dataset: DataSetProtocol,
 ) -> None:
     warning_message = (
         "Independent parameter setpoints are not equal. "
         "Check concatenated output carefully."
     )
 
+    # Expect a warning since independent parameter setpoints differ
     with pytest.warns(UserWarning, match=warning_message):
-        df = different_setpoint_dataset.to_pandas_dataframe()
-    this_2_7_df = df.loc[df["this_2_7"].notna()]["this_2_7"]
-    # Verify that the index for the filtered Series has the expected 2x7 shape
-    assert isinstance(this_2_7_df.index, pd.MultiIndex)
+        df = two_params_partial_2d_dataset.to_pandas_dataframe()
 
-    # Names of setpoint coords as registered by the MultiParameter
-    # because this dataframe has indexes from two different set of
-    # qcodes setpoints the names are just level_0, level_1
-    sp_21 = "level_0"
-    sp_22 = "level_1"
+    # Expect two measured columns (m1 and m2)
+    assert "m1" in df.columns
+    assert "m2" in df.columns
 
-    # Expected coordinate vectors
-    exp_sp_21 = np.linspace(5, 9, 2)
-    exp_sp_22 = np.linspace(9, 11, 7)
+    # Dataframe should use a MultiIndex named by the two setpoints
+    assert isinstance(df.index, pd.MultiIndex)
+    assert list(df.index.names) == ["x", "y"]
 
-    # Expected shape for the MultiIndex
-    dims = _calculate_index_shape(this_2_7_df.index)
-    assert dims == {sp_21: 2, sp_22: 7}
+    # m1 should cover full 5x4 grid
+    m1_series = df.loc[df["m1"].notna(), "m1"]
+    assert isinstance(m1_series.index, pd.MultiIndex)
+    dims_m1 = _calculate_index_shape(m1_series.index)
+    assert dims_m1 == {"x": 5, "y": 4}
+    assert len(m1_series) == 5 * 4
 
-    # Basic sanity checks on index names and size
-    assert list(this_2_7_df.index.names) == [None, None]
-    assert len(this_2_7_df) == 2 * 7
-
-    # Check that each index level matches expected coordinate values
-    mi_clean_2_7 = this_2_7_df.index.remove_unused_levels()
-    np.testing.assert_allclose(mi_clean_2_7.levels[0].values, exp_sp_21)
-    np.testing.assert_allclose(mi_clean_2_7.levels[1].values, exp_sp_22)
-
-    # Repeat for the other parameter (this_5_3)
-    this_5_3_df = df.loc[df["this_5_3"].notna()]["this_5_3"]
-    assert isinstance(this_5_3_df.index, pd.MultiIndex)
-
-    sp_11 = "level_0"
-    sp_12 = "level_1"
-
-    exp_sp_11 = np.linspace(5, 9, 5)
-    exp_sp_12 = np.linspace(9, 11, 3)
-
-    dims = _calculate_index_shape(this_5_3_df.index)
-    assert dims == {sp_11: 5, sp_12: 3}
-
-    assert list(this_5_3_df.index.names) == [None, None]
-    assert len(this_5_3_df) == 5 * 3
-
-    mi_clean_5_3 = this_5_3_df.index.remove_unused_levels()
-    np.testing.assert_allclose(mi_clean_5_3.levels[0].values, exp_sp_11)
-    np.testing.assert_allclose(mi_clean_5_3.levels[1].values, exp_sp_12)
-
-    with pytest.warns(UserWarning, match=warning_message):
-        different_setpoint_dataset.cache.to_pandas_dataframe()
+    # m2 should be partial (5x2 points not NaN)
+    m2_series = df.loc[df["m2"].notna(), "m2"]
+    assert isinstance(m2_series.index, pd.MultiIndex)
+    dims_m2 = _calculate_index_shape(m2_series.index)
+    assert dims_m2 == {"x": 5, "y": 2}
+    assert len(m2_series) == 5 * 2
 
 
 def test_partally_overlapping_setpoint_xarray_export(

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -674,7 +674,53 @@ def test_same_setpoint_warning_for_df(
     )
 
     with pytest.warns(UserWarning, match=warning_message):
-        different_setpoint_dataset.to_pandas_dataframe()
+        df = different_setpoint_dataset.to_pandas_dataframe()
+    this_2_7_df = df.loc[df["this_2_7"].notna()]["this_2_7"]
+    # Verify that the index for the filtered Series has the expected 2x7 shape
+    assert isinstance(this_2_7_df.index, pd.MultiIndex)
+
+    # Names of setpoint coords as registered by the MultiParameter
+    # because this dataframe has indexes from two different set of
+    # qcodes setpoints the names are just level_0, level_1
+    sp_21 = "level_0"
+    sp_22 = "level_1"
+
+    # Expected coordinate vectors
+    exp_sp_21 = np.linspace(5, 9, 2)
+    exp_sp_22 = np.linspace(9, 11, 7)
+
+    # Expected shape for the MultiIndex
+    dims = _calculate_index_shape(this_2_7_df.index)
+    assert dims == {sp_21: 2, sp_22: 7}
+
+    # Basic sanity checks on index names and size
+    assert list(this_2_7_df.index.names) == [None, None]
+    assert len(this_2_7_df) == 2 * 7
+
+    # Check that each index level matches expected coordinate values
+    mi_clean_2_7 = this_2_7_df.index.remove_unused_levels()
+    np.testing.assert_allclose(mi_clean_2_7.levels[0].values, exp_sp_21)
+    np.testing.assert_allclose(mi_clean_2_7.levels[1].values, exp_sp_22)
+
+    # Repeat for the other parameter (this_5_3)
+    this_5_3_df = df.loc[df["this_5_3"].notna()]["this_5_3"]
+    assert isinstance(this_5_3_df.index, pd.MultiIndex)
+
+    sp_11 = "level_0"
+    sp_12 = "level_1"
+
+    exp_sp_11 = np.linspace(5, 9, 5)
+    exp_sp_12 = np.linspace(9, 11, 3)
+
+    dims = _calculate_index_shape(this_5_3_df.index)
+    assert dims == {sp_11: 5, sp_12: 3}
+
+    assert list(this_5_3_df.index.names) == [None, None]
+    assert len(this_5_3_df) == 5 * 3
+
+    mi_clean_5_3 = this_5_3_df.index.remove_unused_levels()
+    np.testing.assert_allclose(mi_clean_5_3.levels[0].values, exp_sp_11)
+    np.testing.assert_allclose(mi_clean_5_3.levels[1].values, exp_sp_12)
 
     with pytest.warns(UserWarning, match=warning_message):
         different_setpoint_dataset.cache.to_pandas_dataframe()


### PR DESCRIPTION
This tries to ensure that we cover in test

* Known shape vs not known shape
* Pandas export vs xarray export
* Exports where 2 different setpoints are scanned in parallel vs using the same setpoints but with different values for different measured parameters. 
