### PR TITLE
Fix lower bound of the span parameter validator of the KeysightPNABase

### DIFF
--- a/docs/changes/newsfragments/8195.improved_driver
+++ b/docs/changes/newsfragments/8195.improved_driver
@@ -1,0 +1,1 @@
+Correct the lower bound of the span parameter validator of the KeysightPNABase driver to 0 Hz.

--- a/src/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/src/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -548,7 +548,7 @@ class KeysightPNABase(VisaInstrument):
             get_parser=float,
             set_cmd="SENS:FREQ:SPAN {}",
             unit="Hz",
-            vals=Numbers(min_value=min_freq, max_value=max_freq),
+            vals=Numbers(min_value=0, max_value=max_freq),
         )
         """Parameter span"""
         self.cw: Parameter = self.add_parameter(


### PR DESCRIPTION
The lower bound of the span in the KeysightPNABase should be 0 Hz, it was currently set to min_freq, which incorrectly limits setting the span for small values.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
