### PR TITLE
Make DriverTestCase generic

### DIFF
--- a/src/qcodes/extensions/_driver_test_case.py
+++ b/src/qcodes/extensions/_driver_test_case.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from qcodes.instrument import Instrument
@@ -25,10 +25,13 @@ Using `DriverTestCase` is pretty easy:
 """
 
 
-class DriverTestCase(unittest.TestCase):
+T = TypeVar("T", bound="Instrument")
+
+
+class DriverTestCase(unittest.TestCase, Generic[T]):
     # override this in a subclass
-    driver: type[Instrument] | None = None
-    instrument: Instrument
+    driver: type[T] | None = None
+    instrument: T
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/drivers/test_Agilent_E8257D.py
+++ b/tests/drivers/test_Agilent_E8257D.py
@@ -2,7 +2,7 @@ from qcodes.extensions import DriverTestCase
 from qcodes.instrument_drivers.agilent import AgilentE8257D
 
 
-class TestAgilentE8257D(DriverTestCase):
+class TestAgilentE8257D(DriverTestCase[AgilentE8257D]):
     """
     This is a test suite for testing the QuTech_ControlBox Instrument.
     It is designed to provide a test function for each function as well as for

--- a/tests/drivers/test_weinchel.py
+++ b/tests/drivers/test_weinchel.py
@@ -2,7 +2,7 @@ from qcodes.extensions import DriverTestCase
 from qcodes.instrument_drivers.weinschel import Weinschel8320
 
 
-class TestWeinschel8320(DriverTestCase):
+class TestWeinschel8320(DriverTestCase[Weinschel8320]):
     """
     This is a test suite for testing the weinschel/aeroflex stepped attenuator.
     It is designed to provide a test function for each function as well as for


### PR DESCRIPTION
Make it such that the type checker can infer the type of self.instrument within the test


