### PR TITLE
Add calibration due date to Keithley save_calibration util func

### DIFF
--- a/docs/changes/newsfragments/8040.improved
+++ b/docs/changes/newsfragments/8040.improved
@@ -1,0 +1,1 @@
+Added calibration due date to Keithley calibration utility functions.

--- a/src/qcodes/calibrations/keithley.py
+++ b/src/qcodes/calibrations/keithley.py
@@ -28,8 +28,14 @@ def setup_dmm(dmm: Instrument) -> None:
 
 def save_calibration(smu: Keithley26xx) -> None:
     calibration_date = int(time.time())
+    one_year_in_seconds = 31536000
+
     for smu_channel in smu.channels:
         smu.write(f"{smu_channel.channel}.cal.adjustdate = {calibration_date}")
+        smu.write(f"{smu_channel.channel}.cal.date = {calibration_date}")
+        smu.write(
+            f"{smu_channel.channel}.cal.due = {calibration_date + one_year_in_seconds}"
+        )
         smu.write(f"{smu_channel.channel}.cal.save()")
 
 

--- a/src/qcodes/calibrations/keithley.py
+++ b/src/qcodes/calibrations/keithley.py
@@ -26,15 +26,28 @@ def setup_dmm(dmm: Instrument) -> None:
     dmm.autorange("OFF")
 
 
-def save_calibration(smu: Keithley26xx) -> None:
+def save_calibration(
+    smu: Keithley26xx, calibration_due_in_years_from_today: float = 1.0
+) -> None:
+    """Saves calibration for Keithley 2600 SMUs and sets a calibration due date
+    based on years.
+
+    Args:
+        smu: Keithley 2600 SMU
+        calibration_due_in_years_from_today: Period added to current date, used to set due date. Defaults to 1.0.
+
+    """
     calibration_date = int(time.time())
-    one_year_in_seconds = 31536000
+    ONE_YEAR_IN_SECONDS = 31536000
+    recalibration_due_period = int(
+        ONE_YEAR_IN_SECONDS * calibration_due_in_years_from_today
+    )
 
     for smu_channel in smu.channels:
         smu.write(f"{smu_channel.channel}.cal.adjustdate = {calibration_date}")
         smu.write(f"{smu_channel.channel}.cal.date = {calibration_date}")
         smu.write(
-            f"{smu_channel.channel}.cal.due = {calibration_date + one_year_in_seconds}"
+            f"{smu_channel.channel}.cal.due = {calibration_date + recalibration_due_period}"
         )
         smu.write(f"{smu_channel.channel}.cal.save()")
 
@@ -45,6 +58,7 @@ def calibrate_keithley_smu_v(
     src_Z: float = 1e-30,
     time_delay: float = 3.0,
     save_calibrations: bool = False,
+    calibration_due_in_years_from_today: float = 1.0,
     dmm_range_per_smu_range_mapping: dict[str, float] | None = None,
 ) -> None:
     if dmm_range_per_smu_range_mapping is None:
@@ -76,7 +90,9 @@ def calibrate_keithley_smu_v(
             )
 
     if save_calibrations:
-        save_calibration(smu)
+        save_calibration(
+            smu, calibration_due_in_years_from_today=calibration_due_in_years_from_today
+        )
 
 
 def calibrate_keithley_smu_v_single(


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
Added calibration due date to Keithley calibration utility function `save_calibration`.