### PR TITLE
Add generic argument to ChannelList

### DIFF
--- a/docs/changes/newsfragments/7520.improved
+++ b/docs/changes/newsfragments/7520.improved
@@ -1,0 +1,4 @@
+``ChannelList`` and ``AutoLoadableChannelList`` can now correctly infer the type of channels in the list
+when indexed using ``__get_item`` e.g. ``mychannellist[0]`` For consistency with the base classes the parent type
+in  ``AutoLoadableChannelList`` has changed from ``Instrument`` to ``InstrumentBase`` which may require downstream
+changes for type checking to work correctly.

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
     from typing_extensions import Unpack
 
-    from .instrument import Instrument
     from .instrument_base import InstrumentBaseKWArgs
 
 
@@ -566,9 +565,9 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
 
 # in index method the parameter obj should be called value but that would
 # be an incompatible change
-class ChannelList(
+class ChannelList(  #  pyright: ignore[reportIncompatibleMethodOverride]
     ChannelTuple[InstrumentModuleType], MutableSequence[InstrumentModuleType]
-):  #  pyright: ignore[reportIncompatibleMethodOverride]
+):
     """
     Mutable Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.
@@ -878,7 +877,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
     @classmethod
     def load_from_instrument(
         cls,
-        parent: Instrument,
+        parent: InstrumentBase,
         channel_list: AutoLoadableChannelList | None = None,
         **kwargs: Any,
     ) -> list[AutoLoadableInstrumentChannel]:
@@ -907,7 +906,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
 
     @classmethod
     def _discover_from_instrument(
-        cls, parent: Instrument, **kwargs: Any
+        cls, parent: InstrumentBase, **kwargs: Any
     ) -> list[dict[Any, Any]]:
         """
         Discover channels on the instrument and return a list kwargs to create
@@ -930,7 +929,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
     @classmethod
     def new_instance(
         cls,
-        parent: Instrument,
+        parent: InstrumentBase,
         create_on_instrument: bool = True,
         channel_list: AutoLoadableChannelList | None = None,
         **kwargs: Any,
@@ -982,7 +981,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
 
     @classmethod
     def _get_new_instance_kwargs(
-        cls, parent: Instrument | None = None, **kwargs: Any
+        cls, parent: InstrumentBase | None = None, **kwargs: Any
     ) -> dict[Any, Any]:
         """
         Returns a dictionary which is used as keyword args when instantiating a
@@ -1014,7 +1013,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
 
     def __init__(
         self,
-        parent: Instrument | InstrumentChannel,
+        parent: InstrumentBase,
         name: str,
         exists_on_instrument: bool = False,
         channel_list: AutoLoadableChannelList | None = None,
@@ -1141,7 +1140,7 @@ class AutoLoadableChannelList(ChannelList[AutoLoadableInstrumentChannel]):
 
     def __init__(
         self,
-        parent: Instrument,
+        parent: InstrumentBase,
         name: str,
         chan_type: type[AutoLoadableInstrumentChannel],
         chan_list: Sequence[AutoLoadableInstrumentChannel] | None = None,

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -666,7 +666,7 @@ class ChannelList(  #  pyright: ignore[reportIncompatibleMethodOverride]
         if isinstance(index, int):
             assert isinstance(value, InstrumentModule)
             self._channels[index] = value  # type: ignore[assignment]
-            # mypy does not that InstrumentModuleType is a TypeVar bound to
+            # mypy does not know that InstrumentModuleType is a TypeVar bound to
             # InstrumentModule so complains here
         else:
             assert not isinstance(value, InstrumentModule)

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -880,7 +880,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
         parent: InstrumentBase,
         channel_list: AutoLoadableChannelList | None = None,
         **kwargs: Any,
-    ) -> list[AutoLoadableInstrumentChannel]:
+    ) -> list[Self]:
         """
         Load channels that already exist on the instrument
 
@@ -933,7 +933,7 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
         create_on_instrument: bool = True,
         channel_list: AutoLoadableChannelList | None = None,
         **kwargs: Any,
-    ) -> AutoLoadableInstrumentChannel:
+    ) -> Self:
         """
         Create a new instance of the channel on the instrument: This involves
         finding initialization arguments which will create a channel with a
@@ -1096,7 +1096,10 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
         return self._exists_on_instrument
 
 
-class AutoLoadableChannelList(ChannelList[AutoLoadableInstrumentChannel]):
+TAUTORELOADCHANNEL = TypeVar("TAUTORELOADCHANNEL", bound=AutoLoadableInstrumentChannel)
+
+
+class AutoLoadableChannelList(ChannelList[TAUTORELOADCHANNEL]):
     """
     Extends the QCoDeS :class:`ChannelList` class to add the following features:
     - Automatically create channel objects on initialization
@@ -1142,8 +1145,8 @@ class AutoLoadableChannelList(ChannelList[AutoLoadableInstrumentChannel]):
         self,
         parent: InstrumentBase,
         name: str,
-        chan_type: type[AutoLoadableInstrumentChannel],
-        chan_list: Sequence[AutoLoadableInstrumentChannel] | None = None,
+        chan_type: type[TAUTORELOADCHANNEL],
+        chan_list: Sequence[TAUTORELOADCHANNEL] | None = None,
         snapshotable: bool = True,
         multichan_paramclass: type = MultiChannelInstrumentParameter,
         **kwargs: Any,
@@ -1157,7 +1160,7 @@ class AutoLoadableChannelList(ChannelList[AutoLoadableInstrumentChannel]):
 
         self.extend(new_channels)
 
-    def add(self, **kwargs: Any) -> AutoLoadableInstrumentChannel:
+    def add(self, **kwargs: Any) -> TAUTORELOADCHANNEL:
         """
         Add a channel to the list
 

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -665,7 +665,9 @@ class ChannelList(  #  pyright: ignore[reportIncompatibleMethodOverride]
         # asserts added to work around https://github.com/python/mypy/issues/7858
         if isinstance(index, int):
             assert isinstance(value, InstrumentModule)
-            self._channels[index] = value
+            self._channels[index] = value  # type: ignore[assignment]
+            # mypy does not that InstrumentModuleType is a TypeVar bound to
+            # InstrumentModule so complains here
         else:
             assert not isinstance(value, InstrumentModule)
             self._channels[index] = value

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -566,7 +566,9 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
 
 # in index method the parameter obj should be called value but that would
 # be an incompatible change
-class ChannelList(ChannelTuple, MutableSequence[InstrumentModuleType]):  #  pyright: ignore[reportIncompatibleMethodOverride]
+class ChannelList(
+    ChannelTuple[InstrumentModuleType], MutableSequence[InstrumentModuleType]
+):  #  pyright: ignore[reportIncompatibleMethodOverride]
     """
     Mutable Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.

--- a/tests/test_autoloadable_channels.py
+++ b/tests/test_autoloadable_channels.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from qcodes.instrument import Instrument, InstrumentChannel
+from qcodes.instrument import Instrument, InstrumentBase, InstrumentChannel
 from qcodes.instrument.channel import (
     AutoLoadableChannelList,
     AutoLoadableInstrumentChannel,
@@ -103,7 +103,7 @@ class SimpleTestChannel(AutoLoadableInstrumentChannel):
 
     @classmethod
     def _discover_from_instrument(
-        cls, parent: Instrument, **kwargs
+        cls, parent: InstrumentBase, **kwargs
     ) -> list[dict[Any, Any]]:
         """
         New channels need `name` and `channel` keyword arguments.
@@ -131,7 +131,7 @@ class SimpleTestChannel(AutoLoadableInstrumentChannel):
 
     @classmethod
     def _get_new_instance_kwargs(
-        cls, parent: Instrument | None = None, **kwargs
+        cls, parent: InstrumentBase | None = None, **kwargs
     ) -> dict[Any, Any]:
         """
         Find the smallest channel number not yet occupied. An optional keyword

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -583,7 +583,7 @@ def test_access_channels_by_name_deprecated(
 
     with pytest.warns(QCoDeSDeprecationWarning, match="get_channel_by_name"):
         mychans = chlist.get_channel_by_name(*channel_names)
-        for chan, chanindex in zip(mychans, myindexs):
+        for chan, chanindex in zip(mychans, myindexs):  # pyright: ignore[reportArgumentType]
             assert chan.name == f"dci_Chan{names[chanindex]}"
 
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections.abc import Generator, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -285,6 +285,15 @@ def test_insert_channel(dci_with_list: DCIWithList) -> None:
 def test_insert_channel_wrong_type_raises(dci_with_list: DCIWithList) -> None:
     with pytest.raises(TypeError, match="All items in a channel list"):
         dci_with_list.channels.insert(1, EmptyChannel(parent=dci_with_list, name="foo"))  # type: ignore
+
+
+def test_channel_type_can_be_inferred(
+    dci_with_list: DCIWithList, dci: DummyChannelInstrument
+) -> None:
+    chan1 = dci_with_list.channels[0]
+    assert_type(chan1, DummyChannel)
+
+    assert_type(dci.channels[0], DummyChannel)
 
 
 def test_add_none_channel_tuple_to_channel_tuple_raises(


### PR DESCRIPTION
This ensures that the type of the element of the ChannelList can be found correctly (like it can for a ChannelTuple)

To make this works requires changing the types in the AutoLoadable channels classes to match ChannelList/Tuple

- [x] Should get a changelog entry for breaking changes to AutoLoadable channel