### PR TITLE
Drop the dead numpy < 2.0 import fallback

### DIFF
--- a/docs/changes/newsfragments/8444.underthehood
+++ b/docs/changes/newsfragments/8444.underthehood
@@ -1,0 +1,4 @@
+``qcodes.utils.numpy_utils`` now imports ``VisibleDeprecationWarning`` from
+``numpy.exceptions`` unconditionally. The fallback to importing it from the top
+level ``numpy`` namespace was for numpy older than the minimum supported
+version, so it could never be taken.

--- a/src/qcodes/utils/numpy_utils.py
+++ b/src/qcodes/utils/numpy_utils.py
@@ -5,15 +5,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
+from numpy.exceptions import VisibleDeprecationWarning
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-try:
-    from numpy.exceptions import VisibleDeprecationWarning
-except ImportError:
-    # numpy < 2.0
-    from numpy import VisibleDeprecationWarning  # type: ignore[attr-defined, no-redef]
 
 
 def list_of_data_to_maybe_ragged_nd_array(


### PR DESCRIPTION
numpy.exceptions was added in numpy 1.25 and qcodes requires numpy 1.26, so the except ImportError branch could never be taken. Import VisibleDeprecationWarning directly and drop the suppression that came with the fallback.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
