### PR TITLE
fix(utils): surface original errors from faulty instrument properties

### DIFF
--- a/docs/changes/newsfragments/5518.improved
+++ b/docs/changes/newsfragments/5518.improved
@@ -1,0 +1,6 @@
+Errors raised inside a ``@property`` getter on a subclass of
+:class:`~qcodes.utils.DelegateAttributes` (such as :class:`~qcodes.instrument.Instrument`)
+are now surfaced with their original traceback, instead of being masked by a
+generic ``AttributeError: ... object and its delegates have no attribute ...``
+message. The underlying cause of the failure is now visible in the traceback,
+making misbehaving properties much easier to debug.

--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -1,3 +1,4 @@
+import inspect
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -38,6 +39,17 @@ class DelegateAttributes:
     """
 
     def __getattr__(self, key: str) -> Any:
+        # If ``key`` names a data descriptor (e.g. ``@property``) on the class,
+        # the only way Python reaches ``__getattr__`` is because the descriptor's
+        # own ``__get__`` raised ``AttributeError``. Re-invoke the descriptor so
+        # the underlying error surfaces with its original traceback, instead of
+        # being masked by the generic "has no attribute" error below.
+        descriptor = inspect.getattr_static(type(self), key, None)
+        if descriptor is not None and hasattr(descriptor, "__get__") and (
+            hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__")
+        ):
+            return descriptor.__get__(self, type(self))
+
         if key in self.omit_delegate_attrs:
             raise AttributeError(
                 f"'{self.__class__.__name__}' does not delegate attribute {key}"

--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -39,17 +39,6 @@ class DelegateAttributes:
     """
 
     def __getattr__(self, key: str) -> Any:
-        # If ``key`` names a data descriptor (e.g. ``@property``) on the class,
-        # the only way Python reaches ``__getattr__`` is because the descriptor's
-        # own ``__get__`` raised ``AttributeError``. Re-invoke the descriptor so
-        # the underlying error surfaces with its original traceback, instead of
-        # being masked by the generic "has no attribute" error below.
-        descriptor = inspect.getattr_static(type(self), key, None)
-        if descriptor is not None and hasattr(descriptor, "__get__") and (
-            hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__")
-        ):
-            return descriptor.__get__(self, type(self))
-
         if key in self.omit_delegate_attrs:
             raise AttributeError(
                 f"'{self.__class__.__name__}' does not delegate attribute {key}"
@@ -79,6 +68,14 @@ class DelegateAttributes:
                     return getattr(obj, key)
             except AttributeError:
                 pass
+
+        # ``inspect.getattr_static`` is comparatively expensive. Keep it as a
+        # fallback only when delegation did not resolve ``key``.
+        descriptor = inspect.getattr_static(type(self), key, None)
+        if descriptor is not None and hasattr(descriptor, "__get__") and (
+            hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__")
+        ):
+            return descriptor.__get__(self, type(self))
 
         raise AttributeError(
             f"'{self.__class__.__name__}' object and its delegates have no attribute '{key}'"

--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -72,8 +72,10 @@ class DelegateAttributes:
         # ``inspect.getattr_static`` is comparatively expensive. Keep it as a
         # fallback only when delegation did not resolve ``key``.
         descriptor = inspect.getattr_static(type(self), key, None)
-        if descriptor is not None and hasattr(descriptor, "__get__") and (
-            hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__")
+        if (
+            descriptor is not None
+            and hasattr(descriptor, "__get__")
+            and (hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__"))
         ):
             return descriptor.__get__(self, type(self))
 

--- a/tests/helpers/test_delegate_attribues.py
+++ b/tests/helpers/test_delegate_attribues.py
@@ -180,3 +180,58 @@ def test_delegate_both() -> None:
     # all appropriate items are in dir() exactly once
     for attr in ["rock", "paper", "scissors", "year", "water"]:
         assert dir(tb).count(attr) == 1
+
+
+def test_faulty_property_surfaces_original_attribute_error() -> None:
+    """A ``@property`` whose getter raises ``AttributeError`` should surface
+    the *inner* error instead of being masked by the generic
+    ``DelegateAttributes.__getattr__`` fallback.
+    """
+
+    class WithFaultyProperty(DelegateAttributes):
+        @property
+        def prop(self) -> int:
+            # ``missing`` does not exist; accessing it raises AttributeError.
+            # Before this fix, Python fell through to ``__getattr__`` which
+            # reported "no attribute 'prop'" and hid the real cause.
+            return self.missing  # type: ignore[attr-defined]
+
+    obj = WithFaultyProperty()
+    with pytest.raises(AttributeError, match="missing"):
+        obj.prop
+
+
+def test_faulty_property_preserves_inner_traceback() -> None:
+    """The traceback of the surfaced error must include the line inside the
+    property's getter that actually raised, so downstream debugging is
+    possible.
+    """
+
+    class WithFaultyProperty(DelegateAttributes):
+        @property
+        def prop(self) -> int:
+            raise AttributeError("specific underlying failure")
+
+    obj = WithFaultyProperty()
+    with pytest.raises(AttributeError, match="specific underlying failure"):
+        obj.prop
+
+
+def test_working_property_still_returns_value() -> None:
+    """Re-invocation of a descriptor from ``__getattr__`` must never happen for
+    a well-behaved ``@property`` — normal attribute lookup should resolve the
+    value directly without touching ``__getattr__`` at all.
+    """
+
+    call_count = 0
+
+    class WithWorkingProperty(DelegateAttributes):
+        @property
+        def prop(self) -> int:
+            nonlocal call_count
+            call_count += 1
+            return 42
+
+    obj = WithWorkingProperty()
+    assert obj.prop == 42
+    assert call_count == 1

--- a/tests/helpers/test_delegate_attribues.py
+++ b/tests/helpers/test_delegate_attribues.py
@@ -213,9 +213,7 @@ def test_faulty_property_preserves_inner_traceback() -> None:
             raise AttributeError("specific underlying failure")
 
     obj = WithFaultyProperty()
-    with pytest.raises(
-        AttributeError, match="specific underlying failure"
-    ) as excinfo:
+    with pytest.raises(AttributeError, match="specific underlying failure") as excinfo:
         obj.prop
     assert any(entry.name == "prop" for entry in excinfo.traceback)
 

--- a/tests/helpers/test_delegate_attribues.py
+++ b/tests/helpers/test_delegate_attribues.py
@@ -213,8 +213,11 @@ def test_faulty_property_preserves_inner_traceback() -> None:
             raise AttributeError("specific underlying failure")
 
     obj = WithFaultyProperty()
-    with pytest.raises(AttributeError, match="specific underlying failure"):
+    with pytest.raises(
+        AttributeError, match="specific underlying failure"
+    ) as excinfo:
         obj.prop
+    assert any(entry.name == "prop" for entry in excinfo.traceback)
 
 
 def test_working_property_still_returns_value() -> None:


### PR DESCRIPTION
## Summary

Closes #5518.

When a ``@property`` defined on a subclass of ``DelegateAttributes`` — such as any ``qcodes.Instrument`` — raises ``AttributeError`` from its getter, Python treats the getter failure as a missing attribute and falls through to ``DelegateAttributes.__getattr__``. The generic "object and its delegates have no attribute X" error then completely masks the real cause and its traceback, which is extremely cumbersome to debug.

### Reproducer (before this PR)

```python
class Foo(qcodes.Instrument):
    @property
    def foo(self):
        return self.bar

Foo("f").foo
# AttributeError: 'Foo' object and its delegates have no attribute 'foo'
# Traceback points only to attribute_helpers.py; no reference to self.bar.
```

### After this PR

The traceback walks through the property getter and points at ``self.bar``, with the underlying "no attribute 'bar'" error preserved.

### Approach

``__getattr__`` is only called when normal attribute lookup has been exhausted, which for a data descriptor (``@property``) can only mean the descriptor's own ``__get__`` raised ``AttributeError``. Before running the delegate fallback, the method now checks the class for a data descriptor under the requested key (``__get__`` plus ``__set__`` or ``__delete__``) and, if found, re-invokes it directly so the descriptor's original error propagates with its traceback intact.

Normal lookups of working properties are untouched because Python resolves them before ``__getattr__`` runs — the test ``test_working_property_still_returns_value`` pins that the descriptor is invoked exactly once.

### Changes

- ``src/qcodes/utils/attribute_helpers.py``: detect data descriptors and re-invoke them to surface the original error.
- ``tests/helpers/test_delegate_attribues.py``: three regression tests covering the faulty-property, custom-error, and happy-path cases.
- Added a newsfragment.

## Test plan

- [x] ``pytest tests/helpers/test_delegate_attribues.py`` — 8 passed locally (5 existing + 3 new).
- [x] ``pytest tests/test_instrument.py tests/helpers/ tests/test_channels.py`` — 118 passed.
- [x] ``pytest tests/parameter/`` — 872 passed.
- [x] Manually reproduced the issue's scenario and confirmed the traceback now surfaces ``self.bar``.