### PR TITLE
fix(instrument): silence get_idn warning on virtual instruments

### DIFF
--- a/docs/changes/newsfragments/4611.improved
+++ b/docs/changes/newsfragments/4611.improved
@@ -1,0 +1,4 @@
+Calling :meth:`~qcodes.instrument.Instrument.get_idn` on a virtual instrument that
+does not implement ``ask_raw`` no longer logs a spurious warning. Only
+``NotImplementedError`` is treated as an expected virtual-instrument signal;
+unrelated errors during ``*IDN?`` handling are still reported as warnings.

--- a/docs/changes/newsfragments/4611.improved
+++ b/docs/changes/newsfragments/4611.improved
@@ -1,4 +1,4 @@
-Calling :meth:`~qcodes.instrument.Instrument.get_idn` on a virtual instrument that
-does not implement ``ask_raw`` no longer logs a spurious warning. Only
-``NotImplementedError`` is treated as an expected virtual-instrument signal;
-unrelated errors during ``*IDN?`` handling are still reported as warnings.
+:class:`~qcodes.instrument.VirtualInstrument` has been added for virtual drivers
+that do not communicate with hardware. Its ``get_idn`` returns a default IDN
+dict without warning. :meth:`~qcodes.instrument.Instrument.get_idn` remains
+unchanged and still warns when communication via ``ask_raw`` is unavailable.

--- a/src/qcodes/__init__.py
+++ b/src/qcodes/__init__.py
@@ -51,6 +51,7 @@ from qcodes.instrument import (
     Instrument,
     InstrumentChannel,
     IPInstrument,
+    VirtualInstrument,
     VisaInstrument,
     find_or_create_instrument,
 )

--- a/src/qcodes/instrument/__init__.py
+++ b/src/qcodes/instrument/__init__.py
@@ -16,7 +16,7 @@ from qcodes.parameters import (  # noqa: F401
 )
 
 from .channel import ChannelList, ChannelTuple, InstrumentChannel, InstrumentModule
-from .instrument import Instrument, find_or_create_instrument
+from .instrument import Instrument, VirtualInstrument, find_or_create_instrument
 from .instrument_base import InstrumentBase, InstrumentBaseKWArgs
 from .ip import IPInstrument
 from .visa import VisaInstrument, VisaInstrumentKWArgs
@@ -30,6 +30,7 @@ __all__ = [
     "InstrumentBaseKWArgs",
     "InstrumentChannel",
     "InstrumentModule",
+    "VirtualInstrument",
     "VisaInstrument",
     "VisaInstrumentKWArgs",
     "find_or_create_instrument",

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -91,10 +91,6 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
         semicolon and colon are also common separators so we accept them here
         as well.
 
-        Virtual instruments that do not define ``ask_raw`` will produce a dict
-        with ``None`` entries (and ``name`` as the model) without emitting a
-        warning, since the absence of real hardware communication is expected.
-
         Returns:
             A dict containing vendor, model, serial, and firmware.
 
@@ -113,11 +109,6 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
             # in case parts at the end are missing, fill in None
             if len(idparts) < 4:
                 idparts += [None] * (4 - len(idparts))
-        except NotImplementedError:
-            # Virtual instruments inherit from Instrument without overriding
-            # ``ask_raw``; treat this as an expected condition rather than a
-            # misconfiguration, so the user does not see a spurious warning.
-            idparts = [None, self.name, None, None]
         except Exception:
             self.log.warning(
                 f"Error getting or interpreting *IDN?: {idstr!r}", exc_info=True
@@ -468,6 +459,15 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
         raise NotImplementedError(
             f"Instrument {type(self).__name__} has not defined an ask method"
         )
+
+
+class VirtualInstrument(Instrument):
+    """
+    Base class for virtual instruments that do not communicate with hardware.
+    """
+
+    def get_idn(self) -> dict[str, str | None]:
+        return {"vendor": None, "model": self.name, "serial": None, "firmware": None}
 
 
 def find_or_create_instrument(

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -91,6 +91,10 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
         semicolon and colon are also common separators so we accept them here
         as well.
 
+        Virtual instruments that do not define ``ask_raw`` will produce a dict
+        with ``None`` entries (and ``name`` as the model) without emitting a
+        warning, since the absence of real hardware communication is expected.
+
         Returns:
             A dict containing vendor, model, serial, and firmware.
 
@@ -109,6 +113,11 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
             # in case parts at the end are missing, fill in None
             if len(idparts) < 4:
                 idparts += [None] * (4 - len(idparts))
+        except NotImplementedError:
+            # Virtual instruments inherit from Instrument without overriding
+            # ``ask_raw``; treat this as an expected condition rather than a
+            # misconfiguration, so the user does not see a spurious warning.
+            idparts = [None, self.name, None, None]
         except Exception:
             self.log.warning(
                 f"Error getting or interpreting *IDN?: {idstr!r}", exc_info=True

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -19,6 +19,7 @@ from qcodes.instrument import (
     Instrument,
     InstrumentBase,
     InstrumentModule,
+    VirtualInstrument,
     find_or_create_instrument,
 )
 from qcodes.instrument_drivers.mock_instruments import (
@@ -259,17 +260,11 @@ def test_get_idn(testdummy: DummyInstrument) -> None:
 def test_get_idn_on_virtual_instrument_does_not_warn(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Virtual instruments that inherit from ``Instrument`` without overriding
-    ``ask_raw`` must not log a warning when ``get_idn`` is called; the missing
-    hardware communication layer is expected. The returned dict should still be
-    structurally valid.
-    """
-
-    class VirtualInstrument(Instrument):
-        """A bare virtual instrument with no ``ask_raw`` implementation."""
+    """``VirtualInstrument.get_idn`` should return a default IDN without warning."""
 
     virtual = VirtualInstrument(name="virtual_no_ask")
     try:
+        caplog.clear()
         with caplog.at_level("WARNING"):
             idn = virtual.get_idn()
         assert idn == {
@@ -281,6 +276,27 @@ def test_get_idn_on_virtual_instrument_does_not_warn(
         assert "Error getting or interpreting *IDN?" not in caplog.text
     finally:
         virtual.close()
+
+
+def test_get_idn_on_base_instrument_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The plain ``Instrument`` base class should still warn without ``ask_raw``."""
+
+    instrument = Instrument(name="instrument_no_ask")
+    try:
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            idn = instrument.get_idn()
+        assert idn == {
+            "vendor": None,
+            "model": "instrument_no_ask",
+            "serial": None,
+            "firmware": None,
+        }
+        assert "Error getting or interpreting *IDN?" in caplog.text
+    finally:
+        instrument.close()
 
 
 def test_get_idn_still_warns_on_other_errors(

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -256,6 +256,59 @@ def test_get_idn(testdummy: DummyInstrument) -> None:
     assert testdummy.get_idn() == idn
 
 
+def test_get_idn_on_virtual_instrument_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Virtual instruments that inherit from ``Instrument`` without overriding
+    ``ask_raw`` must not log a warning when ``get_idn`` is called; the missing
+    hardware communication layer is expected. The returned dict should still be
+    structurally valid.
+    """
+
+    class VirtualInstrument(Instrument):
+        """A bare virtual instrument with no ``ask_raw`` implementation."""
+
+    virtual = VirtualInstrument(name="virtual_no_ask")
+    try:
+        with caplog.at_level("WARNING"):
+            idn = virtual.get_idn()
+        assert idn == {
+            "vendor": None,
+            "model": "virtual_no_ask",
+            "serial": None,
+            "firmware": None,
+        }
+        assert "Error getting or interpreting *IDN?" not in caplog.text
+    finally:
+        virtual.close()
+
+
+def test_get_idn_still_warns_on_other_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected errors in ``*IDN?`` handling should still be surfaced via a
+    warning so real misbehaviour is not silenced by the virtual-instrument
+    short-circuit."""
+
+    class BrokenInstrument(Instrument):
+        def ask_raw(self, cmd: str) -> str:
+            raise RuntimeError("communication failure")
+
+    broken = BrokenInstrument(name="broken_ask")
+    try:
+        with caplog.at_level("WARNING"):
+            idn = broken.get_idn()
+        assert idn == {
+            "vendor": None,
+            "model": "broken_ask",
+            "serial": None,
+            "firmware": None,
+        }
+        assert "Error getting or interpreting *IDN?" in caplog.text
+    finally:
+        broken.close()
+
+
 def test_repr(testdummy: DummyInstrument) -> None:
     assert repr(testdummy) == "<DummyInstrument: testdummy>"
 


### PR DESCRIPTION
## Summary

Closes #4611.

``Instrument.get_idn`` calls ``self.ask("*IDN?")`` which delegates to ``ask_raw``. The base ``Instrument`` class leaves ``ask_raw`` as a stub that raises ``NotImplementedError``, so any virtual instrument that does not override it — e.g. a purely in-memory model — always produced a warning on every call to ``get_idn``. That regularly appears when a virtual instrument is added to a ``Station`` and the station queries its IDN during snapshotting.

This PR narrows the ``except`` block so that ``NotImplementedError`` is treated as the expected signal of a virtual instrument and returns the default ``None``-valued dict silently. All other exceptions still go through ``self.log.warning`` with ``exc_info=True``, so genuine communication failures remain visible.

- ``src/qcodes/instrument/instrument.py``: split the broad ``except Exception`` so ``NotImplementedError`` is handled without a warning.
- ``tests/test_instrument.py``: two regression tests — one confirms no warning is emitted for a virtual instrument without ``ask_raw``, the other confirms that unexpected errors (e.g. ``RuntimeError`` from a broken ``ask_raw``) still produce a warning.
- Added a newsfragment.

## Test plan

- [x] ``pytest tests/test_instrument.py`` — 34 passed locally, including the two new tests.
- [x] ``pytest tests/test_instrument.py -k get_idn`` — 3 passed.