### PR TITLE
feature: KeysightAgilent_33XXX.py improvements

### DIFF
--- a/docs/changes/newsfragments/8254.improved_driver
+++ b/docs/changes/newsfragments/8254.improved_driver
@@ -1,14 +1,15 @@
 Referring to the:
 
 - `Keysight Trueform Series Operating and Service Guide`_
-.. _`Keysight Trueform Series Operating and Service Guide`: https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
-- `Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide`_
-.. _`Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide`: https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
+- `Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User's Guide`_
 - `Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator`_
-.. _`Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator`: https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html
 
 Improvements:
 
 - Expanded the list of supported devices for the KeysightAgilent_33XXX driver
 - Added implementations of SCPI commands for working with: ARB signals, edges of Pulse function, output termination, voltage autoranging
 - Created tests for new commands and update sim file
+
+.. _`Keysight Trueform Series Operating and Service Guide`: https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
+.. _`Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User's Guide`: https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
+.. _`Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator`: https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html

--- a/docs/changes/newsfragments/8254.improved_driver
+++ b/docs/changes/newsfragments/8254.improved_driver
@@ -1,13 +1,14 @@
 Referring to the:
-	- Keysight Trueform Series Operating and Service Guide -
-	  https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
-	- Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide -
-	  https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
-    - Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator -
-	  https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html
+
+- `Keysight Trueform Series Operating and Service Guide`_
+.. _`Keysight Trueform Series Operating and Service Guide`: https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
+- `Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide`_
+.. _`Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide`: https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
+- `Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator`_
+.. _`Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator`: https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html
 
 Improvements:
-	- Expanded the list of supported devices for the KeysightAgilent_33XXX driver
-	- Added implementations of SCPI commands for working with: ARB signals, edges of Pulse function, output termination,
-	  voltage autoranging
-	- Created tests for new commands and update sim file
+
+- Expanded the list of supported devices for the KeysightAgilent_33XXX driver
+- Added implementations of SCPI commands for working with: ARB signals, edges of Pulse function, output termination, voltage autoranging
+- Created tests for new commands and update sim file

--- a/docs/changes/newsfragments/8254.improved_driver
+++ b/docs/changes/newsfragments/8254.improved_driver
@@ -1,0 +1,13 @@
+Referring to the:
+	- Keysight Trueform Series Operating and Service Guide -
+	  https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
+	- Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide -
+	  https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
+    - Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator -
+	  https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html
+
+Improvements:
+	- Expanded the list of supported devices for the KeysightAgilent_33XXX driver
+	- Added implementations of SCPI commands for working with: ARB signals, edges of Pulse function, output termination,
+	  voltage autoranging
+	- Created tests for new commands and update sim file

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -52,6 +52,8 @@ devices:
           r: "{:.8E}"
         setter:
           q: "SOURce1:FUNCtion:PULSe:TRANsition {}"
+        specs:
+          type: float
 
       chan1 load:
         default: 5.000000000000000E+01
@@ -60,6 +62,8 @@ devices:
           r: "{:.8E}"
         setter:
           q: "OUTPut1:LOAD {}"
+        specs:
+          type: float
 
       chan1 auto_range:
         default: 1
@@ -68,6 +72,9 @@ devices:
           r: "{}"
         setter:
           q: "SOURce1:VOLTage:RANGe:AUTO {}"
+        specs:
+          type: int
+          valid: [ 0, 1 ]
 
       chan1 set_srate:
         default: 4.000000000000000E+04
@@ -76,6 +83,8 @@ devices:
           r: "{:.8E}"
         setter:
           q: "SOURce:FUNCtion:ARBitrary:SRATe {}"
+        specs:
+          type: float
 
 resources:
   GPIB::1::INSTR:

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -55,7 +55,7 @@ devices:
         specs:
           type: float
 
-      chan1 load:
+      chan1 output_load:
         default: 5.000000000000000E+01
         getter:
           q: "OUTPut1:LOAD?"

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -79,10 +79,10 @@ devices:
       chan1 srate:
         default: 4.000000000000000E+04
         getter:
-          q: "SOURce:FUNCtion:ARBitrary:SRATe?"
+          q: "SOURce1:FUNCtion:ARBitrary:SRATe?"
           r: "{:.8E}"
         setter:
-          q: "SOURce:FUNCtion:ARBitrary:SRATe {}"
+          q: "SOURce1:FUNCtion:ARBitrary:SRATe {}"
         specs:
           type: float
 

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -76,7 +76,7 @@ devices:
           type: int
           valid: [ 0, 1 ]
 
-      chan1 set_srate:
+      chan1 srate:
         default: 4.000000000000000E+04
         getter:
           q: "SOURce:FUNCtion:ARBitrary:SRATe?"

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -49,7 +49,7 @@ devices:
         default: 4.000000000000000E-09
         getter:
           q: "SOURce1:FUNCtion:PULSe:TRANsition?"
-          r: "{:.8E}"
+          r: "{:.15E}"
         setter:
           q: "SOURce1:FUNCtion:PULSe:TRANsition {}"
         specs:
@@ -59,7 +59,7 @@ devices:
         default: 5.000000000000000E+01
         getter:
           q: "OUTPut1:LOAD?"
-          r: "{:.8E}"
+          r: "{:.15E}"
         setter:
           q: "OUTPut1:LOAD {}"
         specs:
@@ -80,7 +80,7 @@ devices:
         default: 4.000000000000000E+04
         getter:
           q: "SOURce1:FUNCtion:ARBitrary:SRATe?"
-          r: "{:.8E}"
+          r: "{:.15E}"
         setter:
           q: "SOURce1:FUNCtion:ARBitrary:SRATe {}"
         specs:

--- a/src/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/src/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -45,6 +45,38 @@ devices:
         setter:
           q: "SOURce1:BURSt:NCYCles {}"
 
+      chan1 edges:
+        default: 4.000000000000000E-09
+        getter:
+          q: "SOURce1:FUNCtion:PULSe:TRANsition?"
+          r: "{:.8E}"
+        setter:
+          q: "SOURce1:FUNCtion:PULSe:TRANsition {}"
+
+      chan1 load:
+        default: 5.000000000000000E+01
+        getter:
+          q: "OUTPut1:LOAD?"
+          r: "{:.8E}"
+        setter:
+          q: "OUTPut1:LOAD {}"
+
+      chan1 auto_range:
+        default: 1
+        getter:
+          q: "SOURce1:VOLTage:RANGe:AUTO?"
+          r: "{}"
+        setter:
+          q: "SOURce1:VOLTage:RANGe:AUTO {}"
+
+      chan1 set_srate:
+        default: 4.000000000000000E+04
+        getter:
+          q: "SOURce:FUNCtion:ARBitrary:SRATe?"
+          r: "{:.8E}"
+        setter:
+          q: "SOURce:FUNCtion:ARBitrary:SRATe {}"
+
 resources:
   GPIB::1::INSTR:
     device: device 1

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -189,7 +189,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             unit="s",
             vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX")),
         )
-        """Sets the period for pulse waveforms."""
+        """Sets the transition times for the leading and trailing edges of the pulse."""
 
         # TRIGGER MENU
         self.trigger_source: Parameter = self.add_parameter(

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -352,8 +352,8 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             "6",
         ]:  # Older models do not support all arbitrary options
             max_srate = self._parent._max_srate[self.model]
-            self.set_srate: Parameter = self.add_parameter(
-                "set_srate",
+            self.srate: Parameter = self.add_parameter(
+                "srate",
                 label=f"Channel {channum} sample rate",
                 set_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}",
                 get_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe?",

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -325,8 +325,8 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         )
         """The burst period is the time between the starts of consecutive bursts when trigger is immediate."""
 
-        self.load: Parameter = self.add_parameter(
-            "load",
+        self.output_load: Parameter = self.add_parameter(
+            "output_load",
             label=f"Channel {channum} output load",
             set_cmd=f"OUTPut{channum}:LOAD {{}}",
             get_cmd=f"OUTPut{channum}:LOAD?",

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -181,13 +181,13 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         """Parameter pulse_width"""
 
         self.edges: Parameter = self.add_parameter(
-            'edges',
-            label=f'Channel {channum} edges width',
-            set_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition {{}}',
-            get_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition?',
+            "edges",
+            label=f"Channel {channum} edges width",
+            set_cmd=f"SOURce{channum}:FUNCtion:PULSe:TRANsition {{}}",
+            get_cmd=f"SOURce{channum}:FUNCtion:PULSe:TRANsition?",
             get_parser=float,
-            unit='s',
-            vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX"))
+            unit="s",
+            vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX")),
         )
         """Sets the period for pulse waveforms."""
 
@@ -337,48 +337,53 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         """Sets expected output termination. Should equal the load impedance attached to the output."""
 
         self.auto_range: Parameter = self.add_parameter(
-            'auto_range',
-            label=f'Channel {channum} range mode',
-            set_cmd=f'SOURce{channum}:VOLTage:RANGe:AUTO {{}}',
-            get_cmd=f'SOURce{channum}:VOLTage:RANGe:AUTO?',
-            val_mapping={'ON': 1, 'OFF': 0},
-            vals=vals.Enum('ON', 'OFF'),
+            "auto_range",
+            label=f"Channel {channum} range mode",
+            set_cmd=f"SOURce{channum}:VOLTage:RANGe:AUTO {{}}",
+            get_cmd=f"SOURce{channum}:VOLTage:RANGe:AUTO?",
+            val_mapping={"ON": 1, "OFF": 0},
+            vals=vals.Enum("ON", "OFF"),
         )
         """Disables or enables voltage autoranging for all functions."""
 
         # Arbitrary waveforms
-        if self._parent.model[2] in ["5", "6"]:  # Older models do not support all arbitrary options
+        if self._parent.model[2] in [
+            "5",
+            "6",
+        ]:  # Older models do not support all arbitrary options
             max_srate = self._parent._max_srate[self.model]
             self.set_srate: Parameter = self.add_parameter(
-                'set_srate',
-                label=f'Channel {channum} sample rate',
-                set_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}',
-                get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
+                "set_srate",
+                label=f"Channel {channum} sample rate",
+                set_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}",
+                get_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe?",
                 get_parser=int,
-                unit='Sa/s',
-                vals=vals.MultiType(vals.Numbers(1e-6, max_srate), vals.Enum("MIN", "MAX", "DEF")),
+                unit="Sa/s",
+                vals=vals.MultiType(
+                    vals.Numbers(1e-6, max_srate), vals.Enum("MIN", "MAX", "DEF")
+                ),
             )
             """Sets the sample rate for the arbitrary waveform."""
 
             self.add_function(
-                'load_arb',
-                call_cmd=f'SOURce{channum}:DATA:ARBitrary {{}}, {{}}',
+                "load_arb",
+                call_cmd=f"SOURce{channum}:DATA:ARBitrary {{}}, {{}}",
                 args=[vals.Strings(), vals.Arrays()],
-                arg_parser=lambda sig_name, arr: (sig_name, ','.join(map(str, arr))),
+                arg_parser=lambda sig_name, arr: (sig_name, ",".join(map(str, arr))),
             )
             """Downloads integer values representing floating point values into waveform volatile memory."""
             # TODO: add DAC support
 
             self.add_function(
-                'set_arb',
-                call_cmd=f'SOURce{channum}:FUNCtion:ARBitrary {{}}',
+                "set_arb",
+                call_cmd=f"SOURce{channum}:FUNCtion:ARBitrary {{}}",
                 args=[vals.Strings()],
             )
             """Selects an arbitrary waveform that has previously been loaded into volatile memory."""
 
             self.add_function(
-                'clear_arb',
-                call_cmd=f'SOURce{channum}:DATA:VOLatile:CLEar',
+                "clear_arb",
+                call_cmd=f"SOURce{channum}:DATA:VOLatile:CLEar",
             )
             """Clears waveform memory and reloads the default waveform."""
 

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -319,7 +319,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             get_cmd=f"OUTPut{channum}:LOAD?",
             get_parser=partial(val_parser, float),
             unit="ohms",
-            vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX", "DEF")),
+            vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX")),
         )
         """Sets expected output termination. Should equal the load impedance attached to the output."""
 
@@ -336,10 +336,12 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         """Sets the period for pulse waveforms. """
 
         # Arbitrary waveforms
+        # Older models do not support all arbitrary options
+        if self._parent.model[2] in ["5", "6"]:
             max_srate = self._parent._max_srate[self.model]
-        self.set_srate: Parameter = self.add_parameter(
-            'set_srate',
-            label=f'Channel {channum} sample rate',
+            self.set_srate: Parameter = self.add_parameter(
+                'set_srate',
+                label=f'Channel {channum} sample rate',
             set_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}',
             get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
             get_parser=int,

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -298,7 +298,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
 
         self.burst_int_period: Parameter = self.add_parameter(
             "burst_int_period",
-            label=(f"Channel {channum} burst internal period"),
+            label=f"Channel {channum} burst internal period",
             set_cmd=f"SOURce{channum}:BURSt:INTernal:PERiod {{}}",
             get_cmd=f"SOURce{channum}:BURSt:INTernal:PERiod?",
             unit="s",
@@ -322,8 +322,6 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX", "DEF")),
         )
         """Sets expected output termination. Should equal the load impedance attached to the output."""
-
-
 
 
 OutputChannel = Keysight33xxxOutputChannel

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -322,6 +322,19 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX", "DEF")),
         )
         """Sets expected output termination. Should equal the load impedance attached to the output."""
+
+        # Pulse waveforms
+        self.edges: Parameter = self.add_parameter(
+            'edges',
+            label=f'Channel {channum} edges width',
+            set_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition {{}}',
+            get_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition?',
+            get_parser=float,
+            unit='s',
+            vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX"))
+        )
+        """Sets the period for pulse waveforms. """
+
         # Arbitrary waveforms
         self.set_srate: Parameter = self.add_parameter(
             'set_srate',

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -372,7 +372,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
                 arg_parser=lambda sig_name, arr: (sig_name, ",".join(map(str, arr))),
             )
             """Downloads integer values representing floating point values into waveform volatile memory."""
-            # TODO: add DAC support
+            # TODO: add DAC (Digital-to-Analog Converter) support.
 
             self.add_function(
                 "set_arb",

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -449,6 +449,21 @@ class Keysight33xxx(KeysightErrorQueueMixin, VisaInstrument):
             "33622A": 120e6,
         }
 
+        # Refer to instruments User's guides
+        self._max_srate = {
+            "33210A": 50e6,
+            "33250A": 200e6,
+            "33510B": 160e6,
+            "33511B": 160e6,
+            "33512B": 160e6,
+            "33521B": 250e6,
+            "33522B": 250e6,
+            "33611A": 660e6,
+            "33612A": 660e6,
+            "33621A": 1e9,
+            "33622A": 1e9,
+        }
+
         self.num_channels = no_of_channels[self.model]
 
         if dynamic_channels:

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -323,6 +323,16 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         )
         """Sets expected output termination. Should equal the load impedance attached to the output."""
 
+        self.auto_range: Parameter = self.add_parameter(
+            'auto_range',
+            label=f'Channel {channum} range mode',
+            set_cmd=f'SOURce{channum}:VOLTage:RANGe:AUTO {{}}',
+            get_cmd=f'SOURce{channum}:VOLTage:RANGe:AUTO?',
+            val_mapping={'ON': 1, 'OFF': 0},
+            vals=vals.Enum('ON', 'OFF'),
+        )
+        """Disables or enables voltage autoranging for all functions."""
+
         # Pulse waveforms
         self.edges: Parameter = self.add_parameter(
             'edges',
@@ -342,13 +352,13 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             self.set_srate: Parameter = self.add_parameter(
                 'set_srate',
                 label=f'Channel {channum} sample rate',
-            set_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}',
-            get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
-            get_parser=int,
-            unit='Sa/s',
+                set_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}',
+                get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
+                get_parser=int,
+                unit='Sa/s',
                 vals=vals.MultiType(vals.Numbers(1e-6, max_srate), vals.Enum("MIN", "MAX", "DEF")),
-        )
-        """Sets the sample rate for the arbitrary waveform."""
+            )
+            """Sets the sample rate for the arbitrary waveform."""
 
             self.add_function(
                 'load_arb',

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -350,6 +350,28 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         )
         """Sets the sample rate for the arbitrary waveform."""
 
+            self.add_function(
+                'load_arb',
+                call_cmd=f'SOURce{channum}:DATA:ARBitrary {{}}, {{}}',
+                args=[vals.Strings(), vals.Arrays()],
+                arg_parser=lambda sig_name, arr: (sig_name, ','.join(map(str, arr))),
+            )
+            """Downloads integer values representing floating point values into waveform volatile memory."""
+            # ToDo: add DAC support
+
+            self.add_function(
+                'set_arb',
+                call_cmd=f'SOURce{channum}:FUNCtion:ARBitrary {{}}',
+                args=[vals.Strings()],
+            )
+            """Selects an arbitrary waveform that has previously been loaded into volatile memory."""
+
+            self.add_function(
+                'clear_arb',
+                call_cmd=f'SOURce{channum}:DATA:VOLatile:CLEar',
+            )
+            """Clears waveform memory and reloads the default waveform."""
+
 
 OutputChannel = Keysight33xxxOutputChannel
 

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -402,23 +402,29 @@ class Keysight33xxx(KeysightErrorQueueMixin, VisaInstrument):
         no_of_channels = {
             "33210A": 1,
             "33250A": 1,
+            "33510B": 2,
             "33511B": 1,
             "33512B": 2,
+            "33521B": 1,
             "33522B": 2,
             "33611A": 1,
+            "33612A": 2,
+            "33621A": 1,
             "33622A": 2,
-            "33510B": 2,
         }
 
         self._max_freqs = {
             "33210A": 10e6,
+            "33250A": 80e6,
+            "33510B": 20e6,
             "33511B": 20e6,
             "33512B": 20e6,
-            "33250A": 80e6,
+            "33521B": 30e6,
             "33522B": 30e6,
             "33611A": 80e6,
+            "33612A": 80e6,
+            "33621A": 120e6,
             "33622A": 120e6,
-            "33510B": 20e6,
         }
 
         self.num_channels = no_of_channels[self.model]

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -312,6 +312,19 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         )
         """The burst period is the time between the starts of consecutive bursts when trigger is immediate."""
 
+        self.load: Parameter = self.add_parameter(
+            "load",
+            label=f"Channel {channum} output load",
+            set_cmd=f"OUTPut{channum}:LOAD {{}}",
+            get_cmd=f"OUTPut{channum}:LOAD?",
+            get_parser=partial(val_parser, float),
+            unit="ohms",
+            vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX", "DEF")),
+        )
+        """Sets expected output termination. Should equal the load impedance attached to the output."""
+
+
+
 
 OutputChannel = Keysight33xxxOutputChannel
 

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -336,6 +336,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         """Sets the period for pulse waveforms. """
 
         # Arbitrary waveforms
+            max_srate = self._parent._max_srate[self.model]
         self.set_srate: Parameter = self.add_parameter(
             'set_srate',
             label=f'Channel {channum} sample rate',
@@ -343,7 +344,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
             get_parser=int,
             unit='Sa/s',
-            vals=vals.Numbers(1e-6, 6.6e8),
+                vals=vals.MultiType(vals.Numbers(1e-6, max_srate), vals.Enum("MIN", "MAX", "DEF")),
         )
         """Sets the sample rate for the arbitrary waveform."""
 

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -357,7 +357,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
                 label=f"Channel {channum} sample rate",
                 set_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}",
                 get_cmd=f"SOURce{channum}:FUNCtion:ARBitrary:SRATe?",
-                get_parser=int,
+                get_parser=float,
                 unit="Sa/s",
                 vals=vals.MultiType(
                     vals.Numbers(1e-6, max_srate), vals.Enum("MIN", "MAX", "DEF")

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -119,6 +119,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             vals=vals.Numbers(0, 360),
         )
         """Parameter phase"""
+
         self.amplitude_unit: Parameter = self.add_parameter(
             "amplitude_unit",
             label=f"Channel {channum} amplitude unit",
@@ -148,6 +149,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             get_parser=float,
         )
         """Parameter offset"""
+
         self.output: Parameter = self.add_parameter(
             "output",
             label=f"Channel {channum} output state",
@@ -174,9 +176,20 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             set_cmd=f"SOURce{channum}:FUNCtion:PULSE:WIDTh {{}}",
             get_cmd=f"SOURce{channum}:FUNCtion:PULSE:WIDTh?",
             get_parser=float,
-            unit="S",
+            unit="s",
         )
         """Parameter pulse_width"""
+
+        self.edges: Parameter = self.add_parameter(
+            'edges',
+            label=f'Channel {channum} edges width',
+            set_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition {{}}',
+            get_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition?',
+            get_parser=float,
+            unit='s',
+            vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX"))
+        )
+        """Sets the period for pulse waveforms."""
 
         # TRIGGER MENU
         self.trigger_source: Parameter = self.add_parameter(
@@ -333,21 +346,8 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
         )
         """Disables or enables voltage autoranging for all functions."""
 
-        # Pulse waveforms
-        self.edges: Parameter = self.add_parameter(
-            'edges',
-            label=f'Channel {channum} edges width',
-            set_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition {{}}',
-            get_cmd=f'SOURce{channum}:FUNCtion:PULSe:TRANsition?',
-            get_parser=float,
-            unit='s',
-            vals=vals.MultiType(vals.Numbers(), vals.Enum("MIN", "MAX"))
-        )
-        """Sets the period for pulse waveforms. """
-
         # Arbitrary waveforms
-        # Older models do not support all arbitrary options
-        if self._parent.model[2] in ["5", "6"]:
+        if self._parent.model[2] in ["5", "6"]:  # Older models do not support all arbitrary options
             max_srate = self._parent._max_srate[self.model]
             self.set_srate: Parameter = self.add_parameter(
                 'set_srate',
@@ -367,7 +367,7 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
                 arg_parser=lambda sig_name, arr: (sig_name, ','.join(map(str, arr))),
             )
             """Downloads integer values representing floating point values into waveform volatile memory."""
-            # ToDo: add DAC support
+            # TODO: add DAC support
 
             self.add_function(
                 'set_arb',

--- a/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/src/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -322,6 +322,17 @@ class Keysight33xxxOutputChannel(InstrumentChannel["Keysight33xxx"]):
             vals=vals.MultiType(vals.Numbers(1, 10000), vals.Enum("INF", "MIN", "MAX", "DEF")),
         )
         """Sets expected output termination. Should equal the load impedance attached to the output."""
+        # Arbitrary waveforms
+        self.set_srate: Parameter = self.add_parameter(
+            'set_srate',
+            label=f'Channel {channum} sample rate',
+            set_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe {{}}',
+            get_cmd=f'SOURce{channum}:FUNCtion:ARBitrary:SRATe?',
+            get_parser=int,
+            unit='Sa/s',
+            vals=vals.Numbers(1e-6, 6.6e8),
+        )
+        """Sets the sample rate for the arbitrary waveform."""
 
 
 OutputChannel = Keysight33xxxOutputChannel

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_33521a.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_33521a.py
@@ -1,0 +1,7 @@
+from .KeysightAgilent_33XXX import Keysight33xxxSingleChannel
+
+
+class Keysight33521A(Keysight33xxxSingleChannel):
+    """
+    QCoDeS driver for the Keysight 33521A waveform generator.
+    """

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_33521a.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_33521a.py
@@ -1,7 +1,0 @@
-from .KeysightAgilent_33XXX import Keysight33xxxSingleChannel
-
-
-class Keysight33521A(Keysight33xxxSingleChannel):
-    """
-    QCoDeS driver for the Keysight 33521A waveform generator.
-    """

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_33521b.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_33521b.py
@@ -1,0 +1,7 @@
+from .KeysightAgilent_33XXX import Keysight33xxxSingleChannel
+
+
+class Keysight33521B(Keysight33xxxSingleChannel):
+    """
+    QCoDeS driver for the Keysight 33521B waveform generator.
+    """

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_33612a.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_33612a.py
@@ -1,0 +1,7 @@
+from .KeysightAgilent_33XXX import Keysight33xxxDualChannels
+
+
+class Keysight33612A(Keysight33xxxDualChannels):
+    """
+    QCoDeS driver for the Keysight 33612A waveform generator.
+    """

--- a/src/qcodes/instrument_drivers/Keysight/Keysight_33621a.py
+++ b/src/qcodes/instrument_drivers/Keysight/Keysight_33621a.py
@@ -1,0 +1,7 @@
+from .KeysightAgilent_33XXX import Keysight33xxxSingleChannel
+
+
+class Keysight33621A(Keysight33xxxSingleChannel):
+    """
+    QCoDeS driver for the Keysight 33621A waveform generator.
+    """

--- a/src/qcodes/instrument_drivers/Keysight/__init__.py
+++ b/src/qcodes/instrument_drivers/Keysight/__init__.py
@@ -8,10 +8,14 @@ from .Infiniium import (
 )
 from .Keysight_33210a import Keysight33210A
 from .Keysight_33250a import Keysight33250A
+from .Keysight_33510b import Keysight33510B
 from .Keysight_33511b import Keysight33511B
 from .Keysight_33512b import Keysight33512B
+from .Keysight_33521b import Keysight33521B
 from .Keysight_33522b import Keysight33522B
 from .Keysight_33611a import Keysight33611A
+from .Keysight_33612a import Keysight33612A
+from .Keysight_33621a import Keysight33621A
 from .Keysight_33622a import Keysight33622A
 from .Keysight_34410A_submodules import Keysight34410A
 from .Keysight_34411A_submodules import Keysight34411A
@@ -86,10 +90,14 @@ __all__ = [
     "Keysight344xxATrigger",
     "Keysight33210A",
     "Keysight33250A",
+    "Keysight33510B",
     "Keysight33511B",
     "Keysight33512B",
+    "Keysight33521B",
     "Keysight33522B",
     "Keysight33611A",
+    "Keysight33612A",
+    "Keysight33621A",
     "Keysight33622A",
     "Keysight34410A",
     "Keysight34411A",

--- a/tests/drivers/test_Keysight_33XXX.py
+++ b/tests/drivers/test_Keysight_33XXX.py
@@ -93,11 +93,11 @@ def test_auto_range(driver: Keysight33522B) -> None:
     driver.ch1.auto_range("ON")
 
 
-def test_set_srate(driver: Keysight33522B) -> None:
-    assert driver.ch1.set_srate() == 4e04
-    driver.ch1.set_srate(3e04)
-    assert driver.ch1.set_srate() == 3e04
-    driver.ch1.set_srate(4e04)
+def test_srate(driver: Keysight33522B) -> None:
+    assert driver.ch1.srate() == 4e04
+    driver.ch1.srate(3e04)
+    assert driver.ch1.srate() == 3e04
+    driver.ch1.srate(4e04)
 
 
 def test_wrong_model_warns(

--- a/tests/drivers/test_Keysight_33XXX.py
+++ b/tests/drivers/test_Keysight_33XXX.py
@@ -70,6 +70,36 @@ def test_burst(driver: Keysight33522B) -> None:
     # assert driver.ch1.burst_ncycles() == 'INF'
 
 
+def test_edges(driver: Keysight33522B) -> None:
+    assert driver.ch1.edges() == 4e-09
+    driver.ch1.edges(5e-09)
+    assert driver.ch1.edges() == 5e-09
+    driver.ch1.edges(4e-09)
+
+
+def test_load(driver: Keysight33522B) -> None:
+    assert driver.ch1.load() == 50
+    driver.ch1.load(100)
+    assert driver.ch1.load() == 100
+    driver.ch1.load("INF")
+    assert driver.ch1.load() == float("inf")
+    driver.ch1.load(50)
+
+
+def test_auto_range(driver: Keysight33522B) -> None:
+    assert driver.ch1.auto_range() == "ON"
+    driver.ch1.auto_range("OFF")
+    assert driver.ch1.auto_range() == "OFF"
+    driver.ch1.auto_range("ON")
+
+
+def test_set_srate(driver: Keysight33522B) -> None:
+    assert driver.ch1.set_srate() == 4e04
+    driver.ch1.set_srate(3e04)
+    assert driver.ch1.set_srate() == 3e04
+    driver.ch1.set_srate(4e04)
+
+
 def test_wrong_model_warns(
     caplog: pytest.LogCaptureFixture, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/drivers/test_Keysight_33XXX.py
+++ b/tests/drivers/test_Keysight_33XXX.py
@@ -77,13 +77,13 @@ def test_edges(driver: Keysight33522B) -> None:
     driver.ch1.edges(4e-09)
 
 
-def test_load(driver: Keysight33522B) -> None:
-    assert driver.ch1.load() == 50
-    driver.ch1.load(100)
-    assert driver.ch1.load() == 100
-    driver.ch1.load("INF")
-    assert driver.ch1.load() == float("inf")
-    driver.ch1.load(50)
+def test_output_load(driver: Keysight33522B) -> None:
+    assert driver.ch1.output_load() == 50
+    driver.ch1.output_load(100)
+    assert driver.ch1.output_load() == 100
+    driver.ch1.output_load("INF")
+    assert driver.ch1.output_load() == float("inf")
+    driver.ch1.output_load(50)
 
 
 def test_auto_range(driver: Keysight33522B) -> None:


### PR DESCRIPTION
Hello!

I have made a few improvements to the KeysightAgilent_33XXX.py waveform generator driver:
	- Expanded the list of supported devices for the KeysightAgilent_33XXX driver
	- Added implementations of SCPI commands for working with: ARB signals, edges of Pulse function, output termination,
	  voltage autoranging
	- Created tests for new commands and update sim file

Referring to the:
	- Keysight Trueform Series Operating and Service Guide -
	  https://www.keysight.com/us/en/assets/9018-03714/service-manuals/9018-03714.pdf
	- Agilent 33210A 10 MHz Function / Arbitrary Waveform Generator User’s Guide -
	  https://www.keysight.com/us/en/support/33210A/33210a-waveform-and-function-generator.html
    - Agilent 33250A 80 MHz Function / Arbitrary Waveform Generator -
	  https://www.keysight.com/us/en/support/33250A/function--arbitrary-waveform-generator-80-mhz.html

All changes tested on the real device Keysight33612.

Have a nice day!