### PR TITLE
Make full_name a cached_property

### DIFF
--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import warnings
 from collections.abc import Callable, Iterable, Iterator, MutableSequence, Sequence
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, Self, cast, overload
 
 from typing_extensions import TypeVar
@@ -291,7 +292,7 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
     def short_name(self) -> str:
         return self._name
 
-    @property
+    @cached_property
     def full_name(self) -> str:
         return "_".join(self.name_parts)
 

--- a/src/qcodes/instrument/instrument_base.py
+++ b/src/qcodes/instrument/instrument_base.py
@@ -6,6 +6,7 @@ import collections.abc
 import logging
 import warnings
 from collections.abc import Callable, Mapping, Sequence
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
@@ -596,7 +597,7 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         """
         return [self.short_name]
 
-    @property
+    @cached_property
     def full_name(self) -> str:
         """
         Full name of the instrument.

--- a/src/qcodes/metadatable/metadatable_base.py
+++ b/src/qcodes/metadatable/metadatable_base.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, final
 
 from qcodes.utils import deep_update
@@ -79,7 +80,7 @@ class MetadatableWithName(Metadatable):
         Name excluding name of any parent that this object is bound to.
         """
 
-    @property
+    @cached_property
     @abstractmethod
     def full_name(self) -> str:
         """

--- a/src/qcodes/parameters/function.py
+++ b/src/qcodes/parameters/function.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from qcodes.metadatable import MetadatableWithName
@@ -180,7 +181,7 @@ class Function(MetadatableWithName):
         """
         return self.name
 
-    @property
+    @cached_property
     def full_name(self) -> str:
         """
         Name of the function including the name of the instrument and

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -1014,7 +1014,7 @@ class ParameterBase(MetadatableWithName):
         full name refer to :meth:`full_name`."""
         return self._short_name
 
-    @property
+    @cached_property
     def full_name(self) -> str:
         """
         Name of the parameter including the name of the instrument and

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import cProfile
 import os
-from functools import wraps
+from functools import cached_property, wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -159,6 +159,6 @@ class DummyComponent(MetadatableWithName):
     def short_name(self) -> str:
         return self.name
 
-    @property
+    @cached_property
     def full_name(self) -> str:
         return self.full_name


### PR DESCRIPTION
In examples without instrument communication / significant data storage full_name contributes significantly to runtime of measurements. 

TODO 

- [ ] Profile that this matters for real examples
- [ ] Does this have any negative consequences. i.e. for dynamic parameters. Do we support dynamically changing parent. 
