### PR TITLE
fix(dataset): handle plot for dataset with incorrect parameter data

### DIFF
--- a/docs/changes/newsfragments/8080.improved
+++ b/docs/changes/newsfragments/8080.improved
@@ -1,0 +1,1 @@
+Fixed ``_get_data_from_ds`` to correctly handle datasets with incorrect multi-index structure during export by adding a fallback data lookup.

--- a/src/qcodes/dataset/data_export.py
+++ b/src/qcodes/dataset/data_export.py
@@ -50,6 +50,8 @@ def _get_data_from_ds(ds: DataSetProtocol) -> list[list[DSPlotData]]:
                 data = data_dict[param_spec_base.name]
             elif param_spec_base.name in all_data:
                 data = all_data[param_spec_base.name]
+                if param_spec_base.name in data:
+                    data = all_data[param_spec_base.name][param_spec_base.name]
             else:
                 raise KeyError(
                     f"Data for parameter {param_spec_base.name} not found in dataset cache"

--- a/src/qcodes/dataset/data_export.py
+++ b/src/qcodes/dataset/data_export.py
@@ -46,11 +46,19 @@ def _get_data_from_ds(ds: DataSetProtocol) -> list[list[DSPlotData]]:
         dependencies = ds.description.interdeps.dependencies[dependent]
 
         for param_spec_base in (*dependencies, dependent):
+            if param_spec_base.name in data_dict:
+                data = data_dict[param_spec_base.name]
+            elif param_spec_base.name in all_data:
+                data = all_data[param_spec_base.name]
+            else:
+                raise KeyError(
+                    f"Data for parameter {param_spec_base.name} not found in dataset cache"
+                )
             my_data_dict: DSPlotData = {
                 "name": param_spec_base.name,
                 "unit": param_spec_base.unit,
                 "label": param_spec_base.label,
-                "data": data_dict[param_spec_base.name],
+                "data": data,
                 "shape": None,
             }
             data_dicts_list.append(my_data_dict)

--- a/src/qcodes/dataset/data_export.py
+++ b/src/qcodes/dataset/data_export.py
@@ -49,9 +49,7 @@ def _get_data_from_ds(ds: DataSetProtocol) -> list[list[DSPlotData]]:
             if param_spec_base.name in data_dict:
                 data = data_dict[param_spec_base.name]
             elif param_spec_base.name in all_data:
-                data = all_data[param_spec_base.name]
-                if param_spec_base.name in data:
-                    data = all_data[param_spec_base.name][param_spec_base.name]
+                data = all_data[param_spec_base.name][param_spec_base.name]
             else:
                 raise KeyError(
                     f"Data for parameter {param_spec_base.name} not found in dataset cache"

--- a/tests/dataset/test__get_data_from_ds.py
+++ b/tests/dataset/test__get_data_from_ds.py
@@ -5,7 +5,11 @@ from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose
 
 from qcodes.dataset.data_export import _get_data_from_ds
+from qcodes.dataset.data_set_in_memory import DataSetInMem
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
+from qcodes.dataset.exporters.export_to_xarray import (
+    xarray_to_h5netcdf_with_complex_numbers,
+)
 from qcodes.dataset.measurements import Measurement
 from qcodes.parameters import ManualParameter, ParamSpecBase
 
@@ -323,3 +327,62 @@ def test_datasaver_multidim_numeric(experiment, bg_writing) -> None:
             assert_allclose(datadict["data"], expected_data)
 
             assert datadict["data"].shape == (size1 * size2,)
+
+
+def test_get_data_from_ds_non_unique_setpoint_after_netcdf_reload(
+    experiment, tmp_path
+) -> None:
+    """
+    Test that _get_data_from_ds works on a dataset reloaded from netcdf when
+    the setpoint values are not unique (e.g. a sweep that doubles back).
+
+    Non-unique setpoints cause the xarray export to use
+    ``df.reset_index().to_xarray()``, which makes both the setpoint and the
+    dependent parameter appear as top-level data_vars under an integer
+    ``index`` dimension.  After reloading, ``cache.data()`` therefore has
+    structure::
+
+        {
+            'setpoint': {'setpoint': array, 'index': array},
+            'dep':      {'dep':      array, 'index': array},
+        }
+
+    while ``interdeps`` still correctly records ``dep -> (setpoint,)``.  The
+    old code would raise ``KeyError`` because ``setpoint`` was not found
+    inside the ``dep`` sub-dict; the fix falls back to ``all_data``.
+    """
+    setpoint = ManualParameter("setpoint")
+    dep = ManualParameter("dep")
+
+    meas = Measurement(experiment)
+    meas.register_parameter(setpoint, paramtype="numeric")
+    meas.register_parameter(dep, setpoints=[setpoint], paramtype="numeric")
+
+    # Non-unique setpoint: sweep forward then back, 0.5 appears twice
+    setpoint_values = np.array([0.0, 0.5, 1.0, 0.5, 0.0])
+    dep_values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    with meas.run(write_in_background=False) as datasaver:
+        for s, d in zip(setpoint_values, dep_values):
+            datasaver.add_result((setpoint, s), (dep, d))
+
+    dataset = datasaver.dataset
+
+    # Export to netcdf (non-unique setpoint → df.reset_index().to_xarray())
+    xarr = dataset.to_xarray_dataset()
+    file_path = tmp_path / "test_non_unique.nc"
+    xarray_to_h5netcdf_with_complex_numbers(xarr, file_path)
+
+    # Reload: cache has 'setpoint' and 'dep' as separate top-level keys
+    # with 'index' coords, but interdeps still records dep -> (setpoint,)
+    loaded_ds = DataSetInMem._load_from_netcdf(file_path)
+
+    # This must not raise a KeyError
+    datadicts = _get_data_from_ds(loaded_ds)
+
+    # One dependent parameter -> one outer list
+    assert len(datadicts) == 1
+    result = {d["name"]: d for d in datadicts[0]}
+
+    assert "dep" in result
+    assert_allclose(result["dep"]["data"], dep_values)


### PR DESCRIPTION
This PR modifies `plot_dataset` to handle dataset with incorrect parameter data.

When dataset is somehow exported incorrectly, such that `get_parameter_data` shows setpoints and dependent params as
```python
{
  "dep": {"dep": [...], "index": [...]}, 
  "setpoint": {"setpoint": [...], "index": [...]}, 
}
```
instead of
```python
{"dep" {"dep": [...], "setpoint": [...]}}
```
`plot_dataset` function previously throws a `KeyError`.
(Specifically, we see this when a dataset with unsorted setpoint was exported to netcdf with flag `use_multi_index="always"`.)


<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->


