### PR TITLE
Fix xarray inferred-from data ordering

### DIFF
--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -84,6 +84,17 @@ def _add_inferred_data_vars(
     dep_names = {dep.name for dep in deps}
     dims = tuple(d for d in xr_dataset.dims)
 
+    # ``Series.to_xarray()`` expands the index into one dimension per index
+    # level. That is only compatible with the target dataset if the dataset
+    # dimensions are exactly the levels of the index. It is not the case when
+    # the dataset uses a single ``multi_index`` dimension or the flat index
+    # created by ``DataFrame.reset_index()``. A non unique MultiIndex cannot be
+    # converted at all. In those cases the data is already in index order so it
+    # can be reshaped directly.
+    index_is_expandable = (
+        index is not None and index.is_unique and set(dims) == set(index.names)
+    )
+
     for inf in inferred:
         if inf.name in dep_names:
             continue
@@ -108,7 +119,7 @@ def _add_inferred_data_vars(
         expected_shape = tuple(xr_dataset.sizes[d] for d in dims)
         expected_size = prod(expected_shape)
         if flat.shape[0] == expected_size:
-            if index is not None:
+            if index is not None and index_is_expandable:
                 # If an index is provided, we should align the inferred data with the index.
                 # This is necessary because data may be reordered when transforming from a pandas DataFrame to an xarray Dataset.
                 # Passing an index allows the original data ordering to be preserved on reconstruction.

--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -67,6 +67,7 @@ def _add_inferred_data_vars(
     name: str,
     sub_dict: Mapping[str, npt.NDArray],
     xr_dataset: xr.Dataset,
+    index: pd.Index | pd.MultiIndex | None,
 ) -> xr.Dataset:
     """Add inferred parameters as data variables to an xarray dataset.
 
@@ -74,6 +75,7 @@ def _add_inferred_data_vars(
     and present in sub_dict but not yet in the dataset are added as data
     variables along the existing dimensions.
     """
+    from pandas import Series
 
     interdeps = dataset.description.interdeps
     meas_paramspec = interdeps.graph.nodes[name]["value"]
@@ -106,7 +108,14 @@ def _add_inferred_data_vars(
         expected_shape = tuple(xr_dataset.sizes[d] for d in dims)
         expected_size = prod(expected_shape)
         if flat.shape[0] == expected_size:
-            xr_dataset[inf.name] = (dims, flat.reshape(expected_shape))
+            if index is not None:
+                # If an index is provided, we should align the inferred data with the index.
+                # This is necessary because data may be reordered when transforming from a pandas DataFrame to an xarray Dataset.
+                # Passing an index allows the original data ordering to be preserved on reconstruction.
+                indexed_data = Series(flat, index=index, name=inf.name).to_xarray()
+                xr_dataset[inf.name] = indexed_data
+            else:
+                xr_dataset[inf.name] = (dims, flat.reshape(expected_shape))
         else:
             _LOG.warning(
                 "Cannot add inferred parameter '%s' to xarray dataset for '%s' "
@@ -164,7 +173,7 @@ def _load_to_xarray_dataset_dict_no_metadata(
                     dependent_parameter=name,
                 ).to_xarray()
                 xr_dataset_dict[name] = _add_inferred_data_vars(
-                    dataset, name, sub_dict, xr_dataset
+                    dataset, name, sub_dict, xr_dataset, index
                 )
             elif index_is_unique:
                 df = _data_to_dataframe(
@@ -177,7 +186,7 @@ def _load_to_xarray_dataset_dict_no_metadata(
                     dataset, use_multi_index, name, df, index
                 )
                 xr_dataset_dict[name] = _add_inferred_data_vars(
-                    dataset, name, sub_dict, xr_dataset
+                    dataset, name, sub_dict, xr_dataset, index
                 )
             else:
                 df = _data_to_dataframe(
@@ -188,7 +197,7 @@ def _load_to_xarray_dataset_dict_no_metadata(
                 )
                 xr_dataset = df.reset_index().to_xarray()
                 xr_dataset_dict[name] = _add_inferred_data_vars(
-                    dataset, name, sub_dict, xr_dataset
+                    dataset, name, sub_dict, xr_dataset, index
                 )
 
     return xr_dataset_dict
@@ -234,7 +243,9 @@ def _xarray_data_set_from_pandas_multi_index(
 
 
 def _xarray_data_set_direct(
-    dataset: DataSetProtocol, name: str, sub_dict: Mapping[str, npt.NDArray]
+    dataset: DataSetProtocol,
+    name: str,
+    sub_dict: Mapping[str, npt.NDArray],
 ) -> xr.Dataset:
     import xarray as xr
 
@@ -242,56 +253,109 @@ def _xarray_data_set_direct(
     _, deps, inferred = dataset.description.interdeps.all_parameters_in_tree_by_group(
         meas_paramspec
     )
-    # Build coordinate axes from direct dependencies preserving their order
+
+    shape = sub_dict[name].shape
+    expected_size = prod(shape)
+
+    if len(deps) != len(shape):
+        raise ValueError(
+            f"Parameter {name!r} has shape {shape}, but has {len(deps)} dependencies"
+        )
+
     dep_axis: dict[str, npt.NDArray] = {}
-    for axis, dep in enumerate(deps):
-        dep_array = sub_dict[dep.name]
-        dep_axis[dep.name] = dep_array[
-            tuple(slice(None) if i == axis else 0 for i in range(dep_array.ndim))
-        ]
+    destination = np.zeros(expected_size, dtype=np.intp)
+
+    for dimension, dep in enumerate(deps):
+        dep_data = sub_dict[dep.name].ravel()
+
+        if dep_data.size != expected_size:
+            raise ValueError(
+                f"Dependency {dep.name!r} contains {dep_data.size} values, "
+                f"but {expected_size} were expected"
+            )
+
+        values, first_indices, sorted_codes = np.unique(
+            dep_data,
+            return_index=True,
+            return_inverse=True,
+            equal_nan=True,
+        )
+
+        if values.size != shape[dimension]:
+            raise ValueError(
+                f"Dependency {dep.name!r} does not define an axis of length "
+                f"{shape[dimension]}: found {values.size} unique values"
+            )
+
+        # Restore first-seen order because np.unique sorts its output.
+        first_seen_order = np.argsort(first_indices)
+        dep_axis[dep.name] = values[first_seen_order]
+
+        code_remapping = np.empty(values.size, dtype=np.intp)
+        code_remapping[first_seen_order] = np.arange(values.size)
+        codes = code_remapping[sorted_codes]
+
+        # Encode the multidimensional coordinate using C-order mixed radix.
+        destination = destination * shape[dimension] + codes
+
+    if not np.array_equal(
+        np.sort(destination),
+        np.arange(expected_size, dtype=np.intp),
+    ):
+        raise ValueError(
+            f"Dependencies for {name!r} do not form a complete Cartesian "
+            "grid without duplicate points"
+        )
+
+    permutation = np.argsort(destination)
+
+    def reorder(data: npt.NDArray) -> npt.NDArray:
+        if data.size != expected_size:
+            raise ValueError(
+                f"Parameter contains {data.size} values, "
+                f"but {expected_size} were expected"
+            )
+        return data.ravel()[permutation].reshape(shape)
+
+    reordered_data = {
+        parameter_name: reorder(parameter_data)
+        for parameter_name, parameter_data in sub_dict.items()
+    }
 
     extra_coords: dict[str, tuple[tuple[str, ...], npt.NDArray]] = {}
     extra_data_vars: dict[str, tuple[tuple[str, ...], npt.NDArray]] = {}
+
     for inf in inferred:
-        # skip parameters already used as primary coordinate axes
-        if inf.name in dep_axis:
-            continue
-        # add only if data for this parameter is available
-        if inf.name not in sub_dict:
+        if inf.name in dep_axis or inf.name not in reordered_data:
             continue
 
         inf_related = dataset.description.interdeps.find_all_parameters_in_tree(inf)
-
         related_deps = inf_related.intersection(set(deps))
         related_top_level = inf_related.intersection({meas_paramspec})
 
-        if len(related_top_level) > 0:
-            # If inferred param is related to the top-level measurement parameter,
-            # add it as a data variable with the full dependency dimensions
-            inf_data_full = sub_dict[inf.name]
-            inf_dims_full = tuple(dep_axis.keys())
-            extra_data_vars[inf.name] = (inf_dims_full, inf_data_full)
+        if related_top_level:
+            extra_data_vars[inf.name] = (
+                tuple(dep_axis),
+                reordered_data[inf.name],
+            )
         else:
-            # Otherwise, add as a coordinate along the related dependency axes only
-            inf_data = sub_dict[inf.name][
+            inf_data = reordered_data[inf.name][
                 tuple(slice(None) if dep in related_deps else 0 for dep in deps)
             ]
-            inf_coords = [dep.name for dep in deps if dep in related_deps]
+            inf_dims = tuple(dep.name for dep in deps if dep in related_deps)
+            extra_coords[inf.name] = (inf_dims, inf_data)
 
-            extra_coords[inf.name] = (tuple(inf_coords), inf_data)
+    coords: dict[
+        str,
+        tuple[tuple[str, ...], npt.NDArray] | npt.NDArray,
+    ] = {**dep_axis, **extra_coords}
 
-    # Compose coordinates dict including dependency axes and extra inferred coords
-    coords: dict[str, tuple[tuple[str, ...], npt.NDArray] | npt.NDArray]
-    coords = {**dep_axis, **extra_coords}
-
-    # Compose data variables dict including measured var and any inferred data vars
     data_vars: dict[str, tuple[tuple[str, ...], npt.NDArray]] = {
-        name: (tuple(dep_axis.keys()), sub_dict[name])
+        name: (tuple(dep_axis), reordered_data[name]),
+        **extra_data_vars,
     }
-    data_vars.update(extra_data_vars)
 
-    ds = xr.Dataset(data_vars, coords=coords)
-    return ds
+    return xr.Dataset(data_vars, coords=coords)
 
 
 def load_to_xarray_dataset_dict(

--- a/src/qcodes/dataset/exporters/export_to_xarray.py
+++ b/src/qcodes/dataset/exporters/export_to_xarray.py
@@ -326,7 +326,7 @@ def _xarray_data_set_direct(
     extra_data_vars: dict[str, tuple[tuple[str, ...], npt.NDArray]] = {}
 
     for inf in inferred:
-        if inf.name in dep_axis or inf.name not in reordered_data:
+        if inf.name not in reordered_data:
             continue
 
         inf_related = dataset.description.interdeps.find_all_parameters_in_tree(inf)

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -305,6 +305,62 @@ def _make_mock_dataset_non_grid(experiment: Experiment) -> DataSet:
     return dataset
 
 
+@pytest.fixture(name="mock_dataset_non_grid_inferred")
+def _make_mock_dataset_non_grid_inferred(experiment: Experiment) -> DataSet:
+    """Non grid dataset where an inferred parameter is inferred from z."""
+    dataset = new_data_set("dataset")
+    xparam = ParamSpecBase("x", "numeric")
+    yparam = ParamSpecBase("y", "numeric")
+    zparam = ParamSpecBase("z", "numeric")
+    tparam = ParamSpecBase("t", "numeric")
+    idps = InterDependencies_(
+        dependencies={zparam: (xparam, yparam)},
+        inferences={tparam: (zparam,)},
+    )
+    dataset.set_interdependencies(idps)
+
+    num_samples = 50
+
+    rng = np.random.default_rng(1234)
+
+    x_vals = rng.random(num_samples) * 10
+    y_vals = 20 + rng.random(num_samples) * 5
+
+    dataset.mark_started()
+
+    for i, (x, y) in enumerate(zip(x_vals, y_vals)):
+        dataset.add_results([{"x": x, "y": y, "z": x + y, "t": float(i)}])
+    dataset.mark_completed()
+    return dataset
+
+
+@pytest.fixture(name="mock_dataset_non_unique_index_inferred")
+def _make_mock_dataset_non_unique_index_inferred(experiment: Experiment) -> DataSet:
+    """Dataset with a non unique MultiIndex and an inferred parameter."""
+    dataset = new_data_set("dataset")
+    xparam = ParamSpecBase("x", "numeric")
+    yparam = ParamSpecBase("y", "numeric")
+    zparam = ParamSpecBase("z", "numeric")
+    tparam = ParamSpecBase("t", "numeric")
+    idps = InterDependencies_(
+        dependencies={zparam: (xparam, yparam)},
+        inferences={tparam: (zparam,)},
+    )
+    dataset.set_interdependencies(idps)
+
+    num_samples = 20
+    # every (x, y) pair is measured twice making the index non unique
+    x_vals = np.repeat(np.arange(num_samples // 2, dtype=float), 2)
+    y_vals = np.repeat(np.arange(num_samples // 2, dtype=float), 2)
+
+    dataset.mark_started()
+
+    for i, (x, y) in enumerate(zip(x_vals, y_vals)):
+        dataset.add_results([{"x": x, "y": y, "z": x + y, "t": float(i)}])
+    dataset.mark_completed()
+    return dataset
+
+
 @pytest.fixture(name="mock_dataset_non_grid_in_mem")
 def _make_mock_dataset_non_grid_in_mem(experiment: Experiment) -> DataSetProtocol:
     meas = Measurement(exp=experiment, name="in_mem_ds")
@@ -1758,6 +1814,34 @@ def test_multi_index_options_non_grid(mock_dataset_non_grid: DataSet) -> None:
 
     xds_always = mock_dataset_non_grid.to_xarray_dataset(use_multi_index="always")
     assert xds_always.sizes == {"multi_index": 50}
+
+
+@pytest.mark.parametrize("use_multi_index", ["auto", "always"])
+def test_multi_index_export_with_inferred_parameter(
+    mock_dataset_non_grid_inferred: DataSet, use_multi_index: str
+) -> None:
+    """Inferred parameters must export correctly when a MultiIndex dim is used."""
+    xds = mock_dataset_non_grid_inferred.to_xarray_dataset(
+        use_multi_index=use_multi_index  # pyright: ignore[reportArgumentType]
+    )
+
+    assert xds.sizes == {"multi_index": 50}
+    assert "t" in xds.data_vars
+    assert xds["t"].dims == ("multi_index",)
+    np.testing.assert_array_equal(xds["t"].values, np.arange(50, dtype=float))
+
+
+def test_non_unique_multi_index_export_with_inferred_parameter(
+    mock_dataset_non_unique_index_inferred: DataSet,
+) -> None:
+    """A non unique MultiIndex must not break export of inferred parameters."""
+    xds = mock_dataset_non_unique_index_inferred.to_xarray_dataset()
+
+    assert "t" in xds.data_vars
+    assert xds["t"].dims == xds["z"].dims
+    np.testing.assert_array_equal(
+        np.asarray(xds["t"].values).ravel(), np.arange(20, dtype=float)
+    )
 
 
 def test_multi_index_wrong_option(mock_dataset_non_grid: DataSet) -> None:

--- a/tests/dataset/test_dataset_export.py
+++ b/tests/dataset/test_dataset_export.py
@@ -35,7 +35,10 @@ from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.versioning import serialization as serial
 from qcodes.dataset.export_config import DataExportType
 from qcodes.dataset.exporters.export_to_pandas import _generate_pandas_index
-from qcodes.dataset.exporters.export_to_xarray import _calculate_index_shape
+from qcodes.dataset.exporters.export_to_xarray import (
+    _calculate_index_shape,
+    _xarray_data_set_direct,
+)
 from qcodes.dataset.linked_datasets.links import links_to_str
 from qcodes.parameters import ManualParameter, Parameter, ParamSpecBase
 
@@ -173,6 +176,21 @@ def _make_mock_dataset_grid_with_shapes(experiment: Experiment) -> DataSet:
             results = [{"x": x, "y": y, "z": x + y}]
             dataset.add_results(results)
     dataset.mark_completed()
+    return dataset
+
+
+@pytest.fixture(name="direct_export_dataset")
+def _make_direct_export_dataset(experiment: Experiment) -> DataSet:
+    dataset = new_data_set("direct_export_dataset")
+    xparam = ParamSpecBase("x", "numeric")
+    yparam = ParamSpecBase("y", "numeric")
+    signalparam = ParamSpecBase("signal", "numeric")
+    inferredparam = ParamSpecBase("inferred", "numeric")
+    idps = InterDependencies_(
+        dependencies={signalparam: (xparam, yparam)},
+        inferences={inferredparam: (xparam,)},
+    )
+    dataset.set_interdependencies(idps, shapes={"signal": (2, 2)})
     return dataset
 
 
@@ -1584,6 +1602,102 @@ def test_multi_index_options_grid_with_shape(
         use_multi_index="always"
     )
     assert xds_always.sizes == {"multi_index": 50}
+
+
+def test_export_to_xarray_dataset_permuted_grid(experiment: Experiment) -> None:
+    dataset = new_data_set("permuted_grid")
+    xparam = ParamSpecBase("x", "numeric")
+    yparam = ParamSpecBase("y", "numeric")
+    signalparam = ParamSpecBase("signal", "numeric")
+    idps = InterDependencies_(dependencies={signalparam: (xparam, yparam)})
+    dataset.set_interdependencies(idps, shapes={"signal": (3, 3)})
+
+    x_values = np.array([[1, 0, 2], [1, 1, 2], [0, 2, 0]])
+    y_values = np.array([[0, 0, 0], [1, 2, 1], [1, 2, 2]])
+
+    dataset.mark_started()
+    for x, y in zip(x_values.ravel(), y_values.ravel()):
+        dataset.add_results([{"x": x, "y": y, "signal": 10 * x + y}])
+    dataset.mark_completed()
+
+    xarray_dataset = dataset.to_xarray_dataset()
+
+    assert_array_equal(xarray_dataset.coords["x"], [1, 0, 2])
+    assert_array_equal(xarray_dataset.coords["y"], [0, 1, 2])
+    assert_array_equal(
+        xarray_dataset["signal"],
+        np.array([[10, 11, 12], [0, 1, 2], [20, 21, 22]]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("data", "error"),
+    [
+        (
+            {
+                "signal": np.arange(4),
+                "x": np.array([0, 0, 1, 1]),
+                "y": np.array([0, 1, 0, 1]),
+            },
+            "has shape .* but has 2 dependencies",
+        ),
+        (
+            {
+                "signal": np.arange(4).reshape(2, 2),
+                "x": np.array([0, 0, 1]),
+                "y": np.array([[0, 1], [0, 1]]),
+            },
+            "Dependency 'x' contains 3 values, but 4 were expected",
+        ),
+        (
+            {
+                "signal": np.arange(4).reshape(2, 2),
+                "x": np.array([[0, 1], [2, 3]]),
+                "y": np.array([[0, 1], [0, 1]]),
+            },
+            "Dependency 'x' does not define an axis of length 2",
+        ),
+        (
+            {
+                "signal": np.arange(4).reshape(2, 2),
+                "x": np.array([[0, 0], [1, 1]]),
+                "y": np.array([[0, 0], [1, 1]]),
+            },
+            "do not form a complete Cartesian grid",
+        ),
+        (
+            {
+                "signal": np.arange(4).reshape(2, 2),
+                "x": np.array([[0, 0], [1, 1]]),
+                "y": np.array([[0, 1], [0, 1]]),
+                "inferred": np.arange(3),
+            },
+            "Parameter contains 3 values, but 4 were expected",
+        ),
+    ],
+)
+def test_xarray_data_set_direct_rejects_invalid_grid(
+    direct_export_dataset: DataSet,
+    data: dict[str, np.ndarray],
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _xarray_data_set_direct(direct_export_dataset, "signal", data)
+
+
+def test_xarray_data_set_direct_skips_missing_inferred_data(
+    direct_export_dataset: DataSet,
+) -> None:
+    data = {
+        "signal": np.arange(4).reshape(2, 2),
+        "x": np.array([[0, 0], [1, 1]]),
+        "y": np.array([[0, 1], [0, 1]]),
+    }
+
+    xarray_dataset = _xarray_data_set_direct(direct_export_dataset, "signal", data)
+
+    assert set(xarray_dataset.coords) == {"x", "y"}
+    assert set(xarray_dataset.data_vars) == {"signal"}
 
 
 def test_multi_index_options_incomplete_grid(

--- a/tests/dataset/test_inferred_multiple_parents.py
+++ b/tests/dataset/test_inferred_multiple_parents.py
@@ -70,7 +70,7 @@ class TestSingleParentBaseline:
             coords={"sp": sub_dict["sp"]},
         )
 
-        result = _add_inferred_data_vars(ds, "meas", sub_dict, xr_ds)
+        result = _add_inferred_data_vars(ds, "meas", sub_dict, xr_ds, index=None)
 
         assert "inf_param" in result.data_vars
         npt.assert_array_almost_equal(result["inf_param"].values, sub_dict["inf_param"])
@@ -110,7 +110,7 @@ class TestMultipleParentsAllMatch:
             coords={"sp": sub_dict["sp"]},
         )
 
-        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" in result.data_vars
         npt.assert_array_almost_equal(result["inf_param"].values, sub_dict["inf_param"])
@@ -155,7 +155,7 @@ class TestMultipleParentsOnlyFirstMatches:
             coords={"sp1": sub_dict["sp1"]},
         )
 
-        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         # Current behavior: included because it matches parent1
         assert "inf_param" in result.data_vars
@@ -206,7 +206,7 @@ class TestMultipleParentsOnlySecondMatches:
         with caplog.at_level(
             logging.WARNING, logger="qcodes.dataset.exporters.export_to_xarray"
         ):
-            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" not in result.data_vars
         assert any(
@@ -252,7 +252,7 @@ class TestMultipleParentsNoneMatch:
         with caplog.at_level(
             logging.WARNING, logger="qcodes.dataset.exporters.export_to_xarray"
         ):
-            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" not in result.data_vars
         assert any(
@@ -292,7 +292,7 @@ class TestMultipleParentsOneUnavailable:
             coords={"sp": sub_dict["sp"]},
         )
 
-        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" in result.data_vars
         npt.assert_array_almost_equal(result["inf_param"].values, sub_dict["inf_param"])
@@ -328,7 +328,7 @@ class TestMultipleParentsOneUnavailable:
         with caplog.at_level(
             logging.WARNING, logger="qcodes.dataset.exporters.export_to_xarray"
         ):
-            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+            result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" not in result.data_vars
         assert any(
@@ -368,7 +368,7 @@ class TestMultipleParentsSameSizeAllMatch:
             coords={"sp": sub_dict["sp"]},
         )
 
-        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds)
+        result = _add_inferred_data_vars(ds, "parent1", sub_dict, xr_ds, index=None)
 
         assert "inf_param" in result.data_vars
         npt.assert_array_almost_equal(result["inf_param"].values, sub_dict["inf_param"])

--- a/tests/dataset/test_parameter_with_setpoints_has_control.py
+++ b/tests/dataset/test_parameter_with_setpoints_has_control.py
@@ -187,7 +187,9 @@ def test_parameter_with_setpoints_has_control_size_mismatch_warns(
     with caplog.at_level(
         logging.WARNING, logger="qcodes.dataset.exporters.export_to_xarray"
     ):
-        result = _add_inferred_data_vars(ds.dataset, "p2", sub_dict, xr_dataset)
+        result = _add_inferred_data_vars(
+            ds.dataset, "p2", sub_dict, xr_dataset, index=None
+        )
 
     assert "p1" not in result.data_vars
     assert any(


### PR DESCRIPTION
Dataset export to xarray currently fails under the condition.

This can occur when array-valued parameters. Users may wish to acquire and save data in a particular order, and no assumptions.

This failure occurs in two cases:
1. With pandas-based exporting to xarray, indexing is not propagated to inferred-from relationships.
2. With direct xarray exporting, the assumption is made that shape metadata can be used to imply that, e.g., the first column of an NxM sweep can be used to infer the axis of one of the sweep values. This contract is not made explicit in the API, and should not be relied upon. If data for an NxM sweep is created in a permuted order, this MR fixes the direct export to directly extract the axis information from the larger multi-dimensional array. Backwards compatibility of ordering is maintained for non-permuted cases.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://microsoft.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
