### PR TITLE
Add pep794 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pillow>=9.2.0",
     "dask>=2022.1.0", # we are making use of xarray features that requires dask implicitly
 ]
-
+import-names = ["qcodes"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
See https://peps.python.org/pep-0794/

Blocked by setuptools not yet supporting this.

Rebased when packaging + packaging in setuptools updated support but did not resolve the issue just yet

>   NotImplementedError: Setuptools does not support `import-names` and `import-namespaces` in `pyproject.toml` yet. If your are interested in this feature,  please consider submitting a contribution via pull requests.
