### PR TITLE
fix(utils): catch TypeError from inapplicable descriptors in DelegateAttributes

### DIFF
--- a/src/qcodes/utils/attribute_helpers.py
+++ b/src/qcodes/utils/attribute_helpers.py
@@ -77,7 +77,13 @@ class DelegateAttributes:
             and hasattr(descriptor, "__get__")
             and (hasattr(descriptor, "__set__") or hasattr(descriptor, "__delete__"))
         ):
-            return descriptor.__get__(self, type(self))
+            try:
+                return descriptor.__get__(self, type(self))
+            except TypeError:
+                # Descriptor may not be applicable to this type, e.g.
+                # type.__name__ found via the MRO but invoked on a
+                # non-type instance.
+                pass
 
         raise AttributeError(
             f"'{self.__class__.__name__}' object and its delegates have no attribute '{key}'"

--- a/tests/helpers/test_delegate_attribues.py
+++ b/tests/helpers/test_delegate_attribues.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import ClassVar
 
 import pytest
@@ -216,6 +217,32 @@ def test_faulty_property_preserves_inner_traceback() -> None:
     with pytest.raises(AttributeError, match="specific underlying failure") as excinfo:
         obj.prop
     assert any(entry.name == "prop" for entry in excinfo.traceback)
+
+
+def test_inapplicable_descriptor_does_not_raise_type_error() -> None:
+    """Descriptors found via the MRO that are not applicable to the instance
+    (e.g. ``type.__name__`` invoked on a non-type object) must not leak a
+    ``TypeError`` out of ``__getattr__``.  Instead they should be skipped so
+    that the normal ``AttributeError`` is raised.
+
+    Regression test for a bug where ``inspect.iscoroutinefunction`` triggered
+    ``getattr(obj, '__name__', None)`` and the descriptor introspection in
+    ``__getattr__`` called ``type.__name__.__get__`` on a non-type instance.
+    """
+
+    class Plain(DelegateAttributes):
+        delegate_attr_objects: ClassVar[list[str]] = []
+
+    obj = Plain()
+
+    # ``__name__`` is not defined on ``Plain`` instances, so accessing it
+    # should raise ``AttributeError``, never ``TypeError``.
+    with pytest.raises(AttributeError):
+        obj.__name__  # type: ignore[attr-defined]
+
+    # ``inspect.iscoroutinefunction`` internally does
+    # ``getattr(obj, '__name__', None)`` — this must not raise.
+    assert inspect.iscoroutinefunction(obj) is False
 
 
 def test_working_property_still_returns_value() -> None:


### PR DESCRIPTION
The descriptor introspection added in #8039 can find descriptors via the MRO that are not applicable to the current instance (e.g. `type.__name__` invoked on a non-type object). This causes a TypeError when Python's inspect module calls `getattr(obj, '__name__', None)` on DelegateAttributes subclasses like GetLatest.

Catch TypeError in the descriptor `__get__` call so that inapplicable descriptors fall through to the normal AttributeError path.
