### PR TITLE
feat(dataset): expose ParamSpecBase from qcodes.dataset

### DIFF
--- a/docs/changes/newsfragments/7369.improved
+++ b/docs/changes/newsfragments/7369.improved
@@ -1,0 +1,3 @@
+``ParamSpecBase`` is now re-exported from :mod:`qcodes.dataset` so that users
+defining custom ``InterDependencies_`` graphs via the public ``qcodes.dataset``
+namespace do not need to reach into :mod:`qcodes.parameters` to obtain it.

--- a/src/qcodes/dataset/__init__.py
+++ b/src/qcodes/dataset/__init__.py
@@ -17,6 +17,8 @@ from .database_extract_runs import (
     export_datasets_and_create_metadata_db,
     extract_runs_into_db,
 )
+from qcodes.parameters import ParamSpecBase
+
 from .descriptions.dependencies import InterDependencies_, ParamSpecTree
 from .descriptions.param_spec import ParamSpec
 from .descriptions.rundescriber import RunDescriber
@@ -77,6 +79,7 @@ __all__ = [
     "LogSweep",
     "Measurement",
     "ParamSpec",
+    "ParamSpecBase",
     "ParamSpecTree",
     "RunDescriber",
     "SQLiteSettings",

--- a/tests/dataset/test_dependencies.py
+++ b/tests/dataset/test_dependencies.py
@@ -17,6 +17,14 @@ from qcodes.parameters import ParamSpecBase
 from tests.common import error_caused_by
 
 
+def test_param_spec_base_reexported_from_qcodes_dataset() -> None:
+    """``ParamSpecBase`` is part of the public :mod:`qcodes.dataset` API."""
+    import qcodes.dataset as qdataset
+
+    assert qdataset.ParamSpecBase is ParamSpecBase
+    assert "ParamSpecBase" in qdataset.__all__
+
+
 def test_wrong_input_raises() -> None:
     for pspecs in (
         ["p1", "p2", "p3"],


### PR DESCRIPTION
## Summary

Closes #7369.

``ParamSpecBase`` is the base class used for building ``InterDependencies_`` graphs on the public API surface, but until this change it was only importable from ``qcodes.parameters``. ``qcodes.dataset.__init__`` only re-exported the legacy ``ParamSpec`` class, which meant users following the documented dataset-centric entry points had to reach into ``qcodes.parameters`` to obtain it.

This PR re-exports ``ParamSpecBase`` from ``qcodes.dataset`` and adds it to ``__all__`` so the public namespace matches the recommended usage.

- Add ``ParamSpecBase`` to the re-exports in ``src/qcodes/dataset/__init__.py`` and ``__all__``.
- Add a regression test in ``tests/dataset/test_dependencies.py`` that pins the identity of the re-export and its membership in ``__all__``.
- Add a newsfragment.

## Test plan

- [x] ``pytest tests/dataset/test_dependencies.py`` — 19 passed locally.
- [x] ``python -c "from qcodes.dataset import ParamSpecBase; from qcodes.parameters import ParamSpecBase as P; assert ParamSpecBase is P"`` succeeds.