### PR TITLE
Let plot_dataset take back the colorbars it returns

### DIFF
--- a/docs/changes/newsfragments/8388.improved
+++ b/docs/changes/newsfragments/8388.improved
@@ -1,0 +1,5 @@
+The ``colorbars`` argument of :func:`.plot_dataset` and :func:`.plot_by_id` now
+accepts a sequence that may contain ``None``. Both functions return a list of
+colorbars in which the entries for 1D plots are ``None``, so passing the result
+back in, which is how you plot into the same axes again, did not match the
+declared argument type. A sequence of colorbars is still accepted.

--- a/src/qcodes/dataset/plotting.py
+++ b/src/qcodes/dataset/plotting.py
@@ -95,7 +95,10 @@ def _appropriate_kwargs(plottype: str, colorbar_present: bool, **kwargs: Any) ->
 def plot_dataset(
     dataset: DataSetProtocol,
     axes: Axes | Sequence[Axes] | None = None,
-    colorbars: Colorbar | Sequence[Colorbar] | Sequence[None] | None = None,
+    # ``Sequence[Colorbar | None]`` so that the list of colorbars returned by
+    # this function can be passed straight back in, which is how you plot into
+    # the same axes again. A ``Sequence[Colorbar]`` is also one of these.
+    colorbars: Colorbar | Sequence[Colorbar | None] | None = None,
     rescale_axes: bool = True,
     auto_color_scale: bool | None = None,
     cutoff_percentile: tuple[float, float] | float | None = None,
@@ -417,7 +420,7 @@ def plot_and_save_image(
 def plot_by_id(
     run_id: int,
     axes: Axes | Sequence[Axes] | None = None,
-    colorbars: Colorbar | Sequence[Colorbar] | None = None,
+    colorbars: Colorbar | Sequence[Colorbar | None] | None = None,
     rescale_axes: bool = True,
     auto_color_scale: bool | None = None,
     cutoff_percentile: tuple[float, float] | float | None = None,


### PR DESCRIPTION
plot_dataset returns a list of colorbars whose entries are None for the 1D plots, but its colorbars argument only accepted a sequence that was either all colorbars or all None. Passing the result back in, which is how the offline plotting tutorial plots into the same axes again, was therefore a type error.

Take a Sequence[Colorbar | None]. A Sequence[Colorbar] is still one of those, so nothing that worked before stops working, and the body already built and handled lists containing None.

plot_by_id forwards to plot_dataset and returns the same type, so it is widened with it.

Lifted from #8441 