### PR TITLE
Make Parameter cache.set_from_raw_value public

### DIFF
--- a/docs/changes/newsfragments/8484.new
+++ b/docs/changes/newsfragments/8484.new
@@ -1,0 +1,8 @@
+The method for setting a parameter's cache from a raw value as reported by the
+instrument is now public as ``Parameter.cache.set_from_raw_value``. It is the
+raw-side counterpart of ``Parameter.cache.set`` and applies the same
+conversions as a ``get`` (``get_parser``, ``scale``, ``offset`` and
+``val_mapping``). This is useful for drivers that populate the caches of many
+parameters from a single bulk instrument reply without issuing a ``get`` per
+parameter. The previous private ``_set_from_raw_value`` is kept as a
+backwards-compatible alias.

--- a/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
+++ b/src/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/DynaCool.py
@@ -430,7 +430,7 @@ class DynaCool(VisaInstrument):
             while self.temperature_state() != "stable":
                 sleep(self.blocking_t_state_check_interval())
 
-        self.temperature_setpoint.cache._set_from_raw_value(values[0])
+        self.temperature_setpoint.cache.set_from_raw_value(values[0])
 
     def write(self, cmd: str) -> None:
         """

--- a/src/qcodes/parameters/cache.py
+++ b/src/qcodes/parameters/cache.py
@@ -40,6 +40,8 @@ class _CacheProtocol(Protocol, Generic[ParameterDataTypeVar]):  # noqa: PYI046
 
     def set(self, value: ParameterDataTypeVar) -> None: ...
 
+    def set_from_raw_value(self, raw_value: ParamRawDataType) -> None: ...
+
     def _set_from_raw_value(self, raw_value: ParamRawDataType) -> None: ...
 
     @overload
@@ -160,11 +162,36 @@ class _Cache(Generic[ParameterDataTypeVar]):
         raw_value = self._parameter._from_value_to_raw_value(value)
         self._update_with(value=value, raw_value=raw_value)
 
-    def _set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
+    def set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
+        """
+        Set the cached value of the parameter from a raw value as returned by
+        the instrument, without invoking the ``get_cmd`` of the parameter.
+
+        This is the counterpart of :meth:`set`: where :meth:`set` takes a value
+        on the user/scaled side of the parameter, this method takes a value on
+        the instrument/raw side. It applies the same conversions that a regular
+        ``get`` would (``get_parser``, ``scale``, ``offset`` and
+        ``val_mapping``) to derive the user-facing value, and stores both the
+        raw value and the converted value in the cache.
+
+        This is useful for drivers that read the state of several parameters in
+        a single instrument query and want to populate the individual parameter
+        caches from that bulk reply without issuing a ``get`` per parameter.
+
+        Args:
+            raw_value: new raw value for the parameter (as returned by the
+                instrument)
+
+        """
         value = self._parameter._from_raw_value_to_value(raw_value)
         if self._parameter._validate_on_get:
             self._parameter.validate(value)
         self._update_with(value=value, raw_value=raw_value)
+
+    def _set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
+        # Retained for backwards compatibility with code written before
+        # set_from_raw_value() was made public.
+        self.set_from_raw_value(raw_value)
 
     def _update_with(
         self,

--- a/src/qcodes/parameters/delegate_parameter.py
+++ b/src/qcodes/parameters/delegate_parameter.py
@@ -157,12 +157,17 @@ class DelegateParameter(
                 self._parameter._from_value_to_raw_value(value)
             )
 
-        def _set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
+        def set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
             if self._parameter.source is None:
                 raise TypeError(
                     "Cannot set the cache of a DelegateParameter that delegates to None"
                 )
             self._parameter.source.cache.set(raw_value)
+
+        def _set_from_raw_value(self, raw_value: ParamRawDataType) -> None:
+            # Retained for backwards compatibility with code written before
+            # set_from_raw_value() was made public.
+            self.set_from_raw_value(raw_value)
 
         def _update_with(
             self,

--- a/src/qcodes/parameters/group_parameter.py
+++ b/src/qcodes/parameters/group_parameter.py
@@ -290,7 +290,7 @@ class Group:
             )
         self.instrument.write(command_str)
         for name, p in list(self.parameters.items()):
-            p.cache._set_from_raw_value(calling_dict[name])
+            p.cache.set_from_raw_value(calling_dict[name])
 
     def update(self) -> None:
         """
@@ -313,7 +313,7 @@ class Group:
         )
         ret = self.get_parser(self.instrument.ask(get_command))
         for name, p in list(self.parameters.items()):
-            p.cache._set_from_raw_value(ret[name])
+            p.cache.set_from_raw_value(ret[name])
 
     @property
     def parameters(self) -> OrderedDict[str, GroupParameter]:

--- a/src/qcodes/parameters/parameter.py
+++ b/src/qcodes/parameters/parameter.py
@@ -322,7 +322,7 @@ class Parameter(
             mylogger.debug(
                 "Setting raw value of parameter: %s to %s", self.full_name, x
             )
-            self.cache._set_from_raw_value(x)
+            self.cache.set_from_raw_value(x)
             return x
 
         instrument = kwargs.get("instrument")

--- a/tests/parameter/test_parameter_cache.py
+++ b/tests/parameter/test_parameter_cache.py
@@ -166,7 +166,7 @@ def test_set_raw_value_on_cache() -> None:
     scale = 10
     local_parameter = BetterGettableParam("test_param", set_cmd=None, scale=scale)
     before = datetime.now(UTC)
-    local_parameter.cache._set_from_raw_value(value * scale)
+    local_parameter.cache.set_from_raw_value(value * scale)
     after = datetime.now(UTC)
     assert local_parameter.cache.get(get_if_invalid=False) == value
     assert local_parameter.cache.raw_value == value * scale
@@ -174,6 +174,36 @@ def test_set_raw_value_on_cache() -> None:
     assert timestamp is not None
     assert timestamp >= before
     assert timestamp <= after
+
+
+def test_set_from_raw_value_deprecated_alias() -> None:
+    """The private ``_set_from_raw_value`` is kept as a backwards compatible
+    alias of the public ``set_from_raw_value`` and behaves identically."""
+    scale = 10
+    value = 2
+    public_param = BetterGettableParam("public", set_cmd=None, scale=scale)
+    alias_param = BetterGettableParam("alias", set_cmd=None, scale=scale)
+
+    public_param.cache.set_from_raw_value(value * scale)
+    alias_param.cache._set_from_raw_value(value * scale)
+
+    assert (
+        alias_param.cache.get(get_if_invalid=False)
+        == public_param.cache.get(get_if_invalid=False)
+        == value
+    )
+    assert alias_param.cache.raw_value == public_param.cache.raw_value == value * scale
+
+
+def test_set_from_raw_value_applies_val_mapping() -> None:
+    """``set_from_raw_value`` accepts the value as reported by the instrument
+    and applies the parameter's ``val_mapping`` to it, mirroring a ``get``."""
+    param = Parameter(
+        "relay", set_cmd=None, get_cmd=None, val_mapping={"open": 0, "close": 1}
+    )
+    param.cache.set_from_raw_value(1)
+    assert param.cache.get(get_if_invalid=False) == "close"
+    assert param.cache.raw_value == 1
 
 
 def test_max_val_age() -> None:


### PR DESCRIPTION
`cache.set(value)` populates a parameter's cache from a **user/scaled** value. Its raw-side counterpart — setting the cache from a value as reported by the instrument (applying `get_parser`/`scale`/`offset`/`val_mapping`) — only existed as the private `_set_from_raw_value`, despite being driver-facing (the in-tree `DynaCool` driver already uses it, and it's handy for populating many caches from one bulk reply). I found no recorded reason for it being private.

This PR makes it public as `Parameter.cache.set_from_raw_value()`, keeps `_set_from_raw_value` as a backwards-compatible alias, updates in-tree callers, and adds tests + a newsfragment. No behaviour change.
