### PR TITLE
Convert to PEP 695 type parameters and deprecate removed TypeVars + type aliases 

### DIFF
--- a/docs/changes/newsfragments/8096.breaking
+++ b/docs/changes/newsfragments/8096.breaking
@@ -1,3 +1,3 @@
-Several module-level ``TypeVar`` definitions that are no longer used internally have been
-deprecated. Importing them will emit a ``QCoDeSDeprecationWarning``. They will be removed
-in a future version.
+Several module-level ``TypeVar`` definitions and type aliases that are no longer used
+internally have been deprecated. Importing them will emit a ``QCoDeSDeprecationWarning``.
+They will be removed in a future version.

--- a/docs/changes/newsfragments/8096.breaking
+++ b/docs/changes/newsfragments/8096.breaking
@@ -1,0 +1,3 @@
+Several module-level ``TypeVar`` definitions that are no longer used internally have been
+deprecated. Importing them will emit a ``QCoDeSDeprecationWarning``. They will be removed
+in a future version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ select = [
 # it may be worth fixing some or these in the future
 # PYI036 disable until https://github.com/astral-sh/ruff/issues/9794 is fixed
 # UP040, UP046, UP047: PEP 695 type param conversions deferred — TypeVars use default/covariant features
-ignore = ["E501", "G004", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "PYI036", "UP040"]
+ignore = ["E501", "G004", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "PYI036"]
 
 # we want to explicitly use the micro symbol
 # not the greek letter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ select = [
 # it may be worth fixing some or these in the future
 # PYI036 disable until https://github.com/astral-sh/ruff/issues/9794 is fixed
 # UP040, UP046, UP047: PEP 695 type param conversions deferred — TypeVars use default/covariant features
-ignore = ["E501", "G004", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "PYI036", "UP040", "UP046", "UP047"]
+ignore = ["E501", "G004", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "PYI036", "UP040"]
 
 # we want to explicitly use the micro symbol
 # not the greek letter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,6 @@ select = [
 # PLxxxx are pylint lints that generate a fair amount of warnings
 # it may be worth fixing some or these in the future
 # PYI036 disable until https://github.com/astral-sh/ruff/issues/9794 is fixed
-# UP040, UP046, UP047: PEP 695 type param conversions deferred — TypeVars use default/covariant features
 ignore = ["E501", "G004", "PLR2004", "PLR0913", "PLR0911", "PLR0912", "PLR0915", "PLW0602", "PLW0603", "PLW2901", "PYI036"]
 
 # we want to explicitly use the micro symbol

--- a/src/qcodes/dataset/data_set_cache.py
+++ b/src/qcodes/dataset/data_set_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -34,12 +34,10 @@ if TYPE_CHECKING:
     from .data_set_in_memory import DataSetInMem
     from .data_set_protocol import DataSetProtocol, ParameterData
 
-DatasetType_co = TypeVar("DatasetType_co", bound="DataSetProtocol", covariant=True)
-
 log = logging.getLogger(__name__)
 
 
-class DataSetCache(Generic[DatasetType_co]):
+class DataSetCache[DatasetType_co: "DataSetProtocol"]:
     """
     The DataSetCache contains a in memory representation of the
     data in this dataset as well a a method to progressively read data
@@ -572,3 +570,15 @@ class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
         )
         if not data_not_read:
             self._live = False
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "DatasetType_co": TypeVar(
+            "DatasetType_co", bound="DataSetProtocol", covariant=True
+        ),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -51,17 +51,15 @@ if TYPE_CHECKING:
 # twice here convert to set to ensure no duplication.
 _EXPORT_CALLBACKS = set(entry_points(group="qcodes.dataset.on_export"))
 
-ScalarResTypes: TypeAlias = (
-    str | complex | np.integer | np.floating | np.complexfloating
-)
-ValuesType: TypeAlias = (
+type ScalarResTypes = str | complex | np.integer | np.floating | np.complexfloating
+type ValuesType = (
     ScalarResTypes
     | npt.NDArray
     | Sequence[ScalarResTypes]
     | Sequence[Sequence[ScalarResTypes]]
 )
-ResType: TypeAlias = "tuple[ParameterBase | str, ValuesType]"
-SetpointsType: TypeAlias = "Sequence[str | ParameterBase]"
+type ResType = "tuple[ParameterBase | str, ValuesType]"
+type SetpointsType = "Sequence[str | ParameterBase]"
 
 # deprecated alias left for backwards compatibility
 array_like_types = (tuple, list, npt.NDArray)
@@ -71,12 +69,12 @@ res_type: TypeAlias = ResType  # noqa PYI042
 setpoints_type: TypeAlias = SetpointsType  # noqa PYI042
 
 
-SPECS: TypeAlias = list[ParamSpec]
+type SPECS = list[ParamSpec]
 # Transition period type: SpecsOrInterDeps. We will allow both as input to
 # the DataSet constructor for a while, then deprecate SPECS and finally remove
 # the ParamSpec class
-SpecsOrInterDeps: TypeAlias = SPECS | InterDependencies_
-ParameterData: TypeAlias = dict[str, dict[str, npt.NDArray]]
+type SpecsOrInterDeps = SPECS | InterDependencies_
+type ParameterData = dict[str, dict[str, npt.NDArray]]
 
 LOG = logging.getLogger(__name__)
 

--- a/src/qcodes/dataset/data_set_protocol.py
+++ b/src/qcodes/dataset/data_set_protocol.py
@@ -34,8 +34,6 @@ from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
 from .sqlite.queries import raw_time_to_str_time
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     import pandas as pd
     import xarray as xr
 
@@ -60,13 +58,6 @@ type ValuesType = (
 )
 type ResType = "tuple[ParameterBase | str, ValuesType]"
 type SetpointsType = "Sequence[str | ParameterBase]"
-
-# deprecated alias left for backwards compatibility
-array_like_types = (tuple, list, npt.NDArray)
-scalar_res_types: TypeAlias = ScalarResTypes  # noqa PYI042
-values_type: TypeAlias = ValuesType  # noqa PYI042
-res_type: TypeAlias = ResType  # noqa PYI042
-setpoints_type: TypeAlias = SetpointsType  # noqa PYI042
 
 
 type SPECS = list[ParamSpec]
@@ -548,3 +539,18 @@ class BaseDataSet(DataSetProtocol, Protocol):
 class DataSetType(StrEnum):
     DataSet = "DataSet"
     DataSetInMem = "DataSetInMem"
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "array_like_types": (tuple, list, npt.NDArray),
+            "scalar_res_types": ScalarResTypes,
+            "values_type": ValuesType,
+            "res_type": ResType,
+            "setpoints_type": SetpointsType,
+        },
+    )

--- a/src/qcodes/dataset/dond/sweeps.py
+++ b/src/qcodes/dataset/dond/sweeps.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -12,10 +12,8 @@ if TYPE_CHECKING:
     from qcodes.dataset.dond.do_nd_utils import ActionsT
     from qcodes.parameters import ParameterBase
 
-T = TypeVar("T", bound=np.generic)
 
-
-class AbstractSweep(ABC, Generic[T]):
+class AbstractSweep[T: np.generic](ABC):
     """
     Abstract sweep class that defines an interface for concrete sweep classes.
     """
@@ -195,7 +193,7 @@ class LogSweep(AbstractSweep[np.floating]):
         return self._get_after_set
 
 
-class ArraySweep(AbstractSweep, Generic[T]):
+class ArraySweep[T: np.generic](AbstractSweep):
     """
     Sweep the values of a given array.
 
@@ -281,3 +279,13 @@ class TogetherSweep:
     @property
     def num_points(self) -> int:
         return self.sweeps[0].num_points
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T", bound=np.generic),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/dataset/measurements.py
+++ b/src/qcodes/dataset/measurements.py
@@ -18,7 +18,7 @@ from inspect import signature
 from itertools import chain
 from numbers import Number
 from time import perf_counter, perf_counter_ns
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -802,9 +802,6 @@ class Runner:
             if isinstance(self.ds, DataSet):
                 self.ds.unsubscribe_all()
             self._exit_stack.close()
-
-
-T = TypeVar("T", bound="Measurement")
 
 
 class Measurement:
@@ -1616,3 +1613,16 @@ def _numeric_values_are_equal(
         ):
             return False
     return True
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T", bound="Measurement"),
+        },
+    )

--- a/src/qcodes/dataset/measurements.py
+++ b/src/qcodes/dataset/measurements.py
@@ -18,7 +18,7 @@ from inspect import signature
 from itertools import chain
 from numbers import Number
 from time import perf_counter, perf_counter_ns
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -74,8 +74,8 @@ SubscriberType = tuple[
     Callable[..., Any], MutableSequence[Any] | MutableMapping[Any, Any]
 ]
 
-ParameterResultType: TypeAlias = tuple[ParameterBase, ValuesType]
-DatasetResultDict: TypeAlias = dict[ParamSpecBase, npt.NDArray]
+type ParameterResultType = tuple[ParameterBase, ValuesType]
+type DatasetResultDict = dict[ParamSpecBase, npt.NDArray]
 
 
 class ParameterTypeError(Exception):

--- a/src/qcodes/dataset/threading.py
+++ b/src/qcodes/dataset/threading.py
@@ -9,7 +9,7 @@ import itertools
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import TYPE_CHECKING, Protocol, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Protocol, TypeVar
 
 from qcodes.utils import RespondingThread
 
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     from qcodes.dataset.data_set_protocol import ValuesType
     from qcodes.parameters import ParamDataType, ParameterBase
 
-ParamMeasT: TypeAlias = "ParameterBase | Callable[[], None]"
-OutType: TypeAlias = "list[tuple[ParameterBase, ValuesType]]"
+type ParamMeasT = "ParameterBase | Callable[[], None]"
+type OutType = "list[tuple[ParameterBase, ValuesType]]"
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/qcodes/dataset/threading.py
+++ b/src/qcodes/dataset/threading.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 ParamMeasT: TypeAlias = "ParameterBase | Callable[[], None]"
 OutType: TypeAlias = "list[tuple[ParameterBase, ValuesType]]"
 
-T = TypeVar("T")
-
 _LOG = logging.getLogger(__name__)
 
 
@@ -221,3 +219,13 @@ class ThreadPoolParamsCaller(_ParamsCallerProtocol):
         exc_tb: TracebackType | None,
     ) -> None:
         self._thread_pool.__exit__(exc_type, exc_val, exc_tb)
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/extensions/_driver_test_case.py
+++ b/src/qcodes/extensions/_driver_test_case.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from qcodes.instrument import Instrument
@@ -25,10 +25,7 @@ Using `DriverTestCase` is pretty easy:
 """
 
 
-T = TypeVar("T", bound="Instrument")
-
-
-class DriverTestCase(unittest.TestCase, Generic[T]):
+class DriverTestCase[T: "Instrument"](unittest.TestCase):
     # override this in a subclass
     driver: type[T] | None = None
     instrument: T

--- a/src/qcodes/extensions/infer.py
+++ b/src/qcodes/extensions/infer.py
@@ -11,9 +11,6 @@ if TYPE_CHECKING:
 
 DOES_NOT_EXIST = "Does not exist"
 
-C = TypeVar("C", bound=ParameterBase)
-TInstrument = TypeVar("TInstrument", bound=InstrumentBase)
-
 
 class InferError(AttributeError): ...
 
@@ -225,7 +222,7 @@ def _merge_user_and_class_attrs(
         return set.union(set(alt_source_attrs), set(InferAttrs.known_attrs()))
 
 
-def get_chain_links_of_type(
+def get_chain_links_of_type[C: ParameterBase](
     link_param_type: type[C] | tuple[type[C], ...], parameter: Parameter
 ) -> tuple[C, ...]:
     """Gets all parameters in a chain of linked parameters that match a given type"""
@@ -237,7 +234,7 @@ def get_chain_links_of_type(
     return tuple(chain_links)
 
 
-def get_sole_chain_link_of_type(
+def get_sole_chain_link_of_type[C: ParameterBase](
     link_param_type: type[C] | tuple[type[C], ...], parameter: Parameter
 ) -> C:
     """Gets the one parameter in a chain of linked parameters that matches a given type"""
@@ -256,7 +253,7 @@ def get_sole_chain_link_of_type(
     return chain_links[0]
 
 
-def get_parent_instruments_from_chain_of_type(
+def get_parent_instruments_from_chain_of_type[TInstrument: InstrumentBase](
     instrument_type: type[TInstrument] | tuple[type[TInstrument], ...],
     parameter: Parameter,
 ) -> tuple[TInstrument, ...]:
@@ -272,7 +269,7 @@ def get_parent_instruments_from_chain_of_type(
     )
 
 
-def get_sole_parent_instrument_from_chain_of_type(
+def get_sole_parent_instrument_from_chain_of_type[TInstrument: InstrumentBase](
     instrument_type: type[TInstrument] | tuple[type[TInstrument], ...],
     parameter: Parameter,
 ) -> TInstrument:
@@ -289,3 +286,14 @@ def get_sole_parent_instrument_from_chain_of_type(
 
         raise ValueError(f"{error_msg_1} {[instr.name for instr in instruments]}")
     return instruments[0]
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "C": TypeVar("C", bound=ParameterBase),
+        "TInstrument": TypeVar("TInstrument", bound=InstrumentBase),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/extensions/parameters/parameter_mixin.py
+++ b/src/qcodes/extensions/parameters/parameter_mixin.py
@@ -24,11 +24,9 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Any, ClassVar, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from qcodes.parameters import ParameterBase
-
-T = TypeVar("T")
 
 log = logging.getLogger(__name__)
 
@@ -245,7 +243,7 @@ class ParameterMixin:
         cls.__doc__ = (original_doc.strip() + "\n\n" + additional_doc).strip()
 
     @classmethod
-    def _get_leaf_classes(
+    def _get_leaf_classes[T](
         cls, base_type: type[T], exclude_base_type: type | None = None
     ) -> list[type[T]]:
         """
@@ -289,7 +287,7 @@ class ParameterMixin:
         return leaf_classes
 
     @classmethod
-    def _get_mixin_classes(
+    def _get_mixin_classes[T](
         cls, base_type: type[T], exclude_base_type: type | None = None
     ) -> list[type[T]]:
         """
@@ -321,3 +319,16 @@ class ParameterMixin:
             ]
 
         return mixin_classes
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T"),
+        },
+    )

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -15,7 +15,6 @@ from qcodes.parameters import (
     MultiParameter,
     Parameter,
 )
-from qcodes.parameters.multi_channel_instrument_parameter import InstrumentModuleType
 from qcodes.utils import full_class
 from qcodes.validators import Validator
 
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
     from .instrument_base import InstrumentBaseKWArgs
 
 
+# Cannot convert to PEP 695: uses default= and covariant= which require PEP 696 (Python 3.13+).
 _TIB_co = TypeVar(
     "_TIB_co", bound="InstrumentBase", default=InstrumentBase, covariant=True
 )
@@ -98,10 +98,7 @@ class InstrumentChannel(InstrumentModule[_TIB_co], Generic[_TIB_co]):
     pass
 
 
-T = TypeVar("T", bound="ChannelTuple")
-
-
-class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
+class ChannelTuple[InstrumentModuleType: "InstrumentModule"](MetadatableWithName, Sequence[InstrumentModuleType]):
     """
     Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.
@@ -628,7 +625,7 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
 
 # in index method the parameter obj should be called value but that would
 # be an incompatible change
-class ChannelList(  #  pyright: ignore[reportIncompatibleMethodOverride]
+class ChannelList[InstrumentModuleType: "InstrumentModule"](  #  pyright: ignore[reportIncompatibleMethodOverride]
     ChannelTuple[InstrumentModuleType], MutableSequence[InstrumentModuleType]
 ):
     """
@@ -1161,10 +1158,8 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
         return self._exists_on_instrument
 
 
-TAUTORELOADCHANNEL = TypeVar("TAUTORELOADCHANNEL", bound=AutoLoadableInstrumentChannel)
 
-
-class AutoLoadableChannelList(ChannelList[TAUTORELOADCHANNEL]):
+class AutoLoadableChannelList[TAUTORELOADCHANNEL: AutoLoadableInstrumentChannel](ChannelList[TAUTORELOADCHANNEL]):
     """
     Extends the QCoDeS :class:`ChannelList` class to add the following features:
     - Automatically create channel objects on initialization
@@ -1243,3 +1238,16 @@ class AutoLoadableChannelList(ChannelList[TAUTORELOADCHANNEL]):
 
         self.append(new_channel)
         return new_channel
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T", bound="ChannelTuple"),
+        "TAUTORELOADCHANNEL": TypeVar(
+            "TAUTORELOADCHANNEL", bound=AutoLoadableInstrumentChannel
+        ),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/instrument/channel.py
+++ b/src/qcodes/instrument/channel.py
@@ -98,7 +98,9 @@ class InstrumentChannel(InstrumentModule[_TIB_co], Generic[_TIB_co]):
     pass
 
 
-class ChannelTuple[InstrumentModuleType: "InstrumentModule"](MetadatableWithName, Sequence[InstrumentModuleType]):
+class ChannelTuple[InstrumentModuleType: "InstrumentModule"](
+    MetadatableWithName, Sequence[InstrumentModuleType]
+):
     """
     Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.
@@ -1158,8 +1160,9 @@ class AutoLoadableInstrumentChannel(InstrumentChannel):
         return self._exists_on_instrument
 
 
-
-class AutoLoadableChannelList[TAUTORELOADCHANNEL: AutoLoadableInstrumentChannel](ChannelList[TAUTORELOADCHANNEL]):
+class AutoLoadableChannelList[TAUTORELOADCHANNEL: AutoLoadableInstrumentChannel](
+    ChannelList[TAUTORELOADCHANNEL]
+):
     """
     Extends the QCoDeS :class:`ChannelList` class to add the following features:
     - Automatically create channel objects on initialization

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -459,7 +459,7 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
         )
 
 
-def find_or_create_instrument(
+def find_or_create_instrument[T: "Instrument"](
     instrument_class: type[T],
     name: str,
     *args: Any,

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -31,7 +31,6 @@ class InstrumentProtocol(Protocol):
     def write(self, cmd: str) -> None: ...
 
 
-
 # a metaclass that overrides __call__ means that we lose
 # both the args and return type hints.
 # Since our metaclass does not modify the signature
@@ -279,7 +278,9 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
 
     @overload
     @classmethod
-    def find_instrument[T: "Instrument"](cls, name: str, instrument_class: type[T]) -> T: ...
+    def find_instrument[T: "Instrument"](
+        cls, name: str, instrument_class: type[T]
+    ) -> T: ...
 
     @classmethod
     def find_instrument[T: "Instrument"](

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 import weakref
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Protocol, overload
 
 from qcodes.utils import strip_attrs
 from qcodes.validators import Anything
@@ -31,7 +31,6 @@ class InstrumentProtocol(Protocol):
     def write(self, cmd: str) -> None: ...
 
 
-T = TypeVar("T", bound="Instrument")
 
 # a metaclass that overrides __call__ means that we lose
 # both the args and return type hints.
@@ -280,10 +279,10 @@ class Instrument(InstrumentBase, metaclass=instrument_meta_class):
 
     @overload
     @classmethod
-    def find_instrument(cls, name: str, instrument_class: type[T]) -> T: ...
+    def find_instrument[T: "Instrument"](cls, name: str, instrument_class: type[T]) -> T: ...
 
     @classmethod
-    def find_instrument(
+    def find_instrument[T: "Instrument"](
         cls, name: str, instrument_class: type[T] | None = None
     ) -> T | Instrument:
         """
@@ -504,3 +503,16 @@ def find_or_create_instrument[T: "Instrument"](
             instrument.connect_message()  # prints the message
 
     return instrument
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T", bound="Instrument"),
+        },
+    )

--- a/src/qcodes/instrument/instrument_base.py
+++ b/src/qcodes/instrument/instrument_base.py
@@ -27,6 +27,7 @@ from qcodes.utils import QCoDeSDeprecationWarning
 
 log = logging.getLogger(__name__)
 
+# Cannot convert to PEP 695: uses default= which requires PEP 696 (Python 3.13+).
 TParameter = TypeVar("TParameter", bound="ParameterBase", default="Parameter")
 TSubmodule = TypeVar(
     "TSubmodule", bound="InstrumentModule | ChannelTuple", default="InstrumentModule"

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -6,7 +6,7 @@ import sys
 import time
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
     from typing import Unpack
 
 logger = logging.getLogger(__name__)
-
-OutputType = TypeVar("OutputType")
 
 CtypesTypes = (
     type[ctypes.c_uint8]
@@ -308,7 +306,7 @@ class AlazarTechATS(Instrument):
         )
         return buffer
 
-    def acquire(  # noqa: D417 (missing args documentation)
+    def acquire[OutputType](  # noqa: D417 (missing args documentation)
         self,
         mode: str | None = None,
         samples_per_record: int | None = None,
@@ -932,3 +930,16 @@ class AcquisitionController[OutputType](Instrument, AcquisitionInterface[Any]):
         :return: reference to the Alazar instrument
         """
         return self._alazar
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "OutputType": TypeVar("OutputType"),
+        },
+    )

--- a/src/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -6,7 +6,7 @@ import sys
 import time
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -827,7 +827,7 @@ class Buffer:
             )
 
 
-class AcquisitionInterface(Generic[OutputType]):
+class AcquisitionInterface[OutputType]:
     """
     This class represents all choices that the end-user has to make regarding
     the data-acquisition. this class should be subclassed to program these
@@ -903,7 +903,7 @@ class AcquisitionInterface(Generic[OutputType]):
         pass
 
 
-class AcquisitionController(Instrument, AcquisitionInterface[Any], Generic[OutputType]):
+class AcquisitionController[OutputType](Instrument, AcquisitionInterface[Any]):
     """
     Compatibility class. The methods of :class:`AcquisitionController`
     have been extracted. This class is the base class fro AcquisitionInterfaces

--- a/src/qcodes/instrument_drivers/AlazarTech/ats_api.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ats_api.py
@@ -6,7 +6,7 @@ of its C library in a python-friendly way.
 
 import ctypes
 from ctypes import POINTER
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Any, ClassVar
 
 # `ParameterBase` is needed because users may pass instrument parameters
 # that originate from `Instrument.parameters` dictionary which is typed
@@ -30,9 +30,9 @@ POINTER_c_uint32 = Any
 POINTER_c_long = Any
 
 
-IntOrParam: TypeAlias = "int | Parameter"
+type IntOrParam = "int | Parameter"
 # deprecated alias for backwards compatibility
-int_or_param: TypeAlias = IntOrParam  # noqa: PYI042
+type int_or_param = IntOrParam  # noqa: PYI042
 
 
 class AlazarATSAPI(WrappedDll):

--- a/src/qcodes/instrument_drivers/AlazarTech/ats_api.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/ats_api.py
@@ -31,8 +31,6 @@ POINTER_c_long = Any
 
 
 type IntOrParam = "int | Parameter"
-# deprecated alias for backwards compatibility
-type int_or_param = IntOrParam  # noqa: PYI042
 
 
 class AlazarATSAPI(WrappedDll):
@@ -667,3 +665,14 @@ class AlazarATSAPI(WrappedDll):
 
         """
         self.write_register(handle, offset, value, REGISTER_ACCESS_PASSWORD)
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "int_or_param": IntOrParam,
+        },
+    )

--- a/src/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -31,9 +31,6 @@ RETURN_CODE = NewType("RETURN_CODE", ctypes.c_uint)
 
 
 # FUNCTIONS #
-T = TypeVar("T")
-
-
 def _api_call_task(
     lock: Lock, c_func: Callable[..., int], callback: Callable[[], None], *args: Any
 ) -> int:
@@ -43,7 +40,7 @@ def _api_call_task(
     return retval
 
 
-def _normalize_params(*args: T) -> list[T]:
+def _normalize_params[T](*args: T) -> list[T]:
     args_out: list[T] = []
     for arg in args:
         if isinstance(arg, ParameterBase):
@@ -205,3 +202,13 @@ class WrappedDll(metaclass=DllWrapperMeta):
             *_normalize_params(*args),
         )
         return future.result()
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/instrument_drivers/AlazarTech/utils.py
+++ b/src/qcodes/instrument_drivers/AlazarTech/utils.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
 
 
 class TraceParameter(
-    Parameter[ParameterDataTypeVar, "AlazarTechATS"], Generic[ParameterDataTypeVar]
+    Parameter[ParameterDataTypeVar, "AlazarTechATS"],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     """
     A parameter that keeps track of if its value has been synced to

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_6500.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Bool, Enum, Ints, MultiType, Numbers
@@ -9,8 +9,6 @@ if TYPE_CHECKING:
     from typing import Unpack
 
     from qcodes.parameters import Parameter
-
-T = TypeVar("T")
 
 
 def _parse_output_string(string_value: str) -> str:
@@ -258,7 +256,7 @@ class Keithley6500(VisaInstrument):
     def _read_next_value(self) -> float:
         return float(self.ask("READ?"))
 
-    def _get_mode_param(self, parameter: str, parser: "Callable[[str], T]") -> T:
+    def _get_mode_param[T](self, parameter: str, parser: "Callable[[str], T]") -> T:
         """Reads the current mode of the multimeter and ask for the given parameter.
 
         Args:
@@ -287,3 +285,16 @@ class Keithley6500(VisaInstrument):
         mode = _parse_output_string(self._mode_map[self.mode()])
         cmd = f"{mode}:{parameter} {value}"
         self.write(cmd)
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T"),
+        },
+    )

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Unpack
 
+# Cannot convert to PEP 695: uses default= which requires PEP 696 (Python 3.13+).
 _T = TypeVar(
     "_T",
     bound="KeysightN9030BSpectrumAnalyzerMode | KeysightN9030BPhaseNoiseMode",

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
@@ -62,7 +62,10 @@ class FrequencyAxis(
 
 
 class Trace(
-    ParameterWithSetpoints[ParameterDataTypeVar, _T], Generic[ParameterDataTypeVar, _T]
+    ParameterWithSetpoints[ParameterDataTypeVar, _T],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, _T],  # noqa: UP046
 ):
     def __init__(
         self,

--- a/src/qcodes/instrument_drivers/Keysight/KtM960x.py
+++ b/src/qcodes/instrument_drivers/Keysight/KtM960x.py
@@ -19,7 +19,10 @@ if TYPE_CHECKING:
 
 
 class Measure(
-    MultiParameter[ParameterDataTypeVar, "KeysightM960x"], Generic[ParameterDataTypeVar]
+    MultiParameter[ParameterDataTypeVar, "KeysightM960x"],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     def __init__(self, name: str, instrument: "KeysightM960x") -> None:
         super().__init__(

--- a/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_34980a.py
@@ -2,9 +2,7 @@ import logging
 import re
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, TypeVar
-
-from typing_extensions import ParamSpec
+from typing import TYPE_CHECKING
 
 from qcodes import validators as vals
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
@@ -18,12 +16,8 @@ if TYPE_CHECKING:
 
 KEYSIGHT_MODELS = {"34934A": Keysight34934A}
 
-S = TypeVar("S", bound="Keysight34980A")
-P = ParamSpec("P")
-T = TypeVar("T")
 
-
-def post_execution_status_poll(
+def post_execution_status_poll[S: "Keysight34980A", T, **P](
     func: "Callable[Concatenate[S, P], T]",
 ) -> "Callable[Concatenate[S, P], T]":
     """
@@ -191,3 +185,20 @@ class Keysight34980A(VisaInstrument):
         else:
             vals.Ints(min_value=1, max_value=self._total_slot).validate(slot)
             self.write(f"ROUT:OPEN:ALL {slot}")
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "S": TypeVar("S", bound="Keysight34980A"),
+            "T": TypeVar("T"),
+            "P": ParamSpec("P"),
+        },
+    )

--- a/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysight_b220x.py
@@ -1,9 +1,7 @@
 import re
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, TypeVar
-
-from typing_extensions import ParamSpec
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
 from qcodes.validators import Enum, Ints, Lists, MultiType
@@ -15,12 +13,7 @@ if TYPE_CHECKING:
     from qcodes.parameters import Parameter
 
 
-S = TypeVar("S", bound="KeysightB220X")
-P = ParamSpec("P")
-T = TypeVar("T")
-
-
-def post_execution_status_poll(
+def post_execution_status_poll[S: "KeysightB220X", T, **P](
     func: "Callable[Concatenate[S, P], T]",
 ) -> "Callable[Concatenate[S, P], T]":
     """
@@ -447,3 +440,20 @@ class KeysightB2201(KeysightB220X):
     """
     QCodes driver for B2201
     """
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "S": TypeVar("S", bound="KeysightB220X"),
+            "T": TypeVar("T"),
+            "P": ParamSpec("P"),
+        },
+    )

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -499,7 +499,9 @@ class KeysightB1500(VisaInstrument):
 class IVSweepMeasurement(
     MultiParameter[ParameterDataTypeVar, KeysightB1500],
     StatusMixin,
-    Generic[ParameterDataTypeVar],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     """
     IV sweep measurement outputs a list of measured current parameters

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -697,7 +697,10 @@ class KeysightB1500IVSweeper(InstrumentChannel["KeysightB1517A"]):
 
 
 class _ParameterWithStatus(
-    Parameter[ParameterDataTypeVar, "KeysightB1517A"], Generic[ParameterDataTypeVar]
+    Parameter[ParameterDataTypeVar, "KeysightB1517A"],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -724,7 +727,10 @@ class _ParameterWithStatus(
 
 
 class _SpotMeasurementVoltageParameter(
-    _ParameterWithStatus[ParameterDataTypeVar], Generic[ParameterDataTypeVar]
+    _ParameterWithStatus[ParameterDataTypeVar],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     def set_raw(self, value: ParamRawDataType) -> None:
         smu = self.instrument
@@ -767,7 +773,10 @@ class _SpotMeasurementVoltageParameter(
 
 
 class _SpotMeasurementCurrentParameter(
-    _ParameterWithStatus[ParameterDataTypeVar], Generic[ParameterDataTypeVar]
+    _ParameterWithStatus[ParameterDataTypeVar],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     def set_raw(self, value: ParamRawDataType) -> None:
         smu = self.instrument

--- a/src/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
+++ b/src/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from operator import xor
-from typing import TYPE_CHECKING, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from . import constants
 
@@ -14,7 +14,6 @@ def as_csv(comps: "Iterable[object]", sep: str = ",") -> str:
 
 
 P = ParamSpec("P")
-T = TypeVar("T")
 
 
 def final_command(f: "Callable[P, MessageBuilder]") -> "Callable[P, MessageBuilder]":
@@ -28,7 +27,7 @@ def final_command(f: "Callable[P, MessageBuilder]") -> "Callable[P, MessageBuild
     return wrapper
 
 
-class CommandList(list[T], Generic[T]):
+class CommandList[T](list[T]):
     def __init__(self) -> None:
         super().__init__()
         self.is_final = False
@@ -3984,3 +3983,13 @@ class MessageBuilder:
 
         self._msg.append(cmd)
         return self
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/src/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -2,7 +2,7 @@ import textwrap
 from bisect import bisect_left
 from contextlib import ExitStack
 from functools import partial
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, get_args
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from typing import Unpack
 
-NumericScpiMnemonic: TypeAlias = Literal["MIN", "MAX", "DEF"]
+type NumericScpiMnemonic = Literal["MIN", "MAX", "DEF"]
 
 
 class Keysight344xxATrigger(InstrumentChannel["Keysight344xxA"]):

--- a/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -662,6 +662,7 @@ class LakeshoreBaseSensorChannel(InstrumentChannel):
         return terms_in_number
 
 
+# Cannot convert to PEP 695: uses default= and covariant= which require PEP 696 (Python 3.13+).
 ChanType_co = TypeVar(
     "ChanType_co",
     bound=LakeshoreBaseSensorChannel,

--- a/src/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
+++ b/src/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import (
     ChannelList,
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_TINSTR = TypeVar("_TINSTR", bound="MiniCircuitsSPDTBase")
 
-
-class MiniCircuitsSPDTSwitchChannelBase(InstrumentChannel[_TINSTR], Generic[_TINSTR]):
+class MiniCircuitsSPDTSwitchChannelBase[TINSTR: "MiniCircuitsSPDTBase"](
+    InstrumentChannel[TINSTR]
+):
     def __init__(
         self,
-        parent: _TINSTR,
+        parent: TINSTR,
         name: str,
         channel_letter: str,
         **kwargs: Unpack[InstrumentBaseKWArgs],

--- a/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
+++ b/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
     from qcodes.parameters import Parameter
 
+
 class DynaCool(VisaInstrument):
     """
     Class to represent the DynaCoolPPMS

--- a/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
+++ b/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
@@ -1,7 +1,7 @@
 import warnings
 from functools import partial
 from time import sleep
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 import numpy as np
 from pyvisa import VisaIOError
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
     from typing import Unpack
 
     from qcodes.parameters import Parameter
-
-_T = TypeVar("_T")
-
 
 class DynaCool(VisaInstrument):
     """
@@ -276,7 +273,7 @@ class DynaCool(VisaInstrument):
         return self._error_code
 
     @staticmethod
-    def _pick_one(which_one: int, parser: "Callable[[str], _T]", resp: str) -> _T:
+    def _pick_one[T](which_one: int, parser: "Callable[[str], T]", resp: str) -> T:
         """
         Since most of the API calls return several values in a comma-separated
         string, here's a convenience function to pick out the substring of

--- a/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/src/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -6,11 +6,10 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, cast
 
 import numpy as np
 from pyvisa import VisaIOError
-from typing_extensions import ParamSpec
 
 from qcodes.instrument import (
     Instrument,
@@ -32,10 +31,6 @@ log = logging.getLogger(__name__)
 
 CartesianFieldLimitFunction = Callable[[float, float, float], bool]
 
-S = TypeVar("S", bound="AMI430SwitchHeater")
-T = TypeVar("T")
-P = ParamSpec("P")
-
 
 class AMI430Exception(Exception):
     pass
@@ -48,7 +43,7 @@ class AMI430Warning(UserWarning):
 class AMI430SwitchHeater(InstrumentChannel["AMIModel430"]):
     class _Decorators:
         @classmethod
-        def check_enabled(
+        def check_enabled[S: "AMI430SwitchHeater", T, **P](
             cls, f: Callable[Concatenate[S, P], T]
         ) -> Callable[Concatenate[S, P], T]:
             def check_enabled_decorator(
@@ -1320,3 +1315,20 @@ class AMIModel4303D(Instrument):
         self._adjust_child_instruments(setpoint_values)
 
         self._set_point = set_point
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "S": TypeVar("S", bound="AMI430SwitchHeater"),
+            "T": TypeVar("T"),
+            "P": ParamSpec("P"),
+        },
+    )

--- a/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/src/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -947,7 +947,9 @@ class TektronixDPOTrigger(InstrumentChannel):
 
 class TektronixDPOMeasurementParameter(
     Parameter[ParameterDataTypeVar, "TektronixDPOMeasurement"],
-    Generic[ParameterDataTypeVar],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar],  # noqa: UP046
 ):
     """
     A measurement parameter does not only return the instantaneous value

--- a/src/qcodes/math_utils/field_vector.py
+++ b/src/qcodes/math_utils/field_vector.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 AllCoordsType = tuple[float, float, float, float, float, float, float]
 NormOrder = Literal["fro", "nuc"] | None | float
-T = TypeVar("T", bound="FieldVector")
 
 
 class FieldVector:
@@ -424,3 +423,13 @@ class FieldVector:
         # Thus, we start by rescaling such that s == 1.
         hvec /= hvec[-1]
         return cls(x=hvec[0], y=hvec[1], z=hvec[2])
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T", bound="FieldVector"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/parameters/array_parameter.py
+++ b/src/qcodes/parameters/array_parameter.py
@@ -48,7 +48,9 @@ except ImportError:
 
 class ArrayParameter(
     ParameterBase[ParameterDataTypeVar, InstrumentTypeVar_co],
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     A gettable parameter that returns an array of values.

--- a/src/qcodes/parameters/cache.py
+++ b/src/qcodes/parameters/cache.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol, overload
 
 from typing_extensions import TypeVar
 
-# due to circular imports we cannot import the TypeVar from parameter_base
+# Cannot convert to PEP 695: uses default= which requires PEP 696 (Python 3.13+).
+# Due to circular imports we cannot import the TypeVar from parameter_base.
 ParameterDataTypeVar = TypeVar("ParameterDataTypeVar", default=Any)
 
 if TYPE_CHECKING:

--- a/src/qcodes/parameters/command.py
+++ b/src/qcodes/parameters/command.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from qcodes.utils import is_function
 
@@ -12,11 +12,7 @@ class NoCommandError(Exception):
     pass
 
 
-Output = TypeVar("Output")
-ParsedOutput = TypeVar("ParsedOutput")
-
-
-class Command(Generic[Output, ParsedOutput]):
+class Command[Output, ParsedOutput]:
     """
     Create a callable command from a string or function.
 
@@ -211,3 +207,14 @@ class Command(Generic[Output, ParsedOutput]):
         if len(args) != self.arg_count:
             raise TypeError(f"command takes exactly {self.arg_count} args")
         return self.exec_function(*args)
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "Output": TypeVar("Output"),
+        "ParsedOutput": TypeVar("ParsedOutput"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -34,7 +34,9 @@ _SOURCE_UNSET: Any = object()
 
 class DelegateParameter(
     Parameter[ParameterDataTypeVar, InstrumentTypeVar_co],
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     The :class:`.DelegateParameter` wraps a given `source` :class:`Parameter`.

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
         ParamRawDataType,
     )
 
-# Generic type variables for inner cache class
-# these need to be different variables such that both classes can be generic
+# Cannot convert to PEP 695: uses default= which requires PEP 696 (Python 3.13+).
+# Generic type variables for inner cache class —
+# these need to be different variables such that both classes can be generic.
 _local_ParameterDataTypeVar = TypeVar("_local_ParameterDataTypeVar", default=Any)
 _local_InstrumentTypeVar_co = TypeVar(
     "_local_InstrumentTypeVar_co",

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .multi_parameter import MultiParameter
 
@@ -16,7 +16,9 @@ InstrumentModuleType = TypeVar("InstrumentModuleType", bound="InstrumentModule")
 _LOG = logging.getLogger(__name__)
 
 
-class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleType]):
+class MultiChannelInstrumentParameter[InstrumentModuleType: "InstrumentModule"](
+    MultiParameter
+):
     """
     Parameter to get or set multiple channels simultaneously.
 

--- a/src/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/src/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from .multi_parameter import MultiParameter
 
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
     from .parameter_base import ParamRawDataType
 
-InstrumentModuleType = TypeVar("InstrumentModuleType", bound="InstrumentModule")
 _LOG = logging.getLogger(__name__)
 
 
@@ -89,3 +88,18 @@ class MultiChannelInstrumentParameter[InstrumentModuleType: "InstrumentModule"](
         """
 
         return self.names
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "InstrumentModuleType": TypeVar(
+                "InstrumentModuleType", bound="InstrumentModule"
+            ),
+        },
+    )

--- a/src/qcodes/parameters/multi_parameter.py
+++ b/src/qcodes/parameters/multi_parameter.py
@@ -57,7 +57,9 @@ def _is_nested_sequence_or_none(
 
 class MultiParameter(
     ParameterBase[ParameterDataTypeVar, InstrumentTypeVar_co],
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     A gettable parameter that returns multiple values with separate names,

--- a/src/qcodes/parameters/parameter.py
+++ b/src/qcodes/parameters/parameter.py
@@ -34,7 +34,9 @@ log = logging.getLogger(__name__)
 
 class ParameterKWArgs(
     TypedDict,
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     This TypedDict defines the type of the kwargs that can be passed to
@@ -198,7 +200,9 @@ class ParameterKWArgs(
 
 class Parameter(
     ParameterBase[ParameterDataTypeVar, InstrumentTypeVar_co],
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     A parameter represents a single degree of freedom. Most often,

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -49,7 +49,9 @@ if TYPE_CHECKING:
     from qcodes.dataset.data_set_protocol import ValuesType
     from qcodes.instrument import InstrumentBase
     from qcodes.logger.instrument_logger import InstrumentLoggerAdapter
+# Cannot convert to PEP 695: uses default= which requires PEP 696 (Python 3.13+).
 ParameterDataTypeVar = TypeVar("ParameterDataTypeVar", default=Any)
+# Cannot convert to PEP 695: uses default= and covariant= which require PEP 696 (Python 3.13+).
 # InstrumentTypeVar_co is a covariant type variable representing the instrument
 # type associated with the parameter. It needs to be covariant to allow passing
 # a Parameter bound to None or a specific instrument where the default is used in the type hint.

--- a/src/qcodes/parameters/parameter_base.py
+++ b/src/qcodes/parameters/parameter_base.py
@@ -1472,11 +1472,8 @@ class GetLatest(DelegateAttributes, Generic[ParameterDataTypeVar]):
         return self.cache()
 
 
-P = TypeVar("P", bound=ParameterBase)
-
-
 # Does not implement __hash__, not clear it needs to
-class ParameterSet(MutableSet[P], Generic[P]):  # noqa: PLW1641
+class ParameterSet[P: ParameterBase](MutableSet[P]):  # noqa: PLW1641
     """A set-like container that preserves the insertion order of its parameters.
 
     This class implements the common set interface methods while maintaining
@@ -1592,3 +1589,13 @@ class ParameterSet(MutableSet[P], Generic[P]):  # noqa: PLW1641
         raise NotImplementedError(
             f">+ operation is not defined between ParameterSet and {type(other)}"
         )
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "P": TypeVar("P", bound="ParameterBase"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/parameters/parameter_with_setpoints.py
+++ b/src/qcodes/parameters/parameter_with_setpoints.py
@@ -29,7 +29,9 @@ LOG = logging.getLogger(__name__)
 
 class ParameterWithSetpoints(
     Parameter[ParameterDataTypeVar, InstrumentTypeVar_co],
-    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],
+    # Generic can be replaced with PEP 695 type params once Python 3.12
+    # support is dropped (TypeVars use default= which requires PEP 696)
+    Generic[ParameterDataTypeVar, InstrumentTypeVar_co],  # noqa: UP046
 ):
     """
     A parameter that has associated setpoints. The setpoints is nothing

--- a/src/qcodes/parameters/val_mapping.py
+++ b/src/qcodes/parameters/val_mapping.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import TypeVar
-
-T = TypeVar("T")
+from typing import TYPE_CHECKING, TypeVar
 
 
-def create_on_off_val_mapping(
+def create_on_off_val_mapping[T](
     on_val: T | bool = True, off_val: T | bool = False
 ) -> OrderedDict[str | bool, T | bool]:
     """
@@ -32,3 +30,13 @@ def create_on_off_val_mapping(
     offs = (*offs_, False)
     all_vals_tuples = [(on, on_val) for on in ons] + [(off, off_val) for off in offs]
     return OrderedDict(all_vals_tuples)
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "T": TypeVar("T"),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/utils/abstractmethod.py
+++ b/src/qcodes/utils/abstractmethod.py
@@ -1,15 +1,10 @@
-from typing import TYPE_CHECKING, TypeVar
-
-from typing_extensions import ParamSpec
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-input = ParamSpec("input")
-output = TypeVar("output")
 
-
-def qcodes_abstractmethod(
+def qcodes_abstractmethod[**input, output](
     funcobj: "Callable[input, output]",
 ) -> "Callable[input, output]":
     """
@@ -23,3 +18,19 @@ def qcodes_abstractmethod(
     """
     funcobj.__qcodes_is_abstract_method__ = True  # type: ignore[attr-defined]
     return funcobj
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from typing_extensions import ParamSpec
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "input": ParamSpec("input"),
+            "output": TypeVar("output"),
+        },
+    )

--- a/src/qcodes/utils/deep_update_utils.py
+++ b/src/qcodes/utils/deep_update_utils.py
@@ -1,13 +1,10 @@
 from collections import abc
 from collections.abc import Hashable, Mapping, MutableMapping
 from copy import deepcopy
-from typing import Any, TypeVar, cast
-
-K = TypeVar("K", bound=Hashable)
-L = TypeVar("L", bound=Hashable)
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 
-def deep_update(
+def deep_update[K: Hashable, L: Hashable](
     dest: MutableMapping[K, Any], update: Mapping[L, Any]
 ) -> MutableMapping[K | L, Any]:
     """
@@ -25,3 +22,14 @@ def deep_update(
         else:
             dest_int[k] = deepcopy(v_update)
     return dest_int
+
+
+if not TYPE_CHECKING:
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    _deprecated_typevars: dict[str, TypeVar] = {
+        "K": TypeVar("K", bound=Hashable),
+        "L": TypeVar("L", bound=Hashable),
+    }
+
+    __getattr__ = _make_deprecated_typevars_getattr(__name__, _deprecated_typevars)

--- a/src/qcodes/utils/deprecate.py
+++ b/src/qcodes/utils/deprecate.py
@@ -1,5 +1,51 @@
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
 class QCoDeSDeprecationWarning(RuntimeWarning):
     """
     A DeprecationWarning used internally in QCoDeS. This
     fixes `DeprecationWarning` being suppressed by default.
     """
+
+
+def _make_deprecated_typevars_getattr(
+    module_name: str,
+    deprecated: dict[str, Any],
+    fallback: Callable[[str], Any] | None = None,
+) -> Callable[[str], Any]:
+    """Return a module-level ``__getattr__`` that emits deprecation warnings
+    for removed TypeVar / type-alias names.
+
+    Args:
+        module_name: The ``__name__`` of the calling module.
+        deprecated: Mapping of ``{name: object}`` for names that should
+            still be importable but trigger a warning.
+        fallback: Optional existing ``__getattr__`` to delegate to for
+            names not in *deprecated*.
+
+    Returns:
+        A ``__getattr__`` function suitable for assignment at module level.
+
+    """
+
+    def __getattr__(name: str) -> Any:
+        if name in deprecated:
+            warnings.warn(
+                f"Importing {name!r} from {module_name!r} is deprecated. "
+                f"This TypeVar is no longer used and will be removed in a "
+                f"future version.",
+                QCoDeSDeprecationWarning,
+                stacklevel=2,
+            )
+            return deprecated[name]
+        if fallback is not None:
+            return fallback(name)
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    return __getattr__

--- a/src/qcodes/utils/deprecate.py
+++ b/src/qcodes/utils/deprecate.py
@@ -20,7 +20,7 @@ def _make_deprecated_typevars_getattr(
     fallback: Callable[[str], Any] | None = None,
 ) -> Callable[[str], Any]:
     """Return a module-level ``__getattr__`` that emits deprecation warnings
-    for removed TypeVar / type-alias names.
+    for removed TypeVar / type-alias / other names.
 
     Args:
         module_name: The ``__name__`` of the calling module.
@@ -38,7 +38,7 @@ def _make_deprecated_typevars_getattr(
         if name in deprecated:
             warnings.warn(
                 f"Importing {name!r} from {module_name!r} is deprecated. "
-                f"This TypeVar is no longer used and will be removed in a "
+                f"This name is no longer used and will be removed in a "
                 f"future version.",
                 QCoDeSDeprecationWarning,
                 stacklevel=2,

--- a/src/qcodes/utils/snapshot_helpers.py
+++ b/src/qcodes/utils/snapshot_helpers.py
@@ -1,11 +1,9 @@
-from typing import Any, NamedTuple, TypeVar
-
-T = TypeVar("T")
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 # Unbound parameters or Instrument parameters
 ParameterKey = str | tuple[str, str]
 
-ParameterDict = dict[ParameterKey, T]
+type ParameterDict[T] = dict[ParameterKey, T]
 Snapshot = dict[str, Any]
 
 
@@ -59,5 +57,18 @@ def diff_param_values(
             key: (left_params[key], right_params[key])
             for key in common_keys
             if left_params[key] != right_params[key]
+        },
+    )
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T"),
         },
     )

--- a/src/qcodes/utils/threading_utils.py
+++ b/src/qcodes/utils/threading_utils.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -10,7 +10,7 @@ _LOG = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-class RespondingThread(threading.Thread, Generic[T]):
+class RespondingThread[T](threading.Thread):
     """
     Thread subclass for parallelizing execution. Behaves like a
     regular thread but returns a value from target, and propagates

--- a/src/qcodes/utils/threading_utils.py
+++ b/src/qcodes/utils/threading_utils.py
@@ -1,13 +1,11 @@
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 _LOG = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 
 class RespondingThread[T](threading.Thread):
@@ -64,7 +62,7 @@ class RespondingThread[T](threading.Thread):
         return self._output
 
 
-def thread_map(
+def thread_map[T](
     callables: "Sequence[Callable[..., T]]",
     args: Optional["Sequence[Sequence[Any]]"] = None,
     kwargs: Optional["Sequence[dict[str, Any]]"] = None,
@@ -95,3 +93,16 @@ def thread_map(
         t.start()
 
     return [t.output() for t in threads]
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T"),
+        },
+    )

--- a/src/qcodes/utils/types.py
+++ b/src/qcodes/utils/types.py
@@ -85,7 +85,7 @@ All numpy complex types
 concrete_complex_types = (*numpy_concrete_complex, complex)
 complex_types = (*numpy_concrete_complex, complex)
 
-NumberType: TypeAlias = int | float | np.integer | np.floating
+NumberType: TypeAlias = int | float | np.integer | np.floating  # noqa: UP040 # this is used in isinstance checks.
 """
 Python or NumPy real number.
 """

--- a/src/qcodes/validators/validators.py
+++ b/src/qcodes/validators/validators.py
@@ -9,7 +9,7 @@ import math
 import typing
 from collections import abc
 from collections.abc import Hashable
-from typing import Any, Generic, Literal, TypeVar, cast, get_args
+from typing import Any, Literal, TypeVar, cast, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -65,7 +65,7 @@ def range_str(
 T = TypeVar("T")
 
 
-class Validator(Generic[T]):
+class Validator[T]:
     """
     Base class for all value validators
     each validator should implement:

--- a/src/qcodes/validators/validators.py
+++ b/src/qcodes/validators/validators.py
@@ -62,7 +62,6 @@ def range_str(
         return ""
 
 
-
 class Validator[T]:
     """
     Base class for all value validators

--- a/src/qcodes/validators/validators.py
+++ b/src/qcodes/validators/validators.py
@@ -9,7 +9,7 @@ import math
 import typing
 from collections import abc
 from collections.abc import Hashable
-from typing import Any, Literal, TypeVar, cast, get_args
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -61,8 +61,6 @@ def range_str(
     else:
         return ""
 
-
-T = TypeVar("T")
 
 
 class Validator[T]:
@@ -501,7 +499,7 @@ class Enum(Validator[Hashable]):
         return self._values.copy()
 
 
-class LiteralValidator(Validator[T]):
+class LiteralValidator[T](Validator[T]):
     """
 
     A validator that allows users to check that values supplied are in set of members
@@ -1061,7 +1059,7 @@ class Arrays(Validator[npt.NDArray]):
         return float(self._max_value) if self._max_value is not None else None
 
 
-class Lists(Validator[list[T]]):
+class Lists[T](Validator[list[T]]):
     """
     Validator for lists
 
@@ -1253,3 +1251,16 @@ class Dict(Validator[dict[Hashable, Any]]):
     @allowed_keys.setter
     def allowed_keys(self, keys: abc.Sequence[Hashable] | None) -> None:
         self._allowed_keys = keys
+
+
+if not TYPE_CHECKING:
+    from typing import TypeVar
+
+    from qcodes.utils.deprecate import _make_deprecated_typevars_getattr
+
+    __getattr__ = _make_deprecated_typevars_getattr(
+        __name__,
+        {
+            "T": TypeVar("T"),
+        },
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -78,7 +78,7 @@ def retry_until_does_not_throw(
     return retry_until_passes_decorator
 
 
-def profile(func: Callable[P, T]) -> Callable[P, T]:
+def profile[**P, T](func: Callable[P, T]) -> Callable[P, T]:
     """
     Decorator that profiles the wrapped function with cProfile.
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,10 +4,9 @@ import cProfile
 import os
 from functools import wraps
 from time import sleep
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from typing_extensions import ParamSpec
 
 from qcodes.metadatable import MetadatableWithName
 
@@ -18,11 +17,7 @@ if TYPE_CHECKING:
     from pytest import ExceptionInfo
 
 
-T = TypeVar("T")
-P = ParamSpec("P")
-
-
-def retry_until_does_not_throw(
+def retry_until_does_not_throw[**P, T](
     exception_class_to_expect: type[Exception] = AssertionError,
     tries: int = 5,
     delay: float = 0.1,

--- a/tests/utils/test_deprecate.py
+++ b/tests/utils/test_deprecate.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+import pytest
+
+from qcodes.utils.deprecate import (
+    QCoDeSDeprecationWarning,
+    _make_deprecated_typevars_getattr,
+)
+
+
+@pytest.fixture
+def deprecated_getattr() -> tuple[dict[str, TypeVar], callable]:
+    """Create a __getattr__ with two deprecated TypeVars."""
+    deprecated = {
+        "MyT": TypeVar("MyT"),
+        "MyK": TypeVar("MyK", bound=int),
+    }
+    getattr_fn = _make_deprecated_typevars_getattr("fake.module", deprecated)
+    return deprecated, getattr_fn
+
+
+def test_returns_typevar_and_warns(
+    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+) -> None:
+    deprecated, getattr_fn = deprecated_getattr
+    with pytest.warns(QCoDeSDeprecationWarning, match="'MyT'.*'fake.module'"):
+        result = getattr_fn("MyT")
+    assert result is deprecated["MyT"]
+
+
+def test_warns_for_each_deprecated_name(
+    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+) -> None:
+    deprecated, getattr_fn = deprecated_getattr
+    with pytest.warns(QCoDeSDeprecationWarning, match="'MyK'"):
+        result = getattr_fn("MyK")
+    assert result is deprecated["MyK"]
+
+
+def test_unknown_name_raises_attribute_error(
+    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+) -> None:
+    _, getattr_fn = deprecated_getattr
+    with pytest.raises(AttributeError, match="fake.module"):
+        getattr_fn("DoesNotExist")
+
+
+def test_repeated_access_returns_same_object(
+    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+) -> None:
+    deprecated, getattr_fn = deprecated_getattr
+    with pytest.warns(QCoDeSDeprecationWarning):
+        first = getattr_fn("MyT")
+    with pytest.warns(QCoDeSDeprecationWarning):
+        second = getattr_fn("MyT")
+    assert first is second
+    assert first is deprecated["MyT"]
+
+
+def test_fallback_is_called_for_unknown_names() -> None:
+    deprecated: dict[str, TypeVar] = {"X": TypeVar("X")}
+
+    def fallback(name: str) -> str:
+        return f"fallback:{name}"
+
+    getattr_fn = _make_deprecated_typevars_getattr("mod", deprecated, fallback=fallback)
+    assert getattr_fn("something") == "fallback:something"
+
+
+def test_fallback_not_called_for_deprecated_names() -> None:
+    deprecated: dict[str, TypeVar] = {"X": TypeVar("X")}
+    fallback_called = False
+
+    def fallback(name: str) -> str:
+        nonlocal fallback_called
+        fallback_called = True
+        return name
+
+    getattr_fn = _make_deprecated_typevars_getattr("mod", deprecated, fallback=fallback)
+    with pytest.warns(QCoDeSDeprecationWarning):
+        getattr_fn("X")
+    assert not fallback_called
+
+
+def test_real_module_import_triggers_warning() -> None:
+    """Test that importing a deprecated TypeVar from an actual module works."""
+    with pytest.warns(QCoDeSDeprecationWarning, match="'K'"):
+        from qcodes.utils.deep_update_utils import K
+
+    assert isinstance(K, TypeVar)

--- a/tests/utils/test_deprecate.py
+++ b/tests/utils/test_deprecate.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TypeVar
+import importlib
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import pytest
 
@@ -9,9 +11,11 @@ from qcodes.utils.deprecate import (
     _make_deprecated_typevars_getattr,
 )
 
+_FixtureT = tuple[dict[str, TypeVar], Callable[[str], Any]]
+
 
 @pytest.fixture
-def deprecated_getattr() -> tuple[dict[str, TypeVar], callable]:
+def deprecated_getattr() -> _FixtureT:
     """Create a __getattr__ with two deprecated TypeVars."""
     deprecated = {
         "MyT": TypeVar("MyT"),
@@ -22,7 +26,7 @@ def deprecated_getattr() -> tuple[dict[str, TypeVar], callable]:
 
 
 def test_returns_typevar_and_warns(
-    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+    deprecated_getattr: _FixtureT,
 ) -> None:
     deprecated, getattr_fn = deprecated_getattr
     with pytest.warns(QCoDeSDeprecationWarning, match="'MyT'.*'fake.module'"):
@@ -31,7 +35,7 @@ def test_returns_typevar_and_warns(
 
 
 def test_warns_for_each_deprecated_name(
-    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+    deprecated_getattr: _FixtureT,
 ) -> None:
     deprecated, getattr_fn = deprecated_getattr
     with pytest.warns(QCoDeSDeprecationWarning, match="'MyK'"):
@@ -40,15 +44,15 @@ def test_warns_for_each_deprecated_name(
 
 
 def test_unknown_name_raises_attribute_error(
-    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+    deprecated_getattr: _FixtureT,
 ) -> None:
     _, getattr_fn = deprecated_getattr
-    with pytest.raises(AttributeError, match="fake.module"):
+    with pytest.raises(AttributeError, match=r"fake\.module"):
         getattr_fn("DoesNotExist")
 
 
 def test_repeated_access_returns_same_object(
-    deprecated_getattr: tuple[dict[str, TypeVar], callable],
+    deprecated_getattr: _FixtureT,
 ) -> None:
     deprecated, getattr_fn = deprecated_getattr
     with pytest.warns(QCoDeSDeprecationWarning):
@@ -86,7 +90,8 @@ def test_fallback_not_called_for_deprecated_names() -> None:
 
 def test_real_module_import_triggers_warning() -> None:
     """Test that importing a deprecated TypeVar from an actual module works."""
+    mod = importlib.import_module("qcodes.utils.deep_update_utils")
     with pytest.warns(QCoDeSDeprecationWarning, match="'K'"):
-        from qcodes.utils.deep_update_utils import K
+        k = mod.K
 
-    assert isinstance(K, TypeVar)
+    assert isinstance(k, TypeVar)


### PR DESCRIPTION
- Convert 22 classes/functions to PEP 695 type parameter syntax (UP046/UP047)
- Add noqa: UP046 with comments for 14 cases that require PEP 696 (TypeVar defaults), which needs Python 3.13+
- Fix ruff autofix bug in Base_SPDT.py (TINSTR vs _TINSTR mismatch)
- Clean up unused TypeVar definitions and imports across ~13 files
- Add _make_deprecated_typevars_getattr helper in deprecate.py for module-level __getattr__ deprecation warnings
- Add deprecation warnings (QCoDeSDeprecationWarning) for 9 modules with removed public TypeVars, guarded by if not TYPE_CHECKING so type checkers still flag removed imports as errors
- Add tests for the deprecation helper
